### PR TITLE
Remove Symfony 2.3 BC layer

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,23 @@
 UPGRADE
 =======
 
+## Upgrade FROM 1.0.0 to 1.1.0
+
+No significant changes are required.
+
+Support for the Symfony 2.3 OptionsResolver is dropped.
+
+If you require the "symfony/options-resolver" or "symfony/symfony"
+package in your applications composer.json (the root composer.json file).
+You need to eg. set the version constraint to "~2.8" for the "symfony/options-resolver" or
+"symfony/symfony" package.
+
+Installing the new Symfony OptionsResolver should not cause any BC breaks in your
+application. But may give some deprecation notices.
+
+See [UPGRADE-2.6.md#optionsresolver](https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.6.md#optionsresolver)
+for all upgrade instructions.
+
 ## Upgrade FROM 1.0.0-beta4 to 1.0.0-beta5
 
 There has been been some major refactoring to make the system more robust

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,14 @@
     ],
     "require": {
         "php": ">=5.4",
-        "symfony/options-resolver": "~2.3|~3.0",
+        "symfony/options-resolver": "~2.8|~3.0",
         "symfony/property-access": "~2.3|~3.0",
         "symfony/intl": "~2.3|~3.0",
         "seld/jsonlint": "^1.3.1",
         "doctrine/lexer": "^1.0.1"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "~2.7|~3.0",
+        "symfony/phpunit-bridge": "~2.8|~3.0",
         "phpspec/phpspec": "^2.2.1"
     },
     "autoload": {

--- a/src/Extension/Core/Type/BirthdayType.php
+++ b/src/Extension/Core/Type/BirthdayType.php
@@ -84,18 +84,8 @@ class BirthdayType extends AbstractFieldType
             },
         ]);
 
-        // BC layer for Symfony 2.7 and 3.0
-        if ($resolver instanceof OptionsResolverInterface) {
-            $resolver->setAllowedTypes(
-                [
-                    'allow_age' => ['bool'],
-                    'allow_future_date' => ['bool'],
-                ]
-            );
-        } else {
-            $resolver->setAllowedTypes('allow_age', ['bool']);
-            $resolver->setAllowedTypes('allow_future_date', ['bool']);
-        }
+        $resolver->setAllowedTypes('allow_age', ['bool']);
+        $resolver->setAllowedTypes('allow_future_date', ['bool']);
     }
 
     /**

--- a/src/Extension/Core/Type/ChoiceType.php
+++ b/src/Extension/Core/Type/ChoiceType.php
@@ -90,25 +90,13 @@ class ChoiceType extends AbstractFieldType
             'choices' => [],
         ]);
 
-        // BC layer for Symfony 2.7 and 3.0
-        if ($resolver instanceof OptionsResolverInterface) {
-            $resolver->setAllowedTypes(
-                [
-                    'choice_list' => [
-                        'null',
-                        'Rollerworks\Component\Search\Extension\Core\ChoiceList\ChoiceListInterface',
-                    ],
-                ]
-            );
-        } else {
-            $resolver->setAllowedTypes(
-                'choice_list',
-                [
-                    'null',
-                    'Rollerworks\Component\Search\Extension\Core\ChoiceList\ChoiceListInterface',
-                ]
-            );
-        }
+        $resolver->setAllowedTypes(
+            'choice_list',
+            [
+                'null',
+                'Rollerworks\Component\Search\Extension\Core\ChoiceList\ChoiceListInterface',
+            ]
+        );
     }
 
     /**

--- a/src/Extension/Core/Type/DateTimeType.php
+++ b/src/Extension/Core/Type/DateTimeType.php
@@ -177,25 +177,11 @@ class DateTimeType extends AbstractFieldType
             return $value;
         };
 
-        // BC layer for Symfony 2.7 and 3.0
-        if ($resolver instanceof OptionsResolverInterface) {
-            $resolver->setAllowedTypes(
-                [
-                    'pattern' => ['string', 'null'],
-                    'format' => ['string', 'null'],
-                    'date_format' => ['int'],
-                    'time_format' => ['int'],
-                ]
-            );
-
-            $resolver->setNormalizers(['format' => $formatNormalizer]);
-        } else {
-            $resolver->setNormalizer('format', $formatNormalizer);
-            $resolver->setAllowedTypes('pattern', ['string', 'null']);
-            $resolver->setAllowedTypes('format', ['string', 'null']);
-            $resolver->setAllowedTypes('date_format', ['int']);
-            $resolver->setAllowedTypes('time_format', ['int']);
-        }
+        $resolver->setNormalizer('format', $formatNormalizer);
+        $resolver->setAllowedTypes('pattern', ['string', 'null']);
+        $resolver->setAllowedTypes('format', ['string', 'null']);
+        $resolver->setAllowedTypes('date_format', ['int']);
+        $resolver->setAllowedTypes('time_format', ['int']);
     }
 
     /**

--- a/src/Extension/Core/Type/DateType.php
+++ b/src/Extension/Core/Type/DateType.php
@@ -131,14 +131,7 @@ class DateType extends AbstractFieldType
             ]
         );
 
-        // BC layer for Symfony 2.7 and 3.0
-        if ($resolver instanceof OptionsResolverInterface) {
-            $resolver->setAllowedTypes(
-                ['format' => ['int', 'string']]
-            );
-        } else {
-            $resolver->setAllowedTypes('format', ['int', 'string']);
-        }
+        $resolver->setAllowedTypes('format', ['int', 'string']);
     }
 
     /**

--- a/src/Extension/Core/Type/FieldType.php
+++ b/src/Extension/Core/Type/FieldType.php
@@ -75,17 +75,7 @@ class FieldType extends AbstractFieldType
             ]
         );
 
-        // BC layer for Symfony 2.7 and 3.0
-        if ($resolver instanceof OptionsResolverInterface) {
-            $resolver->setAllowedTypes(
-                [
-                    'invalid_message' => ['string'],
-                    'invalid_message_parameters' => ['array'],
-                ]
-            );
-        } else {
-            $resolver->setAllowedTypes('invalid_message', ['string']);
-            $resolver->setAllowedTypes('invalid_message_parameters', ['array']);
-        }
+        $resolver->setAllowedTypes('invalid_message', ['string']);
+        $resolver->setAllowedTypes('invalid_message_parameters', ['array']);
     }
 }

--- a/src/Extension/Core/Type/IntegerType.php
+++ b/src/Extension/Core/Type/IntegerType.php
@@ -81,35 +81,18 @@ class IntegerType extends AbstractFieldType
             ]
         );
 
-        // BC layer for Symfony 2.7 and 3.0
-        if ($resolver instanceof OptionsResolverInterface) {
-            $resolver->setAllowedValues(
-                [
-                    'rounding_mode' => [
-                        \NumberFormatter::ROUND_FLOOR,
-                        \NumberFormatter::ROUND_DOWN,
-                        \NumberFormatter::ROUND_HALFDOWN,
-                        \NumberFormatter::ROUND_HALFEVEN,
-                        \NumberFormatter::ROUND_HALFUP,
-                        \NumberFormatter::ROUND_UP,
-                        \NumberFormatter::ROUND_CEILING,
-                    ],
-                ]
-            );
-        } else {
-            $resolver->setAllowedValues(
-                'rounding_mode',
-                [
-                    \NumberFormatter::ROUND_FLOOR,
-                    \NumberFormatter::ROUND_DOWN,
-                    \NumberFormatter::ROUND_HALFDOWN,
-                    \NumberFormatter::ROUND_HALFEVEN,
-                    \NumberFormatter::ROUND_HALFUP,
-                    \NumberFormatter::ROUND_UP,
-                    \NumberFormatter::ROUND_CEILING,
-                ]
-            );
-        }
+        $resolver->setAllowedValues(
+            'rounding_mode',
+            [
+                \NumberFormatter::ROUND_FLOOR,
+                \NumberFormatter::ROUND_DOWN,
+                \NumberFormatter::ROUND_HALFDOWN,
+                \NumberFormatter::ROUND_HALFEVEN,
+                \NumberFormatter::ROUND_HALFUP,
+                \NumberFormatter::ROUND_UP,
+                \NumberFormatter::ROUND_CEILING,
+            ]
+        );
     }
 
     /**

--- a/src/Extension/Core/Type/NumberType.php
+++ b/src/Extension/Core/Type/NumberType.php
@@ -80,35 +80,18 @@ class NumberType extends AbstractFieldType
             ]
         );
 
-        // BC layer for Symfony 2.7 and 3.0
-        if ($resolver instanceof OptionsResolverInterface) {
-            $resolver->setAllowedValues(
-                [
-                    'rounding_mode' => [
-                        \NumberFormatter::ROUND_FLOOR,
-                        \NumberFormatter::ROUND_DOWN,
-                        \NumberFormatter::ROUND_HALFDOWN,
-                        \NumberFormatter::ROUND_HALFEVEN,
-                        \NumberFormatter::ROUND_HALFUP,
-                        \NumberFormatter::ROUND_UP,
-                        \NumberFormatter::ROUND_CEILING,
-                    ],
-                ]
-            );
-        } else {
-            $resolver->setAllowedValues(
-                'rounding_mode',
-                [
-                    \NumberFormatter::ROUND_FLOOR,
-                    \NumberFormatter::ROUND_DOWN,
-                    \NumberFormatter::ROUND_HALFDOWN,
-                    \NumberFormatter::ROUND_HALFEVEN,
-                    \NumberFormatter::ROUND_HALFUP,
-                    \NumberFormatter::ROUND_UP,
-                    \NumberFormatter::ROUND_CEILING,
-                ]
-            );
-        }
+        $resolver->setAllowedValues(
+            'rounding_mode',
+            [
+                \NumberFormatter::ROUND_FLOOR,
+                \NumberFormatter::ROUND_DOWN,
+                \NumberFormatter::ROUND_HALFDOWN,
+                \NumberFormatter::ROUND_HALFEVEN,
+                \NumberFormatter::ROUND_HALFUP,
+                \NumberFormatter::ROUND_UP,
+                \NumberFormatter::ROUND_CEILING,
+            ]
+        );
     }
 
     /**


### PR DESCRIPTION
|Q            |A          |
|---          |---        |
|Bug Fix?     |no         |
|New Feature? |no         |
|BC Breaks?   |yes (minor)|
|Deprecations?|no         |
|Fixed Tickets|Closes #88 |
|License      |MIT        |
                           

This was actually very easy 😀  note that if you don't allow Symfony 2.8 components this will fail. But Symfony 2.3 is nearing End of live soon