### PR TITLE
Allow setting multiple model mappings

### DIFF
--- a/doc/reference/types/birthday.rst
+++ b/doc/reference/types/birthday.rst
@@ -55,6 +55,8 @@ These options inherit from the :doc:`date </reference/types/date>` type:
 
 These options inherit from the :doc:`field </reference/types/field>` type:
 
+.. include:: /reference/types/options/model_mappings.rst.inc
+
 .. include:: /reference/types/options/invalid_message.rst.inc
 
 .. include:: /reference/types/options/invalid_message_parameters.rst.inc

--- a/doc/reference/types/choice.rst
+++ b/doc/reference/types/choice.rst
@@ -84,6 +84,8 @@ Inherited options
 
 These options inherit from the :doc:`field </reference/types/field>` type:
 
+.. include:: /reference/types/options/model_mappings.rst.inc
+
 .. include:: /reference/types/options/invalid_message.rst.inc
 
 .. include:: /reference/types/options/invalid_message_parameters.rst.inc

--- a/doc/reference/types/country.rst
+++ b/doc/reference/types/country.rst
@@ -45,6 +45,8 @@ Inherited options
 
 These options inherit from the :doc:`field </reference/types/field>` type:
 
+.. include:: /reference/types/options/model_mappings.rst.inc
+
 .. include:: /reference/types/options/invalid_message.rst.inc
 
 .. include:: /reference/types/options/invalid_message_parameters.rst.inc

--- a/doc/reference/types/currency.rst
+++ b/doc/reference/types/currency.rst
@@ -39,6 +39,8 @@ Inherited options
 
 These options inherit from the :doc:`field </reference/types/field>` type:
 
+.. include:: /reference/types/options/model_mappings.rst.inc
+
 .. include:: /reference/types/options/invalid_message.rst.inc
 
 .. include:: /reference/types/options/invalid_message_parameters.rst.inc

--- a/doc/reference/types/date.rst
+++ b/doc/reference/types/date.rst
@@ -34,6 +34,8 @@ Inherited options
 
 These options inherit from the :doc:`field </reference/types/field>` type:
 
+.. include:: /reference/types/options/model_mappings.rst.inc
+
 .. include:: /reference/types/options/invalid_message.rst.inc
 
 .. include:: /reference/types/options/invalid_message_parameters.rst.inc

--- a/doc/reference/types/datetime.rst
+++ b/doc/reference/types/datetime.rst
@@ -40,6 +40,8 @@ Inherited options
 
 These options inherit from the :doc:`field </reference/types/field>` type:
 
+.. include:: /reference/types/options/model_mappings.rst.inc
+
 .. include:: /reference/types/options/invalid_message.rst.inc
 
 .. include:: /reference/types/options/invalid_message_parameters.rst.inc

--- a/doc/reference/types/field.rst
+++ b/doc/reference/types/field.rst
@@ -6,8 +6,15 @@ field Field Type
 
 See :class:`Rollerworks\\Component\\Search\\Extension\\Core\\Type\\FieldType`.
 
-The ``field`` type predefines a couple of options that are then available
+The ``field`` type pre-defines a couple of options that are then available
 on all fields.
 
 The most common one is the :class:`Rollerworks\\Component\\Search\\Extension\\Core\\ValueComparison\\SimpleValueComparison`
 to check for duplicated values.
+
+Field Options
+-------------
+
+.. include:: /reference/types/options/model_mappings.rst.inc
+
+

--- a/doc/reference/types/integer.rst
+++ b/doc/reference/types/integer.rst
@@ -63,6 +63,8 @@ Inherited options
 
 These options inherit from the :doc:`field </reference/types/field>` type:
 
+.. include:: /reference/types/options/model_mappings.rst.inc
+
 .. include:: /reference/types/options/invalid_message.rst.inc
 
 .. include:: /reference/types/options/invalid_message_parameters.rst.inc

--- a/doc/reference/types/language.rst
+++ b/doc/reference/types/language.rst
@@ -47,6 +47,8 @@ Inherited options
 
 These options inherit from the :doc:`field </reference/types/field>` type:
 
+.. include:: /reference/types/options/model_mappings.rst.inc
+
 .. include:: /reference/types/options/invalid_message.rst.inc
 
 .. include:: /reference/types/options/invalid_message_parameters.rst.inc

--- a/doc/reference/types/locale.rst
+++ b/doc/reference/types/locale.rst
@@ -48,6 +48,8 @@ Inherited options
 
 These options inherit from the :doc:`field </reference/types/field>` type:
 
+.. include:: /reference/types/options/model_mappings.rst.inc
+
 .. include:: /reference/types/options/invalid_message.rst.inc
 
 .. include:: /reference/types/options/invalid_message_parameters.rst.inc

--- a/doc/reference/types/money.rst
+++ b/doc/reference/types/money.rst
@@ -65,6 +65,8 @@ Inherited Options
 
 These options inherit from the :doc:`field </reference/types/field>` type:
 
+.. include:: /reference/types/options/model_mappings.rst.inc
+
 .. include:: /reference/types/options/invalid_message.rst.inc
 
 .. include:: /reference/types/options/invalid_message_parameters.rst.inc

--- a/doc/reference/types/number.rst
+++ b/doc/reference/types/number.rst
@@ -63,6 +63,8 @@ Inherited Options
 
 These options inherit from the :doc:`field </reference/types/field>` type:
 
+.. include:: /reference/types/options/model_mappings.rst.inc
+
 .. include:: /reference/types/options/invalid_message.rst.inc
 
 .. include:: /reference/types/options/invalid_message_parameters.rst.inc

--- a/doc/reference/types/options/model_mappings.rst.inc
+++ b/doc/reference/types/options/model_mappings.rst.inc
@@ -1,0 +1,29 @@
+model_mappings
+~~~~~~~~~~~~~~
+
+**type**: ``array`` or ``null`` **default**: ``null``
+
+Model class mappings for specific condition processors.
+
+The Doctrine ORM processor needs to know which Entity (Model) and property,
+the search field is mapped to. This can be configured directly on the field
+using this option, or using the WhereBuilder configuration.
+
+Using this option has the advantage that you only need to configure it once.
+
+The ``model_mappings`` option expects an array with one or more
+``[Entity, property]`` mappings.
+
+.. code-block:: php
+
+    $builder->add('name', 'some_type', [
+        // ...
+        'model_mappings' => [
+            ['Acme\Model\Users', 'firstName'],
+            ['Acme\Model\Users', 'lastName'],
+        ],
+    ]);
+
+Setting more then one mapping will effectively apply the field's values on
+all the mappings, in the example above the ``name`` field is applied for
+both the first and last name of a ``User``.

--- a/doc/reference/types/text.rst
+++ b/doc/reference/types/text.rst
@@ -28,6 +28,8 @@ Inherited Options
 
 These options inherit from the :doc:`field </reference/types/field>` type:
 
+.. include:: /reference/types/options/model_mappings.rst.inc
+
 .. include:: /reference/types/options/invalid_message.rst.inc
 
 .. include:: /reference/types/options/invalid_message_parameters.rst.inc

--- a/doc/reference/types/time.rst
+++ b/doc/reference/types/time.rst
@@ -41,6 +41,8 @@ Inherited options
 
 These options inherit from the :doc:`field </reference/types/field>` type:
 
+.. include:: /reference/types/options/model_mappings.rst.inc
+
 .. include:: /reference/types/options/invalid_message.rst.inc
 
 .. include:: /reference/types/options/invalid_message_parameters.rst.inc

--- a/doc/reference/types/timezone.rst
+++ b/doc/reference/types/timezone.rst
@@ -42,6 +42,8 @@ Inherited options
 
 These options inherit from the :doc:`field </reference/types/field>` type:
 
+.. include:: /reference/types/options/model_mappings.rst.inc
+
 .. include:: /reference/types/options/invalid_message.rst.inc
 
 .. include:: /reference/types/options/invalid_message_parameters.rst.inc

--- a/src/Extension/Core/Type/FieldType.php
+++ b/src/Extension/Core/Type/FieldType.php
@@ -12,6 +12,7 @@
 namespace Rollerworks\Component\Search\Extension\Core\Type;
 
 use Rollerworks\Component\Search\AbstractFieldType;
+use Rollerworks\Component\Search\Exception\InvalidConfigurationException;
 use Rollerworks\Component\Search\FieldConfigInterface;
 use Rollerworks\Component\Search\ValueComparisonInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -58,6 +59,16 @@ class FieldType extends AbstractFieldType
     public function buildType(FieldConfigInterface $config, array $options)
     {
         $config->setValueComparison($this->valueComparison);
+
+        if (null !== $options['model_mappings'] && ($options['model_class'] || $options['model_property'])) {
+            throw new InvalidConfigurationException(
+                sprintf(
+                    'Option "model_mappings" cannot be set in combination with "model_class" '.
+                    'and/or "model_property" for field "%s"',
+                    $config->getName()
+                )
+            );
+        }
     }
 
     /**
@@ -71,10 +82,12 @@ class FieldType extends AbstractFieldType
                 'invalid_message_parameters' => [],
                 'model_class' => null,
                 'model_property' => null,
+                'model_mappings' => null,
             ]
         );
 
         $resolver->setAllowedTypes('invalid_message', ['string']);
         $resolver->setAllowedTypes('invalid_message_parameters', ['array']);
+        $resolver->setAllowedTypes('model_mappings', ['array', 'null']);
     }
 }

--- a/tests/Extension/Core/Type/FieldTypeTest.php
+++ b/tests/Extension/Core/Type/FieldTypeTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Tests\Extension\Core\Type;
+
+use Rollerworks\Component\Search\Test\FieldTypeTestCase;
+
+class FieldTypeTest extends FieldTypeTestCase
+{
+    public function testCreate()
+    {
+        $this->getFactory()->createField('name', 'field');
+    }
+
+    public function testMappingsAllowed()
+    {
+        $this->getFactory()->createField('name', 'field', ['model_mappings' => [['stdClass', 'id']]]);
+    }
+
+    /**
+     * @expectedException \Rollerworks\Component\Search\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage Option "model_mappings" cannot be set in combination with "model_class"
+     */
+    public function testMappingsCannotBeCombinedWithModelClass()
+    {
+        $this->getFactory()->createField('name', 'field', ['model_mappings' => [['stdClass', 'id']], 'model_class' => 'std']);
+    }
+
+    /**
+     * @expectedException \Rollerworks\Component\Search\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage Option "model_mappings" cannot be set in combination with "model_class"
+     */
+    public function testMappingsCannotBeCombinedWithModelProperty()
+    {
+        $this->getFactory()->createField('name', 'field', ['model_mappings' => [['stdClass', 'id']], 'model_property' => 'std']);
+    }
+
+    protected function getTestedType()
+    {
+        return 'field';
+    }
+}


### PR DESCRIPTION
Allow to set multiple model mappings. This change is required to make #1 possible.

Note that the Doctrine processor's need to be updated for this be fully working.
~~And documentation needs to be updated also.~~