### PR TITLE
Add RequiresComparatorValueHolder to check config

### DIFF
--- a/src/FieldConfigInterface.php
+++ b/src/FieldConfigInterface.php
@@ -37,17 +37,14 @@ interface FieldConfigInterface
     /**
      * Returns whether value-type $type is accepted by the field.
      *
-     * Value must be a constant of:
-     *
-     * * ValuesBag::VALUE_TYPE_RANGE
-     * * ValuesBag::VALUE_TYPE_COMPARISON
-     * * ValuesBag::VALUE_TYPE_PATTERN_MATCH
+     * Value must be a FQCN of a class implementing
+     * {@link \Rollerworks\Component\Search\Value\ValueHolder}.
      *
      * @param string $type
      *
      * @return bool
      */
-    public function supportValueType($type);
+    public function supportValueType(string $type): bool;
 
     /**
      * Set whether value-type $type is accepted by the field.
@@ -59,7 +56,7 @@ interface FieldConfigInterface
      * @param string $type
      * @param bool   $enabled
      */
-    public function setValueTypeSupport($type, $enabled);
+    public function setValueTypeSupport(string $type, bool $enabled);
 
     /**
      * Set the {@link ValueComparisonInterface} instance for optimizing

--- a/src/Input/FieldValuesFactory.php
+++ b/src/Input/FieldValuesFactory.php
@@ -95,7 +95,7 @@ class FieldValuesFactory
         $basePath = $this->createValuePath($path[0]);
 
         $this->increaseValuesCount($basePath);
-        $this->assertAcceptsType('range');
+        $this->assertAcceptsType(Range::class);
 
         $lowerNorm = $this->inputToNorm($lower, $basePath.$path[1]);
         $upperNorm = $this->inputToNorm($upper, $basePath.$path[2]);
@@ -120,7 +120,7 @@ class FieldValuesFactory
         $basePath = $this->createValuePath($path[0]);
 
         $this->increaseValuesCount($basePath);
-        $this->assertAcceptsType('range');
+        $this->assertAcceptsType(Range::class);
 
         $lowerNorm = $this->inputToNorm($lower, $basePath.$path[1]);
         $upperNorm = $this->inputToNorm($upper, $basePath.$path[2]);
@@ -138,7 +138,7 @@ class FieldValuesFactory
         $basePath = $this->createValuePath($path[0]);
 
         $this->increaseValuesCount($basePath);
-        $this->assertAcceptsType('comparison');
+        $this->assertAcceptsType(Compare::class);
 
         $modelVal = $this->inputToNorm($value, $basePath.$path[2]);
 
@@ -161,7 +161,7 @@ class FieldValuesFactory
         $valid = true;
 
         $this->increaseValuesCount($basePath);
-        $this->assertAcceptsType('pattern-match');
+        $this->assertAcceptsType(PatternMatch::class);
 
         if (!is_scalar($patternMatch)) {
             $this->addError(new ConditionErrorMessage($basePath.$path[1], 'PatternMatch value must a string.'));

--- a/src/Value/Compare.php
+++ b/src/Value/Compare.php
@@ -16,7 +16,7 @@ namespace Rollerworks\Component\Search\Value;
 /**
  * Compare value structure.
  */
-final class Compare implements ValueHolder
+final class Compare implements RequiresComparatorValueHolder
 {
     private $operator;
     private $value;

--- a/src/Value/Range.php
+++ b/src/Value/Range.php
@@ -16,7 +16,7 @@ namespace Rollerworks\Component\Search\Value;
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class Range implements ValueHolder
+class Range implements RequiresComparatorValueHolder
 {
     private $lower;
     private $upper;

--- a/src/Value/RequiresComparatorValueHolder.php
+++ b/src/Value/RequiresComparatorValueHolder.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Value;
+
+/**
+ * RequiresComparatorValueHolder indicates the value-holder
+ * requires a comparator in the field's type.
+ */
+interface RequiresComparatorValueHolder extends ValueHolder
+{
+}

--- a/src/Value/ValuesBag.php
+++ b/src/Value/ValuesBag.php
@@ -24,19 +24,19 @@ class ValuesBag implements \Countable, \Serializable
      * @deprecated Deprecated since version 1.2, to be removed in 2.0.
      *             Use `Rollerworks\Component\Search\Value\Range::class` instead
      */
-    const VALUE_TYPE_RANGE = 'range';
+    const VALUE_TYPE_RANGE = Range::class;
 
     /**
      * @deprecated Deprecated since version 1.2, to be removed in 2.0.
      *             Use `Rollerworks\Component\Search\Value\Compare::class` instead
      */
-    const VALUE_TYPE_COMPARISON = 'comparison';
+    const VALUE_TYPE_COMPARISON = Compare::class;
 
     /**
      * @deprecated Deprecated since version 1.2, to be removed in 2.0.
      *             Use `Rollerworks\Component\Search\Value\PatternMatch::class` instead
      */
-    const VALUE_TYPE_PATTERN_MATCH = 'pattern-match';
+    const VALUE_TYPE_PATTERN_MATCH = PatternMatch::class;
 
     private $valuesCount = 0;
     private $simpleValues = [];

--- a/tests/Input/ArrayInputTest.php
+++ b/tests/Input/ArrayInputTest.php
@@ -15,6 +15,9 @@ namespace Rollerworks\Component\Search\Tests\Input;
 
 use Rollerworks\Component\Search\ConditionErrorMessage;
 use Rollerworks\Component\Search\Input\ArrayInput;
+use Rollerworks\Component\Search\Value\Compare;
+use Rollerworks\Component\Search\Value\PatternMatch;
+use Rollerworks\Component\Search\Value\Range;
 use Rollerworks\Component\Search\Value\ValuesGroup;
 
 /**
@@ -493,7 +496,7 @@ final class ArrayInputTest extends InputProcessorTestCase
                     ],
                 ],
                 'no-range-field',
-                'range',
+                Range::class,
             ],
             [
                 [
@@ -504,7 +507,7 @@ final class ArrayInputTest extends InputProcessorTestCase
                     ],
                 ],
                 'no-range-field',
-                'range',
+                Range::class,
             ],
             [
                 [
@@ -515,7 +518,7 @@ final class ArrayInputTest extends InputProcessorTestCase
                     ],
                 ],
                 'no-compares-field',
-                'comparison',
+                Compare::class,
             ],
             [
                 [
@@ -526,7 +529,7 @@ final class ArrayInputTest extends InputProcessorTestCase
                     ],
                 ],
                 'no-matchers-field',
-                'pattern-match',
+                PatternMatch::class,
             ],
         ];
     }

--- a/tests/Input/FilterQueryInputTest.php
+++ b/tests/Input/FilterQueryInputTest.php
@@ -20,6 +20,9 @@ use Rollerworks\Component\Search\Input\FilterQuery\QueryException;
 use Rollerworks\Component\Search\Input\FilterQueryInput;
 use Rollerworks\Component\Search\Input\ProcessorConfig;
 use Rollerworks\Component\Search\SearchCondition;
+use Rollerworks\Component\Search\Value\Compare;
+use Rollerworks\Component\Search\Value\PatternMatch;
+use Rollerworks\Component\Search\Value\Range;
 use Rollerworks\Component\Search\Value\ValuesBag;
 use Rollerworks\Component\Search\Value\ValuesGroup;
 
@@ -290,9 +293,9 @@ final class FilterQueryInputTest extends InputProcessorTestCase
     public function provideUnsupportedValueTypeExceptionTests()
     {
         return [
-            ['no-range-field: 1-12;', 'no-range-field', 'range'],
-            ['no-compares-field: >12;', 'no-compares-field', 'comparison'],
-            ['no-matchers-field: ~>12;', 'no-matchers-field', 'pattern-match'],
+            ['no-range-field: 1-12;', 'no-range-field', Range::class],
+            ['no-compares-field: >12;', 'no-compares-field', Compare::class],
+            ['no-matchers-field: ~>12;', 'no-matchers-field', PatternMatch::class],
         ];
     }
 

--- a/tests/Input/JsonInputTest.php
+++ b/tests/Input/JsonInputTest.php
@@ -16,6 +16,9 @@ namespace Rollerworks\Component\Search\Tests\Input;
 use Rollerworks\Component\Search\ConditionErrorMessage;
 use Rollerworks\Component\Search\Input\JsonInput;
 use Rollerworks\Component\Search\Input\ProcessorConfig;
+use Rollerworks\Component\Search\Value\Compare;
+use Rollerworks\Component\Search\Value\PatternMatch;
+use Rollerworks\Component\Search\Value\Range;
 use Rollerworks\Component\Search\Value\ValuesGroup;
 
 final class JsonInputTest extends InputProcessorTestCase
@@ -541,7 +544,7 @@ final class JsonInputTest extends InputProcessorTestCase
                     ]
                 ),
                 'no-range-field',
-                'range',
+               Range::class,
             ],
             [
                 json_encode(
@@ -554,7 +557,7 @@ final class JsonInputTest extends InputProcessorTestCase
                     ]
                 ),
                 'no-range-field',
-                'range',
+                Range::class,
             ],
             [
                 json_encode(
@@ -567,7 +570,7 @@ final class JsonInputTest extends InputProcessorTestCase
                     ]
                 ),
                 'no-compares-field',
-                'comparison',
+                Compare::class,
             ],
             [
                 json_encode(
@@ -580,7 +583,7 @@ final class JsonInputTest extends InputProcessorTestCase
                     ]
                 ),
                 'no-matchers-field',
-                'pattern-match',
+                PatternMatch::class,
             ],
         ];
     }

--- a/tests/Input/XmlInputTest.php
+++ b/tests/Input/XmlInputTest.php
@@ -18,6 +18,9 @@ use Rollerworks\Component\Search\Exception\InvalidSearchConditionException;
 use Rollerworks\Component\Search\Extension\Core\Type\TextType;
 use Rollerworks\Component\Search\Input\ProcessorConfig;
 use Rollerworks\Component\Search\Input\XmlInput;
+use Rollerworks\Component\Search\Value\Compare;
+use Rollerworks\Component\Search\Value\PatternMatch;
+use Rollerworks\Component\Search\Value\Range;
 use Rollerworks\Component\Search\Value\ValuesGroup;
 
 final class XmlInputTest extends InputProcessorTestCase
@@ -754,7 +757,7 @@ final class XmlInputTest extends InputProcessorTestCase
                     </fields>
                 </search>',
                 'no-range-field',
-                'range',
+                Range::class,
             ],
             [
                 '<?xml version="1.0" encoding="UTF-8"'.'?'.'>
@@ -768,7 +771,7 @@ final class XmlInputTest extends InputProcessorTestCase
                     </fields>
                 </search>',
                 'no-compares-field',
-                'comparison',
+                Compare::class,
             ],
             [
                 '<?xml version="1.0" encoding="UTF-8"'.'?'.'>
@@ -782,7 +785,7 @@ final class XmlInputTest extends InputProcessorTestCase
                       </fields>
                 </search>',
                 'no-matchers-field',
-                'pattern-match',
+                PatternMatch::class,
             ],
         ];
     }


### PR DESCRIPTION
A value-holder implementing the RequiresComparatorValueHolder indicates a value Comparator
is required for the field configuration.