### PR TITLE
Rewrite logic of norm transformers and more tests

### DIFF
--- a/src/Extension/Core/CoreExtension.php
+++ b/src/Extension/Core/CoreExtension.php
@@ -35,17 +35,11 @@ class CoreExtension extends AbstractExtension
             new Type\DateType(new ValueComparison\DateValueComparison()),
             new Type\DateTimeType($dateTimeComparison),
             new Type\TimeType($dateTimeComparison),
+            new Type\TimestampType($dateTimeComparison),
             new Type\BirthdayType(new ValueComparison\BirthdayValueComparison()),
-            new Type\ChoiceType(),
-            new Type\CountryType(),
             new Type\IntegerType($numberComparison),
-            new Type\LanguageType(),
-            new Type\LocaleType(),
             new Type\MoneyType(new ValueComparison\MoneyValueComparison()),
             new Type\NumberType($numberComparison),
-            new Type\TextType(),
-            new Type\TimezoneType(),
-            new Type\CurrencyType(),
         ];
     }
 }

--- a/src/Extension/Core/DataTransformer/BaseDateTimeTransformer.php
+++ b/src/Extension/Core/DataTransformer/BaseDateTimeTransformer.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Rollerworks\Component\Search\Extension\Core\DataTransformer;
 
 use Rollerworks\Component\Search\DataTransformerInterface;
+use Rollerworks\Component\Search\Exception\InvalidArgumentException;
 use Rollerworks\Component\Search\Exception\UnexpectedTypeException;
 
 /**
@@ -32,6 +33,14 @@ abstract class BaseDateTimeTransformer implements DataTransformerInterface
      */
     protected $outputTimezone;
 
+    protected static $formats = [
+        \IntlDateFormatter::NONE,
+        \IntlDateFormatter::FULL,
+        \IntlDateFormatter::LONG,
+        \IntlDateFormatter::MEDIUM,
+        \IntlDateFormatter::SHORT,
+    ];
+
     /**
      * Constructor.
      *
@@ -44,5 +53,18 @@ abstract class BaseDateTimeTransformer implements DataTransformerInterface
     {
         $this->inputTimezone = $inputTimezone ?? date_default_timezone_get();
         $this->outputTimezone = $outputTimezone ?? date_default_timezone_get();
+
+        // Check if input and output timezones are valid
+        try {
+            new \DateTimeZone($this->inputTimezone);
+        } catch (\Exception $e) {
+            throw new InvalidArgumentException(sprintf('Input timezone is invalid: %s.', $this->inputTimezone), $e->getCode(), $e);
+        }
+
+        try {
+            new \DateTimeZone($this->outputTimezone);
+        } catch (\Exception $e) {
+            throw new InvalidArgumentException(sprintf('Output timezone is invalid: %s.', $this->outputTimezone), $e->getCode(), $e);
+        }
     }
 }

--- a/src/Extension/Core/DataTransformer/BaseNumberTransformer.php
+++ b/src/Extension/Core/DataTransformer/BaseNumberTransformer.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Extension\Core\DataTransformer;
+
+use Rollerworks\Component\Search\DataTransformerInterface;
+
+/**
+ * Transforms between a number type and a number with grouping
+ * (each thousand) and comma separators.
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ * @author Florian Eckerstorfer <florian@eckerstorfer.org>
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+abstract class BaseNumberTransformer implements DataTransformerInterface
+{
+    /**
+     * Rounds a number towards positive infinity.
+     *
+     * Rounds 1.4 to 2 and -1.4 to -1.
+     */
+    const ROUND_CEILING = \NumberFormatter::ROUND_CEILING;
+
+    /**
+     * Rounds a number towards negative infinity.
+     *
+     * Rounds 1.4 to 1 and -1.4 to -2.
+     */
+    const ROUND_FLOOR = \NumberFormatter::ROUND_FLOOR;
+
+    /**
+     * Rounds a number away from zero.
+     *
+     * Rounds 1.4 to 2 and -1.4 to -2.
+     */
+    const ROUND_UP = \NumberFormatter::ROUND_UP;
+
+    /**
+     * Rounds a number towards zero.
+     *
+     * Rounds 1.4 to 1 and -1.4 to -1.
+     */
+    const ROUND_DOWN = \NumberFormatter::ROUND_DOWN;
+
+    /**
+     * Rounds to the nearest number and halves to the next even number.
+     *
+     * Rounds 2.5, 1.6 and 1.5 to 2 and 1.4 to 1.
+     */
+    const ROUND_HALF_EVEN = \NumberFormatter::ROUND_HALFEVEN;
+
+    /**
+     * Rounds to the nearest number and halves away from zero.
+     *
+     * Rounds 2.5 to 3, 1.6 and 1.5 to 2 and 1.4 to 1.
+     */
+    const ROUND_HALF_UP = \NumberFormatter::ROUND_HALFUP;
+
+    /**
+     * Rounds to the nearest number and halves towards zero.
+     *
+     * Rounds 2.5 and 1.6 to 2, 1.5 and 1.4 to 1.
+     */
+    const ROUND_HALF_DOWN = \NumberFormatter::ROUND_HALFDOWN;
+
+    /**
+     * @var int|null
+     */
+    protected $scale;
+
+    /**
+     * @var bool|null
+     */
+    protected $grouping;
+
+    /**
+     * @var int|null
+     */
+    protected $roundingMode;
+
+    /**
+     * @var int
+     */
+    protected $type;
+
+    /**
+     * Rounds a number according to the configured scale and rounding mode.
+     *
+     * @param int|float $number A number
+     *
+     * @return int|float The rounded number
+     */
+    protected function round($number)
+    {
+        if (null !== $this->scale && null !== $this->roundingMode) {
+            // shift number to maintain the correct scale during rounding
+            $roundingCoef = pow(10, $this->scale);
+            $number *= $roundingCoef;
+
+            switch ($this->roundingMode) {
+                case self::ROUND_CEILING:
+                    $number = ceil($number);
+                    break;
+                case self::ROUND_FLOOR:
+                    $number = floor($number);
+                    break;
+                case self::ROUND_UP:
+                    $number = $number > 0 ? ceil($number) : floor($number);
+                    break;
+                case self::ROUND_DOWN:
+                    $number = $number > 0 ? floor($number) : ceil($number);
+                    break;
+                case self::ROUND_HALF_EVEN:
+                    $number = round($number, 0, PHP_ROUND_HALF_EVEN);
+                    break;
+                case self::ROUND_HALF_UP:
+                    $number = round($number, 0, PHP_ROUND_HALF_UP);
+                    break;
+                case self::ROUND_HALF_DOWN:
+                    $number = round($number, 0, PHP_ROUND_HALF_DOWN);
+                    break;
+            }
+
+            $number /= $roundingCoef;
+        }
+
+        return $number;
+    }
+}

--- a/src/Extension/Core/DataTransformer/BirthdayTransformer.php
+++ b/src/Extension/Core/DataTransformer/BirthdayTransformer.php
@@ -42,7 +42,7 @@ class BirthdayTransformer implements DataTransformerInterface
      * @param bool                     $allowAge
      * @param bool                     $allowFutureDate
      */
-    public function __construct(DataTransformerInterface $transformer, bool $allowAge, bool $allowFutureDate)
+    public function __construct(DataTransformerInterface $transformer, bool $allowAge = true, bool $allowFutureDate = false)
     {
         $this->transformer = $transformer;
         $this->allowFutureDate = $allowFutureDate;
@@ -56,7 +56,7 @@ class BirthdayTransformer implements DataTransformerInterface
     {
         if (is_int($value)) {
             if (!$this->allowAge) {
-                throw new TransformationFailedException('Age is not supported.');
+                throw new TransformationFailedException('Age support is not enabled.');
             }
 
             return $value;
@@ -74,7 +74,7 @@ class BirthdayTransformer implements DataTransformerInterface
 
         if (is_int($value)) {
             if (!$this->allowAge) {
-                throw new TransformationFailedException('Age is not supported.');
+                throw new TransformationFailedException('Age support is not enabled.');
             }
 
             return $value;

--- a/src/Extension/Core/DataTransformer/DateTimeToTimestampTransformer.php
+++ b/src/Extension/Core/DataTransformer/DateTimeToTimestampTransformer.php
@@ -70,7 +70,7 @@ class DateTimeToTimestampTransformer extends BaseDateTimeTransformer
         try {
             $dateTime = new \DateTime();
             $dateTime->setTimezone(new \DateTimeZone($this->outputTimezone));
-            $dateTime->setTimestamp($value);
+            $dateTime->setTimestamp((int) $value);
 
             if ($this->inputTimezone !== $this->outputTimezone) {
                 $dateTime->setTimezone(new \DateTimeZone($this->inputTimezone));

--- a/src/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformer.php
+++ b/src/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformer.php
@@ -24,11 +24,10 @@ class IntegerToLocalizedStringTransformer extends NumberToLocalizedStringTransfo
     /**
      * Constructs a transformer.
      *
-     * @param int  $precision    Unused
      * @param bool $grouping     Whether thousands should be grouped
      * @param int  $roundingMode One of the ROUND_ constants in this class
      */
-    public function __construct(int $precision = null, bool $grouping = null, int $roundingMode = null)
+    public function __construct(bool $grouping = null, int $roundingMode = null)
     {
         parent::__construct(0, $grouping, $roundingMode ?? self::ROUND_DOWN);
     }

--- a/src/Extension/Core/DataTransformer/IntegerToStringTransformer.php
+++ b/src/Extension/Core/DataTransformer/IntegerToStringTransformer.php
@@ -24,13 +24,11 @@ class IntegerToStringTransformer extends NumberToStringTransformer
     /**
      * Constructs a transformer.
      *
-     * @param int  $precision    Unused
-     * @param bool $grouping     Whether thousands should be grouped
-     * @param int  $roundingMode One of the ROUND_ constants in this class
+     * @param int $roundingMode One of the ROUND_ constants in this class
      */
-    public function __construct(int $precision = null, bool $grouping = null, int $roundingMode = null)
+    public function __construct(int $roundingMode = null)
     {
-        parent::__construct(0, $grouping, $roundingMode ?? self::ROUND_DOWN);
+        parent::__construct(0, $roundingMode ?? self::ROUND_DOWN);
     }
 
     /**

--- a/src/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
+++ b/src/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
@@ -23,7 +23,7 @@ use Rollerworks\Component\Search\Extension\Core\Model\MoneyValue;
  * @author Florian Eckerstorfer <florian@eckerstorfer.org>
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class MoneyToLocalizedStringTransformer extends NumberToLocalizedStringTransformer
+class MoneyToLocalizedStringTransformer extends BaseNumberTransformer
 {
     /**
      * @var int|null
@@ -36,18 +36,19 @@ class MoneyToLocalizedStringTransformer extends NumberToLocalizedStringTransform
     private $defaultCurrency;
 
     /**
-     * @param int    $precision
+     * @param int    $scale
      * @param bool   $grouping
      * @param int    $roundingMode
      * @param int    $divisor
      * @param string $defaultCurrency
      */
-    public function __construct(int $precision = null, bool $grouping = null, int $roundingMode = null, int $divisor = null, string $defaultCurrency = null)
+    public function __construct(int $scale = null, bool $grouping = null, int $roundingMode = null, int $divisor = null, string $defaultCurrency = null)
     {
-        parent::__construct($precision ?? 2, $grouping ?? true, $roundingMode, \NumberFormatter::TYPE_CURRENCY);
-
-        $this->divisor = $divisor ?? 1;
+        $this->scale = $scale;
+        $this->grouping = $grouping ?? false;
+        $this->roundingMode = $roundingMode ?? self::ROUND_HALF_UP;
         $this->defaultCurrency = $defaultCurrency;
+        $this->divisor = $divisor ?? 1;
     }
 
     /**
@@ -70,15 +71,11 @@ class MoneyToLocalizedStringTransformer extends NumberToLocalizedStringTransform
             throw new TransformationFailedException('Expected a MoneyValue object.');
         }
 
-        if (!is_numeric($value->value)) {
-            throw new TransformationFailedException('Expected a numeric value.');
-        }
-
         $amountValue = $value->value;
         $amountValue /= $this->divisor;
 
         $formatter = $this->getNumberFormatter();
-        $value = $formatter->formatCurrency($amountValue, $value->currency);
+        $value = $formatter->formatCurrency((float) $amountValue, $value->currency);
 
         if (intl_is_failure($formatter->getErrorCode())) {
             throw new TransformationFailedException($formatter->getErrorMessage());
@@ -91,33 +88,111 @@ class MoneyToLocalizedStringTransformer extends NumberToLocalizedStringTransform
     }
 
     /**
-     * Transforms a localized money string into a normalized format.
+     * Transforms a localized number into an integer or float.
      *
-     * @param string $value Localized money string
+     * @param string $value The localized value
      *
-     * @throws TransformationFailedException If the given value is not a string
+     * @throws TransformationFailedException if the given value is not a string
      *                                       or if the value can not be transformed
      *
-     * @return MoneyValue Normalized number
+     * @return MoneyValue
      */
     public function reverseTransform($value)
     {
+        if (!is_string($value)) {
+            throw new TransformationFailedException('Expected a string.');
+        }
+
+        if ('' === $value) {
+            return null;
+        }
+
+        if ('NaN' === $value) {
+            throw new TransformationFailedException('"NaN" is not a valid number');
+        }
+
         $value = str_replace(' ', "\xc2\xa0", $value);
+        $currency = '';
 
         if (!preg_match('#\p{Sc}#u', $value)) {
             $currency = false;
         }
 
-        $value = parent::reverseTransform($value, $currency);
+        $position = 0;
+        $formatter = $this->getNumberFormatter(false === $currency ? \NumberFormatter::DECIMAL : \NumberFormatter::CURRENCY);
+        $groupSep = $formatter->getSymbol(\NumberFormatter::GROUPING_SEPARATOR_SYMBOL);
+        $decSep = $formatter->getSymbol(\NumberFormatter::DECIMAL_SEPARATOR_SYMBOL);
 
-        if (null !== $value) {
-            $value *= $this->divisor;
+        if ('.' !== $decSep && (!$this->grouping || '.' !== $groupSep)) {
+            $value = str_replace('.', $decSep, $value);
         }
+
+        if (',' !== $decSep && (!$this->grouping || ',' !== $groupSep)) {
+            $value = str_replace(',', $decSep, $value);
+        }
+
+        if (false !== $currency) {
+            $result = $formatter->parseCurrency($value, $currency, $position);
+        } else {
+            $result = $formatter->parse($value, \NumberFormatter::TYPE_DOUBLE, $position);
+        }
+
+        if (intl_is_failure($formatter->getErrorCode())) {
+            throw new TransformationFailedException($formatter->getErrorMessage());
+        }
+
+        if ($result >= PHP_INT_MAX || $result <= -PHP_INT_MAX) {
+            throw new TransformationFailedException('I don\'t have a clear idea what infinity looks like.');
+        }
+
+        if (is_int($result) && $result === (int) $float = (float) $result) {
+            $result = $float;
+        }
+
+        if (false !== $encoding = mb_detect_encoding($value, null, true)) {
+            $length = mb_strlen($value, $encoding);
+            $remainder = mb_substr($value, $position, $length, $encoding);
+        } else {
+            $length = strlen($value);
+            $remainder = substr($value, $position, $length);
+        }
+
+        // After parsing, position holds the index of the character where the
+        // parsing stopped
+        if ($position < $length) {
+            // Check if there are unrecognized characters at the end of the
+            // number (excluding whitespace characters)
+            $remainder = trim($remainder, " \t\n\r\0\x0b\xc2\xa0");
+
+            if ('' !== $remainder) {
+                throw new TransformationFailedException(
+                    sprintf('The number contains unrecognized characters: "%s"', $remainder)
+                );
+            }
+        }
+
+        // NumberFormatter::parse() does not round
+        $result = $this->round($result);
+        $result *= $this->divisor;
 
         if (false === $currency) {
             $currency = $this->defaultCurrency;
         }
 
-        return new MoneyValue($currency, (string) $value);
+        return new MoneyValue($currency, (string) $result);
+    }
+
+    private function getNumberFormatter(int $type = \NumberFormatter::CURRENCY): \NumberFormatter
+    {
+        $formatter = new \NumberFormatter(\Locale::getDefault(), $type);
+
+        if (null !== $this->scale) {
+            $formatter->setAttribute(\NumberFormatter::FRACTION_DIGITS, $this->scale);
+            $formatter->setAttribute(\NumberFormatter::ROUNDING_MODE, $this->roundingMode);
+        }
+
+        $formatter->setAttribute(\NumberFormatter::GROUPING_USED, $this->grouping);
+
+        return $formatter;
     }
 }

--- a/src/Extension/Core/DataTransformer/NumberToStringTransformer.php
+++ b/src/Extension/Core/DataTransformer/NumberToStringTransformer.php
@@ -13,111 +13,38 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Extension\Core\DataTransformer;
 
-use Rollerworks\Component\Search\DataTransformerInterface;
 use Rollerworks\Component\Search\Exception\TransformationFailedException;
 
 /**
- * Transforms between a number type and a number with grouping
- * (each thousand) and comma separators.
+ * Transforms between a number type and a number with rounding.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @author Florian Eckerstorfer <florian@eckerstorfer.org>
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class NumberToStringTransformer implements DataTransformerInterface
+class NumberToStringTransformer extends BaseNumberTransformer
 {
     /**
-     * Rounds a number towards positive infinity.
-     *
-     * Rounds 1.4 to 2 and -1.4 to -1.
+     * @param int $scale
+     * @param int $roundingMode
+     * @param int $type
      */
-    const ROUND_CEILING = \NumberFormatter::ROUND_CEILING;
-
-    /**
-     * Rounds a number towards negative infinity.
-     *
-     * Rounds 1.4 to 1 and -1.4 to -2.
-     */
-    const ROUND_FLOOR = \NumberFormatter::ROUND_FLOOR;
-
-    /**
-     * Rounds a number away from zero.
-     *
-     * Rounds 1.4 to 2 and -1.4 to -2.
-     */
-    const ROUND_UP = \NumberFormatter::ROUND_UP;
-
-    /**
-     * Rounds a number towards zero.
-     *
-     * Rounds 1.4 to 1 and -1.4 to -1.
-     */
-    const ROUND_DOWN = \NumberFormatter::ROUND_DOWN;
-
-    /**
-     * Rounds to the nearest number and halves to the next even number.
-     *
-     * Rounds 2.5, 1.6 and 1.5 to 2 and 1.4 to 1.
-     */
-    const ROUND_HALF_EVEN = \NumberFormatter::ROUND_HALFEVEN;
-
-    /**
-     * Rounds to the nearest number and halves away from zero.
-     *
-     * Rounds 2.5 to 3, 1.6 and 1.5 to 2 and 1.4 to 1.
-     */
-    const ROUND_HALF_UP = \NumberFormatter::ROUND_HALFUP;
-
-    /**
-     * Rounds to the nearest number and halves towards zero.
-     *
-     * Rounds 2.5 and 1.6 to 2, 1.5 and 1.4 to 1.
-     */
-    const ROUND_HALF_DOWN = \NumberFormatter::ROUND_HALFDOWN;
-
-    /**
-     * @var int|null
-     */
-    protected $precision;
-
-    /**
-     * @var bool|null
-     */
-    protected $grouping;
-
-    /**
-     * @var int|null
-     */
-    protected $roundingMode;
-
-    /**
-     * @var int
-     */
-    protected $type;
-
-    /**
-     * @param int  $precision
-     * @param bool $grouping
-     * @param int  $roundingMode
-     * @param int  $type
-     */
-    public function __construct(int $precision = null, bool $grouping = null, int $roundingMode = null, int $type = \NumberFormatter::TYPE_DOUBLE)
+    public function __construct(int $scale = null, int $roundingMode = null, int $type = \NumberFormatter::DECIMAL)
     {
-        $this->precision = $precision;
-        $this->grouping = $grouping ?? false;
+        $this->scale = $scale;
         $this->roundingMode = $roundingMode ?? self::ROUND_HALF_UP;
         $this->type = $type;
     }
 
     /**
-     * Transforms a number type into localized number.
+     * Transforms a number type into number.
      *
      * @param int|float $value Number value
      *
      * @throws TransformationFailedException If the given value is not numeric
      *                                       or if the value can not be transformed
      *
-     * @return string Localized value
+     * @return string
      */
     public function transform($value)
     {
@@ -129,21 +56,15 @@ class NumberToStringTransformer implements DataTransformerInterface
             throw new TransformationFailedException('Expected a numeric.');
         }
 
-        $formatter = $this->getNumberFormatter();
-        $value = $formatter->format($value);
-
-        if (intl_is_failure($formatter->getErrorCode())) {
-            throw new TransformationFailedException($formatter->getErrorMessage());
+        if ($value >= PHP_INT_MAX || $value <= -PHP_INT_MAX) {
+            throw new TransformationFailedException('I don\'t have a clear idea what infinity looks like.');
         }
 
-        // Convert fixed spaces to normal ones
-        $value = str_replace("\xc2\xa0", ' ', $value);
-
-        return $value;
+        return (string) $this->round($value);
     }
 
     /**
-     * Transforms a localized number into an integer or float.
+     * Transforms a normalized number into an integer or float.
      *
      * @param string $value    The localized value
      * @param string $currency The parsed currency value
@@ -163,125 +84,35 @@ class NumberToStringTransformer implements DataTransformerInterface
             return null;
         }
 
-        if ('NaN' === $value) {
-            throw new TransformationFailedException('"NaN" is not a valid number');
-        }
+        $currency = false;
+        $result = $value;
 
-        $position = 0;
-        $formatter = $this->getNumberFormatter(false === $currency ? \NumberFormatter::DECIMAL : null);
-        $groupSep = $formatter->getSymbol(\NumberFormatter::GROUPING_SEPARATOR_SYMBOL);
-        $decSep = $formatter->getSymbol(\NumberFormatter::DECIMAL_SEPARATOR_SYMBOL);
+        if (\NumberFormatter::TYPE_CURRENCY === $this->type && false !== strpos($value, ' ')) {
+            list($currency, $result) = explode(' ', $value, 2);
 
-        if ('.' !== $decSep && (!$this->grouping || '.' !== $groupSep)) {
-            $value = str_replace('.', $decSep, $value);
-        }
-
-        if (',' !== $decSep && (!$this->grouping || ',' !== $groupSep)) {
-            $value = str_replace(',', $decSep, $value);
-        }
-
-        if (false !== $currency && \NumberFormatter::TYPE_CURRENCY === $this->type) {
-            $result = $formatter->parseCurrency($value, $currency, $position);
-        } else {
-            $result = $formatter->parse($value, \NumberFormatter::TYPE_DOUBLE, $position);
-        }
-
-        if (intl_is_failure($formatter->getErrorCode())) {
-            throw new TransformationFailedException($formatter->getErrorMessage());
-        }
-
-        if ($result >= PHP_INT_MAX || $result <= -PHP_INT_MAX) {
-            throw new TransformationFailedException('I don\'t have a clear idea what infinity looks like');
-        }
-
-        $encoding = mb_detect_encoding($value, mb_detect_order(), true);
-        $length = mb_strlen($value, $encoding);
-
-        // After parsing, position holds the index of the character where the
-        // parsing stopped
-        if ($position < $length) {
-            // Check if there are unrecognized characters at the end of the
-            // number (excluding whitespace characters)
-            $remainder = trim(mb_substr($value, $position, $length, $encoding), " \t\n\r\0\x0b\xc2\xa0");
-
-            if ('' !== $remainder) {
+            if (strlen($currency) !== 3) {
                 throw new TransformationFailedException(
-                    sprintf('The number contains unrecognized characters: "%s"', $remainder)
+                    sprintf('Value does not contain a valid 3 character currency code, got "%s".', $currency)
                 );
             }
         }
 
-        // NumberFormatter::parse() does not round
-        return $this->round($result);
-    }
-
-    /**
-     * Returns a pre-configured \NumberFormatter instance.
-     *
-     * @param int $type
-     *
-     * @return \NumberFormatter
-     */
-    protected function getNumberFormatter(int $type = null)
-    {
-        if (null === $type) {
-            $type = \NumberFormatter::TYPE_CURRENCY === $this->type ? \NumberFormatter::CURRENCY : \NumberFormatter::DECIMAL;
+        if (!is_numeric($result)) {
+            throw new TransformationFailedException('Value is not numeric.');
         }
 
-        $formatter = new \NumberFormatter('en_us', $type);
-
-        if (null !== $this->precision) {
-            $formatter->setAttribute(\NumberFormatter::FRACTION_DIGITS, $this->precision);
-            $formatter->setAttribute(\NumberFormatter::ROUNDING_MODE, $this->roundingMode);
-        }
-
-        $formatter->setAttribute(\NumberFormatter::GROUPING_USED, $this->grouping);
-
-        return $formatter;
-    }
-
-    /**
-     * Rounds a number according to the configured precision and rounding mode.
-     *
-     * @param int|float $number A number
-     *
-     * @return int|float The rounded number
-     */
-    private function round($number)
-    {
-        if (null !== $this->precision && null !== $this->roundingMode) {
-            // shift number to maintain the correct precision during rounding
-            $roundingCoef = pow(10, $this->precision);
-            $number *= $roundingCoef;
-
-            switch ($this->roundingMode) {
-                case self::ROUND_CEILING:
-                    $number = ceil($number);
-                    break;
-                case self::ROUND_FLOOR:
-                    $number = floor($number);
-                    break;
-                case self::ROUND_UP:
-                    $number = $number > 0 ? ceil($number) : floor($number);
-                    break;
-                case self::ROUND_DOWN:
-                    $number = $number > 0 ? floor($number) : ceil($number);
-                    break;
-                case self::ROUND_HALF_EVEN:
-                    $number = round($number, 0, PHP_ROUND_HALF_EVEN);
-                    break;
-                case self::ROUND_HALF_UP:
-                    $number = round($number, 0, PHP_ROUND_HALF_UP);
-                    break;
-                case self::ROUND_HALF_DOWN:
-                    $number = round($number, 0, PHP_ROUND_HALF_DOWN);
-                    break;
+        if (is_string($result)) {
+            if (false !== strpos($result, '.')) {
+                $result = (float) $result;
+            } else {
+                $result = (int) $result;
             }
-
-            /* @noinspection CallableParameterUseCaseInTypeContextInspection */
-            $number /= $roundingCoef;
         }
 
-        return $number;
+        if ($result >= PHP_INT_MAX || $result <= -PHP_INT_MAX) {
+            throw new TransformationFailedException('I don\'t have a clear idea what infinity looks like.');
+        }
+
+        return $this->round($result);
     }
 }

--- a/src/Extension/Core/Type/BaseDateTimeType.php
+++ b/src/Extension/Core/Type/BaseDateTimeType.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Extension\Core\Type;
+
+use Rollerworks\Component\Search\AbstractFieldType;
+use Rollerworks\Component\Search\Exception\InvalidConfigurationException;
+use Rollerworks\Component\Search\ValueComparisonInterface;
+
+/**
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+abstract class BaseDateTimeType extends AbstractFieldType
+{
+    const DEFAULT_DATE_FORMAT = \IntlDateFormatter::MEDIUM;
+    const DEFAULT_TIME_FORMAT = \IntlDateFormatter::MEDIUM;
+
+    /**
+     * @var ValueComparisonInterface
+     */
+    protected $valueComparison;
+
+    /**
+     * @var array
+     */
+    protected static $acceptedFormats = [
+        \IntlDateFormatter::FULL,
+        \IntlDateFormatter::LONG,
+        \IntlDateFormatter::MEDIUM,
+        \IntlDateFormatter::SHORT,
+    ];
+
+    /**
+     * Constructor.
+     *
+     * @param ValueComparisonInterface $valueComparison
+     */
+    public function __construct(ValueComparisonInterface $valueComparison)
+    {
+        $this->valueComparison = $valueComparison;
+    }
+
+    protected function validateFormat(string $name, $value)
+    {
+        if (!in_array($value, self::$acceptedFormats, true)) {
+            throw new InvalidConfigurationException(
+                'The "'.$name.'" option must be one of the IntlDateFormatter constants '.
+                '(FULL, LONG, MEDIUM, SHORT) or the "pattern" option must be a string representing a custom format.'
+            );
+        }
+    }
+
+    protected function validateDateFormat(string $name, string $format)
+    {
+        if (null !== $format &&
+            (false === strpos($format, 'y') || false === strpos($format, 'M') || false === strpos($format, 'd'))
+        ) {
+            throw new InvalidConfigurationException(
+                sprintf(
+                    'The "%s" option should contain the letters "y", "M" and "d". Its current value is "%s".',
+                    $name,
+                    $format
+                )
+            );
+        }
+    }
+}

--- a/src/Extension/Core/Type/DateTimeType.php
+++ b/src/Extension/Core/Type/DateTimeType.php
@@ -13,22 +13,19 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Extension\Core\Type;
 
-use Rollerworks\Component\Search\AbstractFieldType;
-use Rollerworks\Component\Search\Exception\InvalidConfigurationException;
 use Rollerworks\Component\Search\Extension\Core\DataTransformer\DateTimeToLocalizedStringTransformer;
 use Rollerworks\Component\Search\Extension\Core\DataTransformer\DateTimeToRfc3339Transformer;
 use Rollerworks\Component\Search\FieldConfigInterface;
 use Rollerworks\Component\Search\SearchFieldView;
 use Rollerworks\Component\Search\Value\Compare;
 use Rollerworks\Component\Search\Value\Range;
-use Rollerworks\Component\Search\ValueComparisonInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class DateTimeType extends AbstractFieldType
+class DateTimeType extends BaseDateTimeType
 {
     const DEFAULT_DATE_FORMAT = \IntlDateFormatter::MEDIUM;
     const DEFAULT_TIME_FORMAT = \IntlDateFormatter::MEDIUM;
@@ -56,31 +53,6 @@ class DateTimeType extends AbstractFieldType
      * is used when the format matches this constant.
      */
     const HTML5_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZZZZZ";
-
-    /**
-     * @var ValueComparisonInterface
-     */
-    private $valueComparison;
-
-    /**
-     * @var array
-     */
-    private static $acceptedFormats = [
-        \IntlDateFormatter::FULL,
-        \IntlDateFormatter::LONG,
-        \IntlDateFormatter::MEDIUM,
-        \IntlDateFormatter::SHORT,
-    ];
-
-    /**
-     * Constructor.
-     *
-     * @param ValueComparisonInterface $valueComparison
-     */
-    public function __construct(ValueComparisonInterface $valueComparison)
-    {
-        $this->valueComparison = $valueComparison;
-    }
 
     /**
      * {@inheritdoc}
@@ -163,15 +135,5 @@ class DateTimeType extends AbstractFieldType
         $resolver->setAllowedTypes('pattern', ['string', 'null']);
         $resolver->setAllowedTypes('date_format', ['int']);
         $resolver->setAllowedTypes('time_format', ['int']);
-    }
-
-    private function validateFormat(string $name, $value)
-    {
-        if (!in_array($value, self::$acceptedFormats, true)) {
-            throw new InvalidConfigurationException(
-                'The "'.$name.'" option must be one of the IntlDateFormatter constants '.
-                '(FULL, LONG, MEDIUM, SHORT) or the "pattern" option must be a string representing a custom format.'
-            );
-        }
     }
 }

--- a/src/Extension/Core/Type/MoneyType.php
+++ b/src/Extension/Core/Type/MoneyType.php
@@ -65,7 +65,6 @@ class MoneyType extends AbstractFieldType
         $config->setNormTransformer(
             new MoneyToStringTransformer(
                 $options['precision'],
-                $options['grouping'],
                 null,
                 $options['divisor'],
                 $options['default_currency']

--- a/src/Extension/Core/Type/NumberType.php
+++ b/src/Extension/Core/Type/NumberType.php
@@ -63,7 +63,6 @@ class NumberType extends AbstractFieldType
         $config->setNormTransformer(
             new NumberToStringTransformer(
                 $options['precision'],
-                $options['grouping'],
                 $options['rounding_mode']
             )
         );

--- a/src/Extension/Core/Type/TimestampType.php
+++ b/src/Extension/Core/Type/TimestampType.php
@@ -14,10 +14,8 @@ declare(strict_types=1);
 namespace Rollerworks\Component\Search\Extension\Core\Type;
 
 use Rollerworks\Component\Search\AbstractFieldType;
-use Rollerworks\Component\Search\Extension\Core\DataTransformer\IntegerToLocalizedStringTransformer;
-use Rollerworks\Component\Search\Extension\Core\DataTransformer\IntegerToStringTransformer;
+use Rollerworks\Component\Search\Extension\Core\DataTransformer\DateTimeToTimestampTransformer;
 use Rollerworks\Component\Search\FieldConfigInterface;
-use Rollerworks\Component\Search\SearchFieldView;
 use Rollerworks\Component\Search\Value\Compare;
 use Rollerworks\Component\Search\Value\Range;
 use Rollerworks\Component\Search\ValueComparisonInterface;
@@ -25,8 +23,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class IntegerType extends AbstractFieldType
+class TimestampType extends AbstractFieldType
 {
     /**
      * @var ValueComparisonInterface
@@ -52,18 +51,12 @@ class IntegerType extends AbstractFieldType
         $config->setValueTypeSupport(Range::class, true);
         $config->setValueTypeSupport(Compare::class, true);
 
-        $config->setNormTransformer(new IntegerToStringTransformer($options['rounding_mode']));
         $config->setViewTransformer(
-            new IntegerToLocalizedStringTransformer($options['grouping'], $options['rounding_mode'])
+            new DateTimeToTimestampTransformer(
+                $options['model_timezone'],
+                $options['view_timezone']
+            )
         );
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function buildView(SearchFieldView $view, FieldConfigInterface $config, array $options)
-    {
-        $view->vars['grouping'] = $options['grouping'];
     }
 
     /**
@@ -71,25 +64,9 @@ class IntegerType extends AbstractFieldType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(
-            [
-                'grouping' => false,
-                // Integer cast rounds towards 0, so do the same when displaying fractions
-                'rounding_mode' => \NumberFormatter::ROUND_DOWN,
-            ]
-        );
-
-        $resolver->setAllowedValues(
-            'rounding_mode',
-            [
-                \NumberFormatter::ROUND_FLOOR,
-                \NumberFormatter::ROUND_DOWN,
-                \NumberFormatter::ROUND_HALFDOWN,
-                \NumberFormatter::ROUND_HALFEVEN,
-                \NumberFormatter::ROUND_HALFUP,
-                \NumberFormatter::ROUND_UP,
-                \NumberFormatter::ROUND_CEILING,
-            ]
-        );
+        $resolver->setDefaults([
+            'model_timezone' => null,
+            'view_timezone' => null,
+        ]);
     }
 }

--- a/src/Test/SearchConditionExporterTestCase.php
+++ b/src/Test/SearchConditionExporterTestCase.php
@@ -44,7 +44,7 @@ abstract class SearchConditionExporterTestCase extends SearchIntegrationTestCase
         $fieldSet->add('id', IntegerType::class);
         $fieldSet->add('name', TextType::class);
         $fieldSet->add('lastname', TextType::class);
-        $fieldSet->add('date', DateType::class, ['format' => 'MM-dd-yyyy']);
+        $fieldSet->add('date', DateType::class, ['pattern' => 'MM-dd-yyyy']);
 
         return $build ? $fieldSet->getFieldSet() : $fieldSet;
     }

--- a/tests/Exporter/ArrayExporterTest.php
+++ b/tests/Exporter/ArrayExporterTest.php
@@ -50,7 +50,7 @@ final class ArrayExporterTest extends SearchConditionExporterTestCase
                     'simple-values' => ['value', 'value2'],
                 ],
                 'date' => [
-                    'simple-values' => ['2014-12-16T00:00:00Z'],
+                    'simple-values' => ['2014-12-16'],
                 ],
             ],
         ];
@@ -73,7 +73,7 @@ final class ArrayExporterTest extends SearchConditionExporterTestCase
                 ],
                 'date' => [
                     'ranges' => [
-                        ['lower' => '2014-12-16T00:00:00Z', 'upper' => '2014-12-20T00:00:00Z'],
+                        ['lower' => '2014-12-16', 'upper' => '2014-12-20'],
                     ],
                 ],
             ],
@@ -94,7 +94,7 @@ final class ArrayExporterTest extends SearchConditionExporterTestCase
                 ],
                 'date' => [
                     'comparisons' => [
-                        ['value' => '2014-12-16T00:00:00Z', 'operator' => '>='],
+                        ['value' => '2014-12-16', 'operator' => '>='],
                     ],
                 ],
             ],

--- a/tests/Exporter/JsonExporterTest.php
+++ b/tests/Exporter/JsonExporterTest.php
@@ -53,7 +53,7 @@ final class JsonExporterTest extends SearchConditionExporterTestCase
                         'simple-values' => ['value', 'value2'],
                     ],
                     'date' => [
-                        'simple-values' => ['2014-12-16T00:00:00Z'],
+                        'simple-values' => ['2014-12-16'],
                     ],
                 ],
             ]
@@ -78,7 +78,7 @@ final class JsonExporterTest extends SearchConditionExporterTestCase
                     ],
                     'date' => [
                         'ranges' => [
-                            ['lower' => '2014-12-16T00:00:00Z', 'upper' => '2014-12-20T00:00:00Z'],
+                            ['lower' => '2014-12-16', 'upper' => '2014-12-20'],
                         ],
                     ],
                 ],
@@ -101,7 +101,7 @@ final class JsonExporterTest extends SearchConditionExporterTestCase
                     ],
                     'date' => [
                         'comparisons' => [
-                            ['operator' => '>=', 'value' => '2014-12-16T00:00:00Z'],
+                            ['operator' => '>=', 'value' => '2014-12-16'],
                         ],
                     ],
                 ],

--- a/tests/Exporter/XmlExporterTest.php
+++ b/tests/Exporter/XmlExporterTest.php
@@ -65,7 +65,7 @@ final class XmlExporterTest extends SearchConditionExporterTestCase
                     </field>
                     <field name="date">
                         <simple-values>
-                            <value>2014-12-16T00:00:00Z</value>
+                            <value>2014-12-16</value>
                         </simple-values>
                     </field>
                 </fields>
@@ -110,8 +110,8 @@ final class XmlExporterTest extends SearchConditionExporterTestCase
                     <field name="date">
                         <ranges>
                             <range>
-                                <lower>2014-12-16T00:00:00Z</lower>
-                                <upper>2014-12-20T00:00:00Z</upper>
+                                <lower>2014-12-16</lower>
+                                <upper>2014-12-20</upper>
                             </range>
                         </ranges>
                     </field>
@@ -138,7 +138,7 @@ final class XmlExporterTest extends SearchConditionExporterTestCase
                     </field>
                     <field name="date">
                         <comparisons>
-                            <compare operator="&gt;=">2014-12-16T00:00:00Z</compare>
+                            <compare operator="&gt;=">2014-12-16</compare>
                         </comparisons>
                     </field>
                 </fields>

--- a/tests/Extension/Core/DataTransformer/BaseDateTimeTransformerTest.php
+++ b/tests/Extension/Core/DataTransformer/BaseDateTimeTransformerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Tests\Extension\Core\DataTransformer;
+
+use PHPUnit\Framework\TestCase;
+use Rollerworks\Component\Search\Extension\Core\DataTransformer\BaseDateTimeTransformer;
+
+class BaseDateTimeTransformerTest extends TestCase
+{
+    /**
+     * @expectedException \Rollerworks\Component\Search\Exception\InvalidArgumentException
+     * @expectedExceptionMessage this_timezone_does_not_exist
+     */
+    public function testConstructFailsIfInputTimezoneIsInvalid()
+    {
+        $this->getMockBuilder(BaseDateTimeTransformer::class)->setConstructorArgs(['this_timezone_does_not_exist'])->getMock();
+    }
+
+    /**
+     * @expectedException \Rollerworks\Component\Search\Exception\InvalidArgumentException
+     * @expectedExceptionMessage that_timezone_does_not_exist
+     */
+    public function testConstructFailsIfOutputTimezoneIsInvalid()
+    {
+        $this->getMockBuilder(BaseDateTimeTransformer::class)->setConstructorArgs([null, 'that_timezone_does_not_exist'])->getMock();
+    }
+}

--- a/tests/Extension/Core/DataTransformer/BirthdayTransformerTest.php
+++ b/tests/Extension/Core/DataTransformer/BirthdayTransformerTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Tests\Extension\Core\DataTransformer;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Rollerworks\Component\Search\DataTransformerInterface;
+use Rollerworks\Component\Search\Exception\TransformationFailedException;
+use Rollerworks\Component\Search\Extension\Core\DataTransformer\BirthdayTransformer;
+
+class BirthdayTransformerTest extends TestCase
+{
+    /** @test */
+    public function it_transforms_age_to_integer()
+    {
+        $dateTransformer = $this->prophesize(DataTransformerInterface::class);
+        $dateTransformer->reverseTransform(Argument::any())->shouldNotBeCalled();
+        $dateTransformer->transform(Argument::any())->shouldNotBeCalled();
+
+        $transformer = new BirthdayTransformer($dateTransformer->reveal());
+
+        self::assertEquals(18, $transformer->reverseTransform('18'));
+        self::assertEquals('18', $transformer->transform(18));
+    }
+
+    /** @test */
+    public function it_transforms_with_date()
+    {
+        $date = new \DateTime('2010-03-05 00:00:00 UTC');
+
+        $dateTransformer = $this->prophesize(DataTransformerInterface::class);
+        $dateTransformer->reverseTransform('2010-03-05')->willReturn($date);
+        $dateTransformer->transform($date)->willReturn('2010-03-05');
+
+        $transformer = new BirthdayTransformer($dateTransformer->reveal());
+
+        self::assertEquals($date, $transformer->reverseTransform('2010-03-05'));
+        self::assertEquals('2010-03-05', $transformer->transform($date));
+
+        self::assertEquals(18, $transformer->reverseTransform('18'));
+        self::assertEquals('18', $transformer->transform(18));
+    }
+
+    /** @test */
+    public function it_allows_disabled_age()
+    {
+        $date = new \DateTime('2010-03-05 00:00:00 UTC');
+
+        $dateTransformer = $this->prophesize(DataTransformerInterface::class);
+        $dateTransformer->reverseTransform('2010-03-05')->willReturn($date);
+        $dateTransformer->transform($date)->willReturn('2010-03-05');
+
+        $transformer = new BirthdayTransformer($dateTransformer->reveal(), false);
+
+        self::assertEquals($date, $transformer->reverseTransform('2010-03-05'));
+        self::assertEquals('2010-03-05', $transformer->transform($date));
+
+        try {
+            $transformer->reverseTransform('18');
+
+            $this->fail('Age should not be reverseTransformed.');
+        } catch (TransformationFailedException $e) {
+            self::assertEquals('Age support is not enabled.', $e->getMessage());
+        }
+
+        try {
+            $transformer->transform(18);
+
+            $this->fail('Age should not be transformed.');
+        } catch (TransformationFailedException $e) {
+            self::assertEquals('Age support is not enabled.', $e->getMessage());
+        }
+    }
+
+    /** @test */
+    public function it_disallows_date_in_the_future_by_default()
+    {
+        $dateObj = new \DateTime('tomorrow');
+
+        $dateTransformer = $this->prophesize(DataTransformerInterface::class);
+        $dateTransformer->reverseTransform($dateObj->format('Y-m-d'))->willReturn($dateObj);
+
+        $transformer = new BirthdayTransformer($dateTransformer->reveal());
+
+        $this->expectException(TransformationFailedException::class);
+        $this->expectExceptionMessage(sprintf('Date "%s" is higher then current date ', $dateObj->format('Y-m-d')));
+
+        $transformer->reverseTransform($dateObj->format('Y-m-d'));
+    }
+
+    /** @test */
+    public function it_allows_date_in_the_future_when_enabled()
+    {
+        $dateObj = new \DateTime('tomorrow');
+
+        $dateTransformer = $this->prophesize(DataTransformerInterface::class);
+        $dateTransformer->reverseTransform($dateObj->format('Y-m-d'))->willReturn($dateObj);
+        $dateTransformer->transform($dateObj)->willReturn($dateObj->format('Y-m-d'));
+
+        $transformer = new BirthdayTransformer($dateTransformer->reveal(), false, true);
+
+        self::assertEquals($dateObj, $transformer->reverseTransform($dateObj->format('Y-m-d')));
+        self::assertEquals($dateObj->format('Y-m-d'), $transformer->transform($dateObj));
+    }
+}

--- a/tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
+++ b/tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
@@ -1,0 +1,327 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Tests\Extension\Core\DataTransformer;
+
+use PHPUnit\Framework\TestCase;
+use Rollerworks\Component\Search\Exception\TransformationFailedException;
+use Rollerworks\Component\Search\Exception\UnexpectedTypeException;
+use Rollerworks\Component\Search\Extension\Core\DataTransformer\DateTimeToLocalizedStringTransformer;
+use Rollerworks\Component\Search\Tests\assertDateTimeEqualsTrait;
+use Symfony\Component\Intl\Util\IntlTestHelper;
+
+final class DateTimeToLocalizedStringTransformerTest extends TestCase
+{
+    use assertDateTimeEqualsTrait;
+
+    protected $dateTime;
+    protected $dateTimeWithoutSeconds;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        // Since we test against "de_AT", we need the full implementation
+        IntlTestHelper::requireFullIntl($this, '58.1');
+
+        \Locale::setDefault('de_AT');
+
+        $this->dateTime = new \DateTime('2010-02-03 04:05:06 UTC');
+        $this->dateTimeWithoutSeconds = new \DateTime('2010-02-03 04:05:00 UTC');
+    }
+
+    protected function tearDown()
+    {
+        $this->dateTime = null;
+        $this->dateTimeWithoutSeconds = null;
+    }
+
+    public static function assertEquals($expected, $actual, $message = '', $delta = 0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false)
+    {
+        if ($expected instanceof \DateTimeInterface && $actual instanceof \DateTimeInterface) {
+            $expected = $expected->format('c');
+            $actual = $actual->format('c');
+        }
+
+        parent::assertEquals($expected, $actual, $message, $delta, $maxDepth, $canonicalize, $ignoreCase);
+    }
+
+    public function dataProvider()
+    {
+        return [
+            [\IntlDateFormatter::SHORT, null, null, '03.02.10, 04:05', '2010-02-03 04:05:00 UTC'],
+            [\IntlDateFormatter::MEDIUM, null, null, '03.02.2010, 04:05', '2010-02-03 04:05:00 UTC'],
+            [\IntlDateFormatter::LONG, null, null, '3. Februar 2010 um 04:05', '2010-02-03 04:05:00 UTC'],
+            [\IntlDateFormatter::FULL, null, null, 'Mittwoch, 3. Februar 2010 um 04:05', '2010-02-03 04:05:00 UTC'],
+            [\IntlDateFormatter::SHORT, \IntlDateFormatter::NONE, null, '03.02.10', '2010-02-03 00:00:00 UTC'],
+            [\IntlDateFormatter::MEDIUM, \IntlDateFormatter::NONE, null, '03.02.2010', '2010-02-03 00:00:00 UTC'],
+            [\IntlDateFormatter::LONG, \IntlDateFormatter::NONE, null, '3. Februar 2010', '2010-02-03 00:00:00 UTC'],
+            [\IntlDateFormatter::FULL, \IntlDateFormatter::NONE, null, 'Mittwoch, 3. Februar 2010', '2010-02-03 00:00:00 UTC'],
+            [null, \IntlDateFormatter::SHORT, null, '03.02.2010, 04:05', '2010-02-03 04:05:00 UTC'],
+            [null, \IntlDateFormatter::MEDIUM, null, '03.02.2010, 04:05:06', '2010-02-03 04:05:06 UTC'],
+            [null, \IntlDateFormatter::LONG, null, '03.02.2010, 04:05:06 GMT', '2010-02-03 04:05:06 UTC'],
+            // see below for extra test case for time format FULL
+            [\IntlDateFormatter::NONE, \IntlDateFormatter::SHORT, null, '04:05', '1970-01-01 04:05:00 UTC'],
+            [\IntlDateFormatter::NONE, \IntlDateFormatter::MEDIUM, null, '04:05:06', '1970-01-01 04:05:06 UTC'],
+            [\IntlDateFormatter::NONE, \IntlDateFormatter::LONG, null, '04:05:06 GMT', '1970-01-01 04:05:06 UTC'],
+            [null, null, 'yyyy-MM-dd HH:mm:00', '2010-02-03 04:05:00', '2010-02-03 04:05:00 UTC'],
+            [null, null, 'yyyy-MM-dd HH:mm', '2010-02-03 04:05', '2010-02-03 04:05:00 UTC'],
+            [null, null, 'yyyy-MM-dd HH', '2010-02-03 04', '2010-02-03 04:00:00 UTC'],
+            [null, null, 'yyyy-MM-dd', '2010-02-03', '2010-02-03 00:00:00 UTC'],
+            [null, null, 'yyyy-MM', '2010-02', '2010-02-01 00:00:00 UTC'],
+            [null, null, 'yyyy', '2010', '2010-01-01 00:00:00 UTC'],
+            [null, null, 'dd-MM-yyyy', '03-02-2010', '2010-02-03 00:00:00 UTC'],
+            [null, null, 'HH:mm:ss', '04:05:06', '1970-01-01 04:05:06 UTC'],
+            [null, null, 'HH:mm:00', '04:05:00', '1970-01-01 04:05:00 UTC'],
+            [null, null, 'HH:mm', '04:05', '1970-01-01 04:05:00 UTC'],
+            [null, null, 'HH', '04', '1970-01-01 04:00:00 UTC'],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testTransform($dateFormat, $timeFormat, $pattern, $output, $input)
+    {
+        $transformer = new DateTimeToLocalizedStringTransformer(
+            'UTC',
+            'UTC',
+            $dateFormat,
+            $timeFormat,
+            \IntlDateFormatter::GREGORIAN,
+            $pattern
+        );
+
+        $input = new \DateTime($input);
+
+        self::assertEquals($output, $transformer->transform($input));
+    }
+
+    public function testTransformFullTime()
+    {
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, \IntlDateFormatter::FULL);
+
+        self::assertEquals('03.02.2010, 04:05:06 GMT', $transformer->transform($this->dateTime));
+    }
+
+    public function testTransformToDifferentLocale()
+    {
+        \Locale::setDefault('en_US');
+
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC');
+
+        self::assertEquals('Feb 3, 2010, 4:05 AM', $transformer->transform($this->dateTime));
+    }
+
+    public function testTransformEmpty()
+    {
+        $transformer = new DateTimeToLocalizedStringTransformer();
+
+        self::assertSame('', $transformer->transform(null));
+    }
+
+    public function testTransformWithDifferentTimezones()
+    {
+        $transformer = new DateTimeToLocalizedStringTransformer('America/New_York', 'Asia/Hong_Kong');
+
+        $input = new \DateTime('2010-02-03 04:05:06 America/New_York');
+
+        $dateTime = clone $input;
+        $dateTime->setTimezone(new \DateTimeZone('Asia/Hong_Kong'));
+
+        self::assertEquals($dateTime->format('d.m.Y, H:i'), $transformer->transform($input));
+    }
+
+    public function testReverseTransformWithNoConstructorParameters()
+    {
+        $tz = date_default_timezone_get();
+        date_default_timezone_set('Europe/Rome');
+
+        $transformer = new DateTimeToLocalizedStringTransformer();
+
+        $dateTime = new \DateTime('2010-02-03 04:05');
+
+        self::assertEquals(
+            $dateTime->format('c'),
+            $transformer->reverseTransform('03.02.2010, 04:05')->format('c')
+        );
+
+        date_default_timezone_set($tz);
+    }
+
+    public function testTransformWithDifferentPatterns()
+    {
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', \IntlDateFormatter::FULL, \IntlDateFormatter::FULL, \IntlDateFormatter::GREGORIAN, 'MM*yyyy*dd HH|mm|ss');
+
+        self::assertEquals('02*2010*03 04|05|06', $transformer->transform($this->dateTime));
+    }
+
+    public function testTransformDateTimeImmutableTimezones()
+    {
+        $transformer = new DateTimeToLocalizedStringTransformer('America/New_York', 'Asia/Hong_Kong');
+
+        $input = new \DateTimeImmutable('2010-02-03 04:05:06 America/New_York');
+
+        $dateTime = clone $input;
+        $dateTime = $dateTime->setTimezone(new \DateTimeZone('Asia/Hong_Kong'));
+
+        self::assertEquals($dateTime->format('d.m.Y, H:i'), $transformer->transform($input));
+    }
+
+    public function testTransformRequiresValidDateTime()
+    {
+        $transformer = new DateTimeToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->transform('2010-01-01');
+    }
+
+    public function testTransformWrapsIntlErrors()
+    {
+        $transformer = new DateTimeToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->transform(1.5);
+    }
+
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testReverseTransform($dateFormat, $timeFormat, $pattern, $input, $output)
+    {
+        $transformer = new DateTimeToLocalizedStringTransformer(
+            'UTC',
+            'UTC',
+            $dateFormat,
+            $timeFormat,
+            \IntlDateFormatter::GREGORIAN,
+            $pattern
+        );
+
+        $output = new \DateTime($output);
+
+        self::assertEquals($output, $transformer->reverseTransform($input));
+    }
+
+    public function testReverseTransformFullTime()
+    {
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, \IntlDateFormatter::FULL);
+
+        self::assertDateTimeEquals($this->dateTime, $transformer->reverseTransform('03.02.2010, 04:05:06 GMT+00:00'));
+    }
+
+    public function testReverseTransformFromDifferentLocale()
+    {
+        \Locale::setDefault('en_US');
+
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC');
+
+        self::assertDateTimeEquals($this->dateTimeWithoutSeconds, $transformer->reverseTransform('Feb 3, 2010, 04:05 AM'));
+    }
+
+    public function testReverseTransformWithDifferentTimezones()
+    {
+        $transformer = new DateTimeToLocalizedStringTransformer('America/New_York', 'Asia/Hong_Kong');
+
+        $dateTime = new \DateTime('2010-02-03 04:05:00 Asia/Hong_Kong');
+        $dateTime->setTimezone(new \DateTimeZone('America/New_York'));
+
+        self::assertDateTimeEquals($dateTime, $transformer->reverseTransform('03.02.2010, 04:05'));
+    }
+
+    public function testReverseTransformWithDifferentPatterns()
+    {
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', \IntlDateFormatter::FULL, \IntlDateFormatter::FULL, \IntlDateFormatter::GREGORIAN, 'MM*yyyy*dd HH|mm|ss');
+
+        self::assertDateTimeEquals($this->dateTime, $transformer->reverseTransform('02*2010*03 04|05|06'));
+    }
+
+    public function testReverseTransformDateOnlyWithDstIssue()
+    {
+        $transformer = new DateTimeToLocalizedStringTransformer('Europe/Rome', 'Europe/Rome', \IntlDateFormatter::FULL, \IntlDateFormatter::FULL, \IntlDateFormatter::GREGORIAN, 'dd/MM/yyyy');
+
+        self::assertDateTimeEquals(
+            new \DateTime('1978-05-28', new \DateTimeZone('Europe/Rome')),
+            $transformer->reverseTransform('28/05/1978')
+        );
+    }
+
+    public function testReverseTransformDateOnlyWithDstIssueAndEscapedText()
+    {
+        $transformer = new DateTimeToLocalizedStringTransformer('Europe/Rome', 'Europe/Rome', \IntlDateFormatter::FULL, \IntlDateFormatter::FULL, \IntlDateFormatter::GREGORIAN, "'day': dd 'month': MM 'year': yyyy");
+
+        self::assertDateTimeEquals(
+            new \DateTime('1978-05-28', new \DateTimeZone('Europe/Rome')),
+            $transformer->reverseTransform('day: 28 month: 05 year: 1978')
+        );
+    }
+
+    public function testReverseTransformEmpty()
+    {
+        $transformer = new DateTimeToLocalizedStringTransformer();
+
+        self::assertNull($transformer->reverseTransform(''));
+    }
+
+    public function testReverseTransformRequiresString()
+    {
+        $transformer = new DateTimeToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform(12345);
+    }
+
+    public function testReverseTransformWrapsIntlErrors()
+    {
+        $transformer = new DateTimeToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('12345');
+    }
+
+    public function testValidateDateFormatOption()
+    {
+        $this->expectException(UnexpectedTypeException::class);
+
+        new DateTimeToLocalizedStringTransformer(null, null, 99);
+    }
+
+    public function testValidateTimeFormatOption()
+    {
+        $this->expectException(UnexpectedTypeException::class);
+
+        new DateTimeToLocalizedStringTransformer(null, null, null, 99);
+    }
+
+    public function testReverseTransformWithNonExistingDate()
+    {
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', \IntlDateFormatter::SHORT);
+
+        $this->expectException(TransformationFailedException::class);
+
+        self::assertDateTimeEquals($this->dateTimeWithoutSeconds, $transformer->reverseTransform('31.04.10 04:05'));
+    }
+
+    public function testReverseTransformOutOfTimestampRange()
+    {
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC');
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('1789-07-14');
+    }
+}

--- a/tests/Extension/Core/DataTransformer/DateTimeToRfc3339TransformerTest.php
+++ b/tests/Extension/Core/DataTransformer/DateTimeToRfc3339TransformerTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Tests\Extension\Core\DataTransformer;
+
+use PHPUnit\Framework\TestCase;
+use Rollerworks\Component\Search\Exception\TransformationFailedException;
+use Rollerworks\Component\Search\Extension\Core\DataTransformer\DateTimeToRfc3339Transformer;
+
+final class DateTimeToRfc3339TransformerTest extends TestCase
+{
+    protected $dateTime;
+    protected $dateTimeWithoutSeconds;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->dateTime = new \DateTime('2010-02-03 04:05:06 UTC');
+        $this->dateTimeWithoutSeconds = new \DateTime('2010-02-03 04:05:00 UTC');
+    }
+
+    protected function tearDown()
+    {
+        $this->dateTime = null;
+        $this->dateTimeWithoutSeconds = null;
+    }
+
+    public function allProvider()
+    {
+        return [
+            ['UTC', 'UTC', '2010-02-03 04:05:06 UTC', '2010-02-03T04:05:06Z'],
+            ['UTC', 'UTC', null, ''],
+            ['America/New_York', 'Asia/Hong_Kong', '2010-02-03 04:05:06 America/New_York', '2010-02-03T17:05:06+08:00'],
+            ['America/New_York', 'Asia/Hong_Kong', null, ''],
+            ['UTC', 'Asia/Hong_Kong', '2010-02-03 04:05:06 UTC', '2010-02-03T12:05:06+08:00'],
+            ['America/New_York', 'UTC', '2010-02-03 04:05:06 America/New_York', '2010-02-03T09:05:06Z'],
+        ];
+    }
+
+    public function reverseTransformProvider()
+    {
+        return array_merge($this->allProvider(), [
+            // format without seconds, as appears in some browsers
+            ['UTC', 'UTC', '2010-02-03 04:05:00 UTC', '2010-02-03T04:05Z'],
+            ['America/New_York', 'Asia/Hong_Kong', '2010-02-03 04:05:00 America/New_York', '2010-02-03T17:05+08:00'],
+            ['Europe/Amsterdam', 'Europe/Amsterdam', '2013-08-21 10:30:00 Europe/Amsterdam', '2013-08-21T08:30:00Z'],
+        ]);
+    }
+
+    /**
+     * @dataProvider allProvider
+     */
+    public function testTransform($fromTz, $toTz, $from, $to)
+    {
+        $transformer = new DateTimeToRfc3339Transformer($fromTz, $toTz);
+
+        self::assertSame($to, $transformer->transform(null !== $from ? new \DateTime($from) : null));
+    }
+
+    /**
+     * @dataProvider allProvider
+     */
+    public function testTransformDateTimeImmutable($fromTz, $toTz, $from, $to)
+    {
+        $transformer = new DateTimeToRfc3339Transformer($fromTz, $toTz);
+
+        self::assertSame($to, $transformer->transform(null !== $from ? new \DateTimeImmutable($from) : null));
+    }
+
+    public function testTransformRequiresValidDateTime()
+    {
+        $transformer = new DateTimeToRfc3339Transformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->transform('2010-01-01');
+    }
+
+    /**
+     * @dataProvider reverseTransformProvider
+     */
+    public function testReverseTransform($toTz, $fromTz, $to, $from)
+    {
+        $transformer = new DateTimeToRfc3339Transformer($toTz, $fromTz);
+
+        if (null !== $to) {
+            self::assertEquals(new \DateTime($to), $transformer->reverseTransform($from));
+        } else {
+            self::assertSame($to, $transformer->reverseTransform($from));
+        }
+    }
+
+    public function testReverseTransformRequiresString()
+    {
+        $transformer = new DateTimeToRfc3339Transformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform(12345);
+    }
+
+    public function testReverseTransformWithNonExistingDate()
+    {
+        $transformer = new DateTimeToRfc3339Transformer('UTC', 'UTC');
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('2010-04-31T04:05Z');
+    }
+
+    public function testReverseTransformExpectsValidDateString()
+    {
+        $transformer = new DateTimeToRfc3339Transformer('UTC', 'UTC');
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('2010-2010-2010');
+    }
+}

--- a/tests/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
+++ b/tests/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Tests\Extension\Core\DataTransformer;
+
+use PHPUnit\Framework\TestCase;
+use Rollerworks\Component\Search\Exception\TransformationFailedException;
+use Rollerworks\Component\Search\Extension\Core\DataTransformer\DateTimeToStringTransformer;
+use Rollerworks\Component\Search\Tests\assertDateTimeEqualsTrait;
+
+final class DateTimeToStringTransformerTest extends TestCase
+{
+    use assertDateTimeEqualsTrait;
+
+    public function dataProvider()
+    {
+        $data = [
+            ['Y-m-d H:i:s', '2010-02-03 16:05:06', '2010-02-03 16:05:06 UTC'],
+            ['Y-m-d H:i:00', '2010-02-03 16:05:00', '2010-02-03 16:05:00 UTC'],
+            ['Y-m-d H:i', '2010-02-03 16:05', '2010-02-03 16:05:00 UTC'],
+            ['Y-m-d H', '2010-02-03 16', '2010-02-03 16:00:00 UTC'],
+            ['Y-m-d', '2010-02-03', '2010-02-03 00:00:00 UTC'],
+            ['Y-m', '2010-12', '2010-12-01 00:00:00 UTC'],
+            ['Y', '2010', '2010-01-01 00:00:00 UTC'],
+            ['d-m-Y', '03-02-2010', '2010-02-03 00:00:00 UTC'],
+            ['H:i:s', '16:05:06', '1970-01-01 16:05:06 UTC'],
+            ['H:i:00', '16:05:00', '1970-01-01 16:05:00 UTC'],
+            ['H:i', '16:05', '1970-01-01 16:05:00 UTC'],
+            ['H', '16', '1970-01-01 16:00:00 UTC'],
+            ['Y-z', '2010-33', '2010-02-03 00:00:00 UTC'],
+
+            // different day representations
+            ['Y-m-j', '2010-02-3', '2010-02-03 00:00:00 UTC'],
+            ['z', '33', '1970-02-03 00:00:00 UTC'],
+
+            // not bijective
+            // this will not work as PHP will use actual date to replace missing info
+            // and after change of date will lookup for closest Wednesday
+            // i.e. value: 2010-02, PHP value: 2010-02-(today i.e. 20), parsed date: 2010-02-24
+            //array('Y-m-D', '2010-02-Wed', '2010-02-03 00:00:00 UTC'),
+            //array('Y-m-l', '2010-02-Wednesday', '2010-02-03 00:00:00 UTC'),
+
+            // different month representations
+            ['Y-n-d', '2010-2-03', '2010-02-03 00:00:00 UTC'],
+            ['Y-M-d', '2010-Feb-03', '2010-02-03 00:00:00 UTC'],
+            ['Y-F-d', '2010-February-03', '2010-02-03 00:00:00 UTC'],
+
+            // different year representations
+            ['y-m-d', '10-02-03', '2010-02-03 00:00:00 UTC'],
+
+            // different time representations
+            ['G:i:s', '16:05:06', '1970-01-01 16:05:06 UTC'],
+            ['g:i:s a', '4:05:06 pm', '1970-01-01 16:05:06 UTC'],
+            ['h:i:s a', '04:05:06 pm', '1970-01-01 16:05:06 UTC'],
+
+            // seconds since Unix
+            ['U', '1265213106', '2010-02-03 16:05:06 UTC'],
+
+            ['Y-z', '2010-33', '2010-02-03 00:00:00 UTC'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testTransform($format, $output, $input)
+    {
+        $transformer = new DateTimeToStringTransformer('UTC', 'UTC', $format);
+
+        $input = new \DateTime($input);
+
+        $this->assertEquals($output, $transformer->transform($input));
+    }
+
+    public function testTransformEmpty()
+    {
+        $transformer = new DateTimeToStringTransformer();
+
+        $this->assertSame('', $transformer->transform(null));
+    }
+
+    public function testTransformWithDifferentTimezones()
+    {
+        $transformer = new DateTimeToStringTransformer('Asia/Hong_Kong', 'America/New_York', 'Y-m-d H:i:s');
+
+        $input = new \DateTime('2010-02-03 12:05:06 America/New_York');
+        $output = $input->format('Y-m-d H:i:s');
+        $input->setTimezone(new \DateTimeZone('Asia/Hong_Kong'));
+
+        $this->assertEquals($output, $transformer->transform($input));
+    }
+
+    public function testTransformDateTimeImmutable()
+    {
+        $transformer = new DateTimeToStringTransformer('Asia/Hong_Kong', 'America/New_York', 'Y-m-d H:i:s');
+
+        $input = new \DateTimeImmutable('2010-02-03 12:05:06 America/New_York');
+        $output = $input->format('Y-m-d H:i:s');
+        $input = $input->setTimezone(new \DateTimeZone('Asia/Hong_Kong'));
+
+        $this->assertEquals($output, $transformer->transform($input));
+    }
+
+    public function testTransformExpectsDateTime()
+    {
+        $transformer = new DateTimeToStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->transform('1234');
+    }
+
+    public function testReverseTransformEmpty()
+    {
+        $reverseTransformer = new DateTimeToStringTransformer();
+
+        $this->assertNull($reverseTransformer->reverseTransform(''));
+    }
+
+    public function testReverseTransformWithDifferentTimezones()
+    {
+        $reverseTransformer = new DateTimeToStringTransformer('America/New_York', 'Asia/Hong_Kong', 'Y-m-d H:i:s');
+
+        $output = new \DateTime('2010-02-03 16:05:06 Asia/Hong_Kong');
+        $input = $output->format('Y-m-d H:i:s');
+        $output->setTimezone(new \DateTimeZone('America/New_York'));
+
+        $this->assertDateTimeEquals($output, $reverseTransformer->reverseTransform($input));
+    }
+
+    public function testReverseTransformExpectsString()
+    {
+        $reverseTransformer = new DateTimeToStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $reverseTransformer->reverseTransform(1234);
+    }
+
+    public function testReverseTransformExpectsValidDateString()
+    {
+        $reverseTransformer = new DateTimeToStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $reverseTransformer->reverseTransform('2010-2010-2010');
+    }
+
+    public function testReverseTransformWithNonExistingDate()
+    {
+        $reverseTransformer = new DateTimeToStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $reverseTransformer->reverseTransform('2010-04-31');
+    }
+}

--- a/tests/Extension/Core/DataTransformer/DateTimeToTimestampTransformerTest.php
+++ b/tests/Extension/Core/DataTransformer/DateTimeToTimestampTransformerTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Tests\Extension\Core\DataTransformer;
+
+use PHPUnit\Framework\TestCase;
+use Rollerworks\Component\Search\Exception\TransformationFailedException;
+use Rollerworks\Component\Search\Extension\Core\DataTransformer\DateTimeToTimestampTransformer;
+use Rollerworks\Component\Search\Tests\assertDateTimeEqualsTrait;
+
+final class DateTimeToTimestampTransformerTest extends TestCase
+{
+    use assertDateTimeEqualsTrait;
+
+    public function testTransform()
+    {
+        $transformer = new DateTimeToTimestampTransformer('UTC', 'UTC');
+
+        $input = new \DateTime('2010-02-03 04:05:06 UTC');
+        $output = $input->format('U');
+
+        self::assertEquals($output, $transformer->transform($input));
+    }
+
+    public function testTransformEmpty()
+    {
+        $transformer = new DateTimeToTimestampTransformer();
+
+        self::assertNull($transformer->transform(null));
+    }
+
+    public function testTransformWithDifferentTimezones()
+    {
+        $transformer = new DateTimeToTimestampTransformer('Asia/Hong_Kong', 'America/New_York');
+
+        $input = new \DateTime('2010-02-03 04:05:06 America/New_York');
+        $output = $input->format('U');
+        $input->setTimezone(new \DateTimeZone('Asia/Hong_Kong'));
+
+        self::assertEquals($output, $transformer->transform($input));
+    }
+
+    public function testTransformFromDifferentTimezone()
+    {
+        $transformer = new DateTimeToTimestampTransformer('Asia/Hong_Kong', 'UTC');
+
+        $input = new \DateTime('2010-02-03 04:05:06 Asia/Hong_Kong');
+
+        $dateTime = clone $input;
+        $dateTime->setTimezone(new \DateTimeZone('UTC'));
+        $output = $dateTime->format('U');
+
+        self::assertEquals($output, $transformer->transform($input));
+    }
+
+    public function testTransformDateTimeImmutable()
+    {
+        $transformer = new DateTimeToTimestampTransformer('Asia/Hong_Kong', 'America/New_York');
+
+        $input = new \DateTimeImmutable('2010-02-03 04:05:06 America/New_York');
+        $output = $input->format('U');
+        $input = $input->setTimezone(new \DateTimeZone('Asia/Hong_Kong'));
+
+        self::assertEquals($output, $transformer->transform($input));
+    }
+
+    public function testTransformExpectsDateTime()
+    {
+        $transformer = new DateTimeToTimestampTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->transform('1234');
+    }
+
+    public function testReverseTransform()
+    {
+        $reverseTransformer = new DateTimeToTimestampTransformer('UTC', 'UTC');
+
+        $output = new \DateTime('2010-02-03 04:05:06 UTC');
+        $input = $output->format('U');
+
+        self::assertDateTimeEquals($output, $reverseTransformer->reverseTransform($input));
+    }
+
+    public function testReverseTransformEmpty()
+    {
+        $reverseTransformer = new DateTimeToTimestampTransformer();
+
+        self::assertNull($reverseTransformer->reverseTransform(null));
+    }
+
+    public function testReverseTransformWithDifferentTimezones()
+    {
+        $reverseTransformer = new DateTimeToTimestampTransformer('Asia/Hong_Kong', 'America/New_York');
+
+        $output = new \DateTime('2010-02-03 04:05:06 America/New_York');
+        $input = $output->format('U');
+        $output->setTimezone(new \DateTimeZone('Asia/Hong_Kong'));
+
+        self::assertDateTimeEquals($output, $reverseTransformer->reverseTransform($input));
+    }
+
+    public function testReverseTransformExpectsValidTimestamp()
+    {
+        $reverseTransformer = new DateTimeToTimestampTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $reverseTransformer->reverseTransform('2010-2010-2010');
+    }
+}

--- a/tests/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformerTest.php
+++ b/tests/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformerTest.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Tests\Extension\Core\DataTransformer;
+
+use PHPUnit\Framework\TestCase;
+use Rollerworks\Component\Search\Exception\TransformationFailedException;
+use Rollerworks\Component\Search\Extension\Core\DataTransformer\IntegerToLocalizedStringTransformer;
+use Symfony\Component\Intl\Util\IntlTestHelper;
+
+class IntegerToLocalizedStringTransformerTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        \Locale::setDefault('en');
+    }
+
+    public function transformWithRoundingProvider()
+    {
+        return [
+            // towards positive infinity (1.6 -> 2, -1.6 -> -1)
+            [1234.5, '1235', IntegerToLocalizedStringTransformer::ROUND_CEILING],
+            [1234.4, '1235', IntegerToLocalizedStringTransformer::ROUND_CEILING],
+            [-1234.5, '-1234', IntegerToLocalizedStringTransformer::ROUND_CEILING],
+            [-1234.4, '-1234', IntegerToLocalizedStringTransformer::ROUND_CEILING],
+            // towards negative infinity (1.6 -> 1, -1.6 -> -2)
+            [1234.5, '1234', IntegerToLocalizedStringTransformer::ROUND_FLOOR],
+            [1234.4, '1234', IntegerToLocalizedStringTransformer::ROUND_FLOOR],
+            [-1234.5, '-1235', IntegerToLocalizedStringTransformer::ROUND_FLOOR],
+            [-1234.4, '-1235', IntegerToLocalizedStringTransformer::ROUND_FLOOR],
+            // away from zero (1.6 -> 2, -1.6 -> 2)
+            [1234.5, '1235', IntegerToLocalizedStringTransformer::ROUND_UP],
+            [1234.4, '1235', IntegerToLocalizedStringTransformer::ROUND_UP],
+            [-1234.5, '-1235', IntegerToLocalizedStringTransformer::ROUND_UP],
+            [-1234.4, '-1235', IntegerToLocalizedStringTransformer::ROUND_UP],
+            // towards zero (1.6 -> 1, -1.6 -> -1)
+            [1234.5, '1234', IntegerToLocalizedStringTransformer::ROUND_DOWN],
+            [1234.4, '1234', IntegerToLocalizedStringTransformer::ROUND_DOWN],
+            [-1234.5, '-1234', IntegerToLocalizedStringTransformer::ROUND_DOWN],
+            [-1234.4, '-1234', IntegerToLocalizedStringTransformer::ROUND_DOWN],
+            // round halves (.5) to the next even number
+            [1234.6, '1235', IntegerToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1234.5, '1234', IntegerToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1234.4, '1234', IntegerToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1233.5, '1234', IntegerToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1232.5, '1232', IntegerToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [-1234.6, '-1235', IntegerToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [-1234.5, '-1234', IntegerToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [-1234.4, '-1234', IntegerToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [-1233.5, '-1234', IntegerToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [-1232.5, '-1232', IntegerToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            // round halves (.5) away from zero
+            [1234.6, '1235', IntegerToLocalizedStringTransformer::ROUND_HALF_UP],
+            [1234.5, '1235', IntegerToLocalizedStringTransformer::ROUND_HALF_UP],
+            [1234.4, '1234', IntegerToLocalizedStringTransformer::ROUND_HALF_UP],
+            [-1234.6, '-1235', IntegerToLocalizedStringTransformer::ROUND_HALF_UP],
+            [-1234.5, '-1235', IntegerToLocalizedStringTransformer::ROUND_HALF_UP],
+            [-1234.4, '-1234', IntegerToLocalizedStringTransformer::ROUND_HALF_UP],
+            // round halves (.5) towards zero
+            [1234.6, '1235', IntegerToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [1234.5, '1234', IntegerToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [1234.4, '1234', IntegerToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [-1234.6, '-1235', IntegerToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [-1234.5, '-1234', IntegerToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [-1234.4, '-1234', IntegerToLocalizedStringTransformer::ROUND_HALF_DOWN],
+        ];
+    }
+
+    /**
+     * @dataProvider transformWithRoundingProvider
+     */
+    public function testTransformWithRounding(float $input, string $output, int $roundingMode)
+    {
+        $transformer = new IntegerToLocalizedStringTransformer(null, $roundingMode);
+
+        $this->assertEquals($output, $transformer->transform($input));
+    }
+
+    public function testReverseTransform()
+    {
+        // Since we test against "de_AT", we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('de_AT');
+
+        $transformer = new IntegerToLocalizedStringTransformer();
+
+        $this->assertEquals(1, $transformer->reverseTransform('1'));
+        $this->assertEquals(1, $transformer->reverseTransform('1,5'));
+        $this->assertEquals(1234, $transformer->reverseTransform('1234,5'));
+        $this->assertEquals(12345, $transformer->reverseTransform('12345,912'));
+    }
+
+    public function testReverseTransformEmpty()
+    {
+        $transformer = new IntegerToLocalizedStringTransformer();
+
+        $this->assertNull($transformer->reverseTransform(''));
+    }
+
+    public function testReverseTransformWithGrouping()
+    {
+        // Since we test against "de_DE", we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('de_DE');
+
+        $transformer = new IntegerToLocalizedStringTransformer(true);
+
+        $this->assertEquals(1234, $transformer->reverseTransform('1.234,5'));
+        $this->assertEquals(12345, $transformer->reverseTransform('12.345,912'));
+        $this->assertEquals(1234, $transformer->reverseTransform('1234,5'));
+        $this->assertEquals(12345, $transformer->reverseTransform('12345,912'));
+    }
+
+    public function reverseTransformWithRoundingProvider()
+    {
+        return [
+            // towards positive infinity (1.6 -> 2, -1.6 -> -1)
+            ['1234,5', 1235, IntegerToLocalizedStringTransformer::ROUND_CEILING],
+            ['1234,4', 1235, IntegerToLocalizedStringTransformer::ROUND_CEILING],
+            ['-1234,5', -1234, IntegerToLocalizedStringTransformer::ROUND_CEILING],
+            ['-1234,4', -1234, IntegerToLocalizedStringTransformer::ROUND_CEILING],
+            // towards negative infinity (1.6 -> 1, -1.6 -> -2)
+            ['1234,5', 1234, IntegerToLocalizedStringTransformer::ROUND_FLOOR],
+            ['1234,4', 1234, IntegerToLocalizedStringTransformer::ROUND_FLOOR],
+            ['-1234,5', -1235, IntegerToLocalizedStringTransformer::ROUND_FLOOR],
+            ['-1234,4', -1235, IntegerToLocalizedStringTransformer::ROUND_FLOOR],
+            // away from zero (1.6 -> 2, -1.6 -> 2)
+            ['1234,5', 1235, IntegerToLocalizedStringTransformer::ROUND_UP],
+            ['1234,4', 1235, IntegerToLocalizedStringTransformer::ROUND_UP],
+            ['-1234,5', -1235, IntegerToLocalizedStringTransformer::ROUND_UP],
+            ['-1234,4', -1235, IntegerToLocalizedStringTransformer::ROUND_UP],
+            // towards zero (1.6 -> 1, -1.6 -> -1)
+            ['1234,5', 1234, IntegerToLocalizedStringTransformer::ROUND_DOWN],
+            ['1234,4', 1234, IntegerToLocalizedStringTransformer::ROUND_DOWN],
+            ['-1234,5', -1234, IntegerToLocalizedStringTransformer::ROUND_DOWN],
+            ['-1234,4', -1234, IntegerToLocalizedStringTransformer::ROUND_DOWN],
+            // round halves (.5) to the next even number
+            ['1234,6', 1235, IntegerToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            ['1234,5', 1234, IntegerToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            ['1234,4', 1234, IntegerToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            ['1233,5', 1234, IntegerToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            ['1232,5', 1232, IntegerToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            ['-1234,6', -1235, IntegerToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            ['-1234,5', -1234, IntegerToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            ['-1234,4', -1234, IntegerToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            ['-1233,5', -1234, IntegerToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            ['-1232,5', -1232, IntegerToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            // round halves (.5) away from zero
+            ['1234,6', 1235, IntegerToLocalizedStringTransformer::ROUND_HALF_UP],
+            ['1234,5', 1235, IntegerToLocalizedStringTransformer::ROUND_HALF_UP],
+            ['1234,4', 1234, IntegerToLocalizedStringTransformer::ROUND_HALF_UP],
+            ['-1234,6', -1235, IntegerToLocalizedStringTransformer::ROUND_HALF_UP],
+            ['-1234,5', -1235, IntegerToLocalizedStringTransformer::ROUND_HALF_UP],
+            ['-1234,4', -1234, IntegerToLocalizedStringTransformer::ROUND_HALF_UP],
+            // round halves (.5) towards zero
+            ['1234,6', 1235, IntegerToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            ['1234,5', 1234, IntegerToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            ['1234,4', 1234, IntegerToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            ['-1234,6', -1235, IntegerToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            ['-1234,5', -1234, IntegerToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            ['-1234,4', -1234, IntegerToLocalizedStringTransformer::ROUND_HALF_DOWN],
+        ];
+    }
+
+    /**
+     * @dataProvider reverseTransformWithRoundingProvider
+     */
+    public function testReverseTransformWithRounding(string $input, int $output, int $roundingMode)
+    {
+        $transformer = new IntegerToLocalizedStringTransformer(null, $roundingMode);
+
+        $this->assertEquals($output, $transformer->reverseTransform($input));
+    }
+
+    public function testReverseTransformExpectsString()
+    {
+        $transformer = new IntegerToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform(1);
+    }
+
+    public function testReverseTransformExpectsValidNumber()
+    {
+        $transformer = new IntegerToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('foo');
+    }
+
+    public function testReverseTransformDisallowsNaN()
+    {
+        $transformer = new IntegerToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('NaN');
+    }
+
+    public function testReverseTransformDisallowsNaN2()
+    {
+        $transformer = new IntegerToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('nan');
+    }
+
+    public function testReverseTransformDisallowsInfinity()
+    {
+        $transformer = new IntegerToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('∞');
+    }
+
+    public function testReverseTransformDisallowsNegativeInfinity()
+    {
+        $transformer = new IntegerToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('-∞');
+    }
+}

--- a/tests/Extension/Core/DataTransformer/IntegerToStringTransformerTest.php
+++ b/tests/Extension/Core/DataTransformer/IntegerToStringTransformerTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Tests\Extension\Core\DataTransformer;
+
+use PHPUnit\Framework\TestCase;
+use Rollerworks\Component\Search\Exception\TransformationFailedException;
+use Rollerworks\Component\Search\Extension\Core\DataTransformer\IntegerToStringTransformer;
+
+class IntegerToStringTransformerTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        \Locale::setDefault('en');
+    }
+
+    public function transformWithRoundingProvider()
+    {
+        return [
+            // towards positive infinity (1.6 -> 2, -1.6 -> -1)
+            [1234.5, '1235', IntegerToStringTransformer::ROUND_CEILING],
+            [1234.4, '1235', IntegerToStringTransformer::ROUND_CEILING],
+            [-1234.5, '-1234', IntegerToStringTransformer::ROUND_CEILING],
+            [-1234.4, '-1234', IntegerToStringTransformer::ROUND_CEILING],
+            // towards negative infinity (1.6 -> 1, -1.6 -> -2)
+            [1234.5, '1234', IntegerToStringTransformer::ROUND_FLOOR],
+            [1234.4, '1234', IntegerToStringTransformer::ROUND_FLOOR],
+            [-1234.5, '-1235', IntegerToStringTransformer::ROUND_FLOOR],
+            [-1234.4, '-1235', IntegerToStringTransformer::ROUND_FLOOR],
+            // away from zero (1.6 -> 2, -1.6 -> 2)
+            [1234.5, '1235', IntegerToStringTransformer::ROUND_UP],
+            [1234.4, '1235', IntegerToStringTransformer::ROUND_UP],
+            [-1234.5, '-1235', IntegerToStringTransformer::ROUND_UP],
+            [-1234.4, '-1235', IntegerToStringTransformer::ROUND_UP],
+            // towards zero (1.6 -> 1, -1.6 -> -1)
+            [1234.5, '1234', IntegerToStringTransformer::ROUND_DOWN],
+            [1234.4, '1234', IntegerToStringTransformer::ROUND_DOWN],
+            [-1234.5, '-1234', IntegerToStringTransformer::ROUND_DOWN],
+            [-1234.4, '-1234', IntegerToStringTransformer::ROUND_DOWN],
+            // round halves (.5) to the next even number
+            [1234.6, '1235', IntegerToStringTransformer::ROUND_HALF_EVEN],
+            [1234.5, '1234', IntegerToStringTransformer::ROUND_HALF_EVEN],
+            [1234.4, '1234', IntegerToStringTransformer::ROUND_HALF_EVEN],
+            [1233.5, '1234', IntegerToStringTransformer::ROUND_HALF_EVEN],
+            [1232.5, '1232', IntegerToStringTransformer::ROUND_HALF_EVEN],
+            [-1234.6, '-1235', IntegerToStringTransformer::ROUND_HALF_EVEN],
+            [-1234.5, '-1234', IntegerToStringTransformer::ROUND_HALF_EVEN],
+            [-1234.4, '-1234', IntegerToStringTransformer::ROUND_HALF_EVEN],
+            [-1233.5, '-1234', IntegerToStringTransformer::ROUND_HALF_EVEN],
+            [-1232.5, '-1232', IntegerToStringTransformer::ROUND_HALF_EVEN],
+            // round halves (.5) away from zero
+            [1234.6, '1235', IntegerToStringTransformer::ROUND_HALF_UP],
+            [1234.5, '1235', IntegerToStringTransformer::ROUND_HALF_UP],
+            [1234.4, '1234', IntegerToStringTransformer::ROUND_HALF_UP],
+            [-1234.6, '-1235', IntegerToStringTransformer::ROUND_HALF_UP],
+            [-1234.5, '-1235', IntegerToStringTransformer::ROUND_HALF_UP],
+            [-1234.4, '-1234', IntegerToStringTransformer::ROUND_HALF_UP],
+            // round halves (.5) towards zero
+            [1234.6, '1235', IntegerToStringTransformer::ROUND_HALF_DOWN],
+            [1234.5, '1234', IntegerToStringTransformer::ROUND_HALF_DOWN],
+            [1234.4, '1234', IntegerToStringTransformer::ROUND_HALF_DOWN],
+            [-1234.6, '-1235', IntegerToStringTransformer::ROUND_HALF_DOWN],
+            [-1234.5, '-1234', IntegerToStringTransformer::ROUND_HALF_DOWN],
+            [-1234.4, '-1234', IntegerToStringTransformer::ROUND_HALF_DOWN],
+        ];
+    }
+
+    /**
+     * @dataProvider transformWithRoundingProvider
+     */
+    public function testTransformWithRounding(float $input, string $output, $roundingMode)
+    {
+        $transformer = new IntegerToStringTransformer($roundingMode);
+
+        $this->assertEquals($output, $transformer->transform($input));
+    }
+
+    public function testReverseTransform()
+    {
+        $transformer = new IntegerToStringTransformer();
+
+        $this->assertEquals(1, $transformer->reverseTransform('1'));
+        $this->assertEquals(1, $transformer->reverseTransform('1.5'));
+        $this->assertEquals(1234, $transformer->reverseTransform('1234.5'));
+        $this->assertEquals(12345, $transformer->reverseTransform('12345.912'));
+    }
+
+    public function testReverseTransformEmpty()
+    {
+        $transformer = new IntegerToStringTransformer();
+
+        $this->assertNull($transformer->reverseTransform(''));
+    }
+
+    public function reverseTransformWithRoundingProvider()
+    {
+        return [
+            // towards positive infinity (1.6 -> 2, -1.6 -> -1)
+            ['1234.5', 1235, IntegerToStringTransformer::ROUND_CEILING],
+            ['1234.4', 1235, IntegerToStringTransformer::ROUND_CEILING],
+            ['-1234.5', -1234, IntegerToStringTransformer::ROUND_CEILING],
+            ['-1234.4', -1234, IntegerToStringTransformer::ROUND_CEILING],
+            // towards negative infinity (1.6 -> 1, -1.6 -> -2)
+            ['1234.5', 1234, IntegerToStringTransformer::ROUND_FLOOR],
+            ['1234.4', 1234, IntegerToStringTransformer::ROUND_FLOOR],
+            ['-1234.5', -1235, IntegerToStringTransformer::ROUND_FLOOR],
+            ['-1234.4', -1235, IntegerToStringTransformer::ROUND_FLOOR],
+            // away from zero (1.6 -> 2, -1.6 -> 2)
+            ['1234.5', 1235, IntegerToStringTransformer::ROUND_UP],
+            ['1234.4', 1235, IntegerToStringTransformer::ROUND_UP],
+            ['-1234.5', -1235, IntegerToStringTransformer::ROUND_UP],
+            ['-1234.4', -1235, IntegerToStringTransformer::ROUND_UP],
+            // towards zero (1.6 -> 1, -1.6 -> -1)
+            ['1234.5', 1234, IntegerToStringTransformer::ROUND_DOWN],
+            ['1234.4', 1234, IntegerToStringTransformer::ROUND_DOWN],
+            ['-1234.5', -1234, IntegerToStringTransformer::ROUND_DOWN],
+            ['-1234.4', -1234, IntegerToStringTransformer::ROUND_DOWN],
+            // round halves (.5) to the next even number
+            ['1234.6', 1235, IntegerToStringTransformer::ROUND_HALF_EVEN],
+            ['1234.5', 1234, IntegerToStringTransformer::ROUND_HALF_EVEN],
+            ['1234.4', 1234, IntegerToStringTransformer::ROUND_HALF_EVEN],
+            ['1233.5', 1234, IntegerToStringTransformer::ROUND_HALF_EVEN],
+            ['1232.5', 1232, IntegerToStringTransformer::ROUND_HALF_EVEN],
+            ['-1234.6', -1235, IntegerToStringTransformer::ROUND_HALF_EVEN],
+            ['-1234.5', -1234, IntegerToStringTransformer::ROUND_HALF_EVEN],
+            ['-1234.4', -1234, IntegerToStringTransformer::ROUND_HALF_EVEN],
+            ['-1233.5', -1234, IntegerToStringTransformer::ROUND_HALF_EVEN],
+            ['-1232.5', -1232, IntegerToStringTransformer::ROUND_HALF_EVEN],
+            // round halves (.5) away from zero
+            ['1234.6', 1235, IntegerToStringTransformer::ROUND_HALF_UP],
+            ['1234.5', 1235, IntegerToStringTransformer::ROUND_HALF_UP],
+            ['1234.4', 1234, IntegerToStringTransformer::ROUND_HALF_UP],
+            ['-1234.6', -1235, IntegerToStringTransformer::ROUND_HALF_UP],
+            ['-1234.5', -1235, IntegerToStringTransformer::ROUND_HALF_UP],
+            ['-1234.4', -1234, IntegerToStringTransformer::ROUND_HALF_UP],
+            // round halves (.5) towards zero
+            ['1234.6', 1235, IntegerToStringTransformer::ROUND_HALF_DOWN],
+            ['1234.5', 1234, IntegerToStringTransformer::ROUND_HALF_DOWN],
+            ['1234.4', 1234, IntegerToStringTransformer::ROUND_HALF_DOWN],
+            ['-1234.6', -1235, IntegerToStringTransformer::ROUND_HALF_DOWN],
+            ['-1234.5', -1234, IntegerToStringTransformer::ROUND_HALF_DOWN],
+            ['-1234.4', -1234, IntegerToStringTransformer::ROUND_HALF_DOWN],
+        ];
+    }
+
+    /**
+     * @dataProvider reverseTransformWithRoundingProvider
+     */
+    public function testReverseTransformWithRounding(string $input, $output, int $roundingMode)
+    {
+        $transformer = new IntegerToStringTransformer($roundingMode);
+
+        $this->assertEquals($output, $transformer->reverseTransform($input));
+    }
+
+    public function testReverseTransformExpectsScalar()
+    {
+        $transformer = new IntegerToStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform(['1']);
+    }
+
+    public function testReverseTransformExpectsValidNumber()
+    {
+        $transformer = new IntegerToStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('foo');
+    }
+
+    public function testReverseTransformDisallowsNaN()
+    {
+        $transformer = new IntegerToStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('NaN');
+    }
+
+    public function testReverseTransformDisallowsNaN2()
+    {
+        $transformer = new IntegerToStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('nan');
+    }
+
+    public function testReverseTransformDisallowsInfinity()
+    {
+        $transformer = new IntegerToStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('∞');
+    }
+
+    public function testReverseTransformDisallowsNegativeInfinity()
+    {
+        $transformer = new IntegerToStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('-∞');
+    }
+}

--- a/tests/Extension/Core/DataTransformer/LocalizedBirthdayTransformerTest.php
+++ b/tests/Extension/Core/DataTransformer/LocalizedBirthdayTransformerTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Tests\Extension\Core\DataTransformer;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Rollerworks\Component\Search\DataTransformerInterface;
+use Rollerworks\Component\Search\Exception\TransformationFailedException;
+use Rollerworks\Component\Search\Extension\Core\DataTransformer\LocalizedBirthdayTransformer;
+use Symfony\Component\Intl\Util\IntlTestHelper;
+
+class LocalizedBirthdayTransformerTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        \Locale::setDefault('en');
+    }
+
+    /** @test */
+    public function it_transforms_age_to_integer()
+    {
+        $dateTransformer = $this->prophesize(DataTransformerInterface::class);
+        $dateTransformer->reverseTransform(Argument::any())->shouldNotBeCalled();
+        $dateTransformer->transform(Argument::any())->shouldNotBeCalled();
+
+        $transformer = new LocalizedBirthdayTransformer($dateTransformer->reveal());
+
+        self::assertEquals(18, $transformer->reverseTransform('18'));
+        self::assertEquals('18', $transformer->transform(18));
+    }
+
+    /** @test */
+    public function it_transforms_ar_localized_age_to_integer()
+    {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('ar');
+
+        $dateTransformer = $this->prophesize(DataTransformerInterface::class);
+        $dateTransformer->reverseTransform(Argument::any())->shouldNotBeCalled();
+        $dateTransformer->transform(Argument::any())->shouldNotBeCalled();
+
+        $transformer = new LocalizedBirthdayTransformer($dateTransformer->reveal());
+
+        self::assertEquals(79, $transformer->reverseTransform('٧٩'));
+        self::assertEquals('٧٩', $transformer->transform(79));
+    }
+
+    /** @test */
+    public function it_transforms_with_date()
+    {
+        $date = new \DateTime('2010-03-05 00:00:00 UTC');
+
+        $dateTransformer = $this->prophesize(DataTransformerInterface::class);
+        $dateTransformer->reverseTransform('2010-03-05')->willReturn($date);
+        $dateTransformer->transform($date)->willReturn('2010-03-05');
+
+        $transformer = new LocalizedBirthdayTransformer($dateTransformer->reveal());
+
+        self::assertEquals($date, $transformer->reverseTransform('2010-03-05'));
+        self::assertEquals('2010-03-05', $transformer->transform($date));
+
+        self::assertEquals(18, $transformer->reverseTransform('18'));
+        self::assertEquals('18', $transformer->transform(18));
+    }
+
+    /** @test */
+    public function it_allows_disabled_age()
+    {
+        $date = new \DateTime('2010-03-05 00:00:00 UTC');
+
+        $dateTransformer = $this->prophesize(DataTransformerInterface::class);
+        $dateTransformer->reverseTransform('2010-03-05')->willReturn($date);
+        $dateTransformer->transform($date)->willReturn('2010-03-05');
+
+        $transformer = new LocalizedBirthdayTransformer($dateTransformer->reveal(), false);
+
+        self::assertEquals($date, $transformer->reverseTransform('2010-03-05'));
+        self::assertEquals('2010-03-05', $transformer->transform($date));
+
+        try {
+            $transformer->reverseTransform('18');
+
+            $this->fail('Age should not be reverseTransformed.');
+        } catch (TransformationFailedException $e) {
+            self::assertEquals('Age support is not enabled.', $e->getMessage());
+        }
+
+        try {
+            $transformer->transform(18);
+
+            $this->fail('Age should not be transformed.');
+        } catch (TransformationFailedException $e) {
+            self::assertEquals('Age support is not enabled.', $e->getMessage());
+        }
+    }
+
+    /** @test */
+    public function it_disallows_date_in_the_future_by_default()
+    {
+        $dateObj = new \DateTime('tomorrow');
+
+        $dateTransformer = $this->prophesize(DataTransformerInterface::class);
+        $dateTransformer->reverseTransform($dateObj->format('Y-m-d'))->willReturn($dateObj);
+
+        $transformer = new LocalizedBirthdayTransformer($dateTransformer->reveal());
+
+        $this->expectException(TransformationFailedException::class);
+        $this->expectExceptionMessage(sprintf('Date "%s" is higher then current date ', $dateObj->format('Y-m-d')));
+
+        $transformer->reverseTransform($dateObj->format('Y-m-d'));
+    }
+
+    /** @test */
+    public function it_allows_date_in_the_future_when_enabled()
+    {
+        $dateObj = new \DateTime('tomorrow');
+
+        $dateTransformer = $this->prophesize(DataTransformerInterface::class);
+        $dateTransformer->reverseTransform($dateObj->format('Y-m-d'))->willReturn($dateObj);
+        $dateTransformer->transform($dateObj)->willReturn($dateObj->format('Y-m-d'));
+
+        $transformer = new LocalizedBirthdayTransformer($dateTransformer->reveal(), false, true);
+
+        self::assertEquals($dateObj, $transformer->reverseTransform($dateObj->format('Y-m-d')));
+        self::assertEquals($dateObj->format('Y-m-d'), $transformer->transform($dateObj));
+    }
+}

--- a/tests/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformerTest.php
+++ b/tests/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformerTest.php
@@ -14,35 +14,645 @@ declare(strict_types=1);
 namespace Rollerworks\Component\Search\Tests\Extension\Core\DataTransformer;
 
 use PHPUnit\Framework\TestCase;
+use Rollerworks\Component\Search\Exception\TransformationFailedException;
 use Rollerworks\Component\Search\Extension\Core\DataTransformer\MoneyToLocalizedStringTransformer;
 use Rollerworks\Component\Search\Extension\Core\Model\MoneyValue;
+use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class MoneyToLocalizedStringTransformerTest extends TestCase
 {
-    /** @var MoneyToLocalizedStringTransformer */
-    private $transformer;
-
     protected function setUp()
     {
-        $this->transformer = new MoneyToLocalizedStringTransformer(2, false, null, 1, 'EUR');
+        parent::setUp();
+
+        \Locale::setDefault('en');
     }
 
-    /** @test */
-    public function it_should_reverse_transform_to_a_MoneyObject()
+    public function provideTransformations()
     {
-        \Locale::setDefault('de_AT');
-
-        $value = new MoneyValue('EUR', '1.23');
-
-        self::assertEquals('€ 1,23', $this->transformer->transform($value));
-        self::assertEquals(new MoneyValue('EUR', '1.23'), $this->transformer->reverseTransform('€ 1,23'));
+        return [
+            [null, '', 'de_AT'],
+            [1, '€ 1,00', 'de_AT'],
+            [1.5, '€ 1,50', 'de_AT'],
+            [1234.5, '€ 1234,50', 'de_AT'],
+            [12345.912, '€ 12345,91', 'de_AT'],
+            [1234.5, '1234,50 €', 'ru'],
+            [1234.5, '1234,50 €', 'fi'],
+        ];
     }
 
-    /** @test */
-    public function it_should_reverse_transform_without_currency_to_a_MoneyObject()
+    /**
+     * @dataProvider provideTransformations
+     */
+    public function testTransform($from, $to, $locale)
     {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault($locale);
+
+        $transformer = new MoneyToLocalizedStringTransformer(null, null, null, null, 'EUR');
+
+        if (null !== $from) {
+            $from = new MoneyValue('EUR', $from);
+        }
+
+        $this->assertEquals($to, $transformer->transform($from));
+    }
+
+    public function provideTransformationsWithGrouping()
+    {
+        return [
+            [1234.5, '1.234,50 €', 'de_DE'],
+            [12345.912, '12.345,91 €', 'de_DE'],
+            [1234.5, '1 234,50 €', 'fr'],
+            [1234.5, '1 234,50 €', 'ru'],
+            [1234.5, '1 234,50 €', 'fi'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideTransformationsWithGrouping
+     */
+    public function testTransformWithGrouping($from, $to, $locale)
+    {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault($locale);
+
+        $transformer = new MoneyToLocalizedStringTransformer(null, true, null, null, 'EUR');
+
+        $from = new MoneyValue('EUR', $from);
+        $this->assertEquals($to, $transformer->transform($from));
+    }
+
+    public function testTransformWithScale()
+    {
+        // Since we test against "de_AT", we need the full implementation
+        IntlTestHelper::requireFullIntl($this, '58.1');
+
         \Locale::setDefault('de_AT');
 
-        self::assertEquals(new MoneyValue('EUR', '1.23'), $this->transformer->reverseTransform('1,23'));
+        $transformer = new MoneyToLocalizedStringTransformer(2, null, null, null, 'EUR');
+
+        $this->assertEquals('€ 1234,50', $transformer->transform(new MoneyValue('EUR', 1234.5)));
+        $this->assertEquals('€ 678,92', $transformer->transform(new MoneyValue('EUR', 678.916)));
+    }
+
+    public function transformWithRoundingProvider()
+    {
+        return [
+            // towards positive infinity (1.6 -> 2, -1.6 -> -1)
+            [0, 1234.5, '€ 1235', MoneyToLocalizedStringTransformer::ROUND_CEILING],
+            [0, 1234.4, '€ 1235', MoneyToLocalizedStringTransformer::ROUND_CEILING],
+            [0, -1234.5, '-€ 1234', MoneyToLocalizedStringTransformer::ROUND_CEILING],
+            [0, -1234.4, '-€ 1234', MoneyToLocalizedStringTransformer::ROUND_CEILING],
+            [1, 123.45, '€ 123,5', MoneyToLocalizedStringTransformer::ROUND_CEILING],
+            [1, 123.44, '€ 123,5', MoneyToLocalizedStringTransformer::ROUND_CEILING],
+            [1, -123.45, '-€ 123,4', MoneyToLocalizedStringTransformer::ROUND_CEILING],
+            [1, -123.44, '-€ 123,4', MoneyToLocalizedStringTransformer::ROUND_CEILING],
+            // towards negative infinity (1.6 -> 1, -1.6 -> -2)
+            [0, 1234.5, '€ 1234', MoneyToLocalizedStringTransformer::ROUND_FLOOR],
+            [0, 1234.4, '€ 1234', MoneyToLocalizedStringTransformer::ROUND_FLOOR],
+            [0, -1234.5, '-€ 1235', MoneyToLocalizedStringTransformer::ROUND_FLOOR],
+            [0, -1234.4, '-€ 1235', MoneyToLocalizedStringTransformer::ROUND_FLOOR],
+            [1, 123.45, '€ 123,4', MoneyToLocalizedStringTransformer::ROUND_FLOOR],
+            [1, 123.44, '€ 123,4', MoneyToLocalizedStringTransformer::ROUND_FLOOR],
+            [1, -123.45, '-€ 123,5', MoneyToLocalizedStringTransformer::ROUND_FLOOR],
+            [1, -123.44, '-€ 123,5', MoneyToLocalizedStringTransformer::ROUND_FLOOR],
+            // away from zero (1.6 -> 2, -1.6 -> 2)
+            [0, 1234.5, '€ 1235', MoneyToLocalizedStringTransformer::ROUND_UP],
+            [0, 1234.4, '€ 1235', MoneyToLocalizedStringTransformer::ROUND_UP],
+            [0, -1234.5, '-€ 1235', MoneyToLocalizedStringTransformer::ROUND_UP],
+            [0, -1234.4, '-€ 1235', MoneyToLocalizedStringTransformer::ROUND_UP],
+            [1, 123.45, '€ 123,5', MoneyToLocalizedStringTransformer::ROUND_UP],
+            [1, 123.44, '€ 123,5', MoneyToLocalizedStringTransformer::ROUND_UP],
+            [1, -123.45, '-€ 123,5', MoneyToLocalizedStringTransformer::ROUND_UP],
+            [1, -123.44, '-€ 123,5', MoneyToLocalizedStringTransformer::ROUND_UP],
+            // towards zero (1.6 -> 1, -1.6 -> -1)
+            [0, 1234.5, '€ 1234', MoneyToLocalizedStringTransformer::ROUND_DOWN],
+            [0, 1234.4, '€ 1234', MoneyToLocalizedStringTransformer::ROUND_DOWN],
+            [0, -1234.5, '-€ 1234', MoneyToLocalizedStringTransformer::ROUND_DOWN],
+            [0, -1234.4, '-€ 1234', MoneyToLocalizedStringTransformer::ROUND_DOWN],
+            [1, 123.45, '€ 123,4', MoneyToLocalizedStringTransformer::ROUND_DOWN],
+            [1, 123.44, '€ 123,4', MoneyToLocalizedStringTransformer::ROUND_DOWN],
+            [1, -123.45, '-€ 123,4', MoneyToLocalizedStringTransformer::ROUND_DOWN],
+            [1, -123.44, '-€ 123,4', MoneyToLocalizedStringTransformer::ROUND_DOWN],
+            // round halves (.5) to the next even number
+            [0, 1234.6, '€ 1235', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, 1234.5, '€ 1234', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, 1234.4, '€ 1234', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, 1233.5, '€ 1234', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, 1232.5, '€ 1232', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, -1234.6, '-€ 1235', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, -1234.5, '-€ 1234', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, -1234.4, '-€ 1234', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, -1233.5, '-€ 1234', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, -1232.5, '-€ 1232', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, 123.46, '€ 123,5', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, 123.45, '€ 123,4', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, 123.44, '€ 123,4', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, 123.35, '€ 123,4', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, 123.25, '€ 123,2', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, -123.46, '-€ 123,5', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, -123.45, '-€ 123,4', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, -123.44, '-€ 123,4', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, -123.35, '-€ 123,4', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, -123.25, '-€ 123,2', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            // round halves (.5) away from zero
+            [0, 1234.6, '€ 1235', MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
+            [0, 1234.5, '€ 1235', MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
+            [0, 1234.4, '€ 1234', MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
+            [0, -1234.6, '-€ 1235', MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
+            [0, -1234.5, '-€ 1235', MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
+            [0, -1234.4, '-€ 1234', MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
+            [1, 123.46, '€ 123,5', MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
+            [1, 123.45, '€ 123,5', MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
+            [1, 123.44, '€ 123,4', MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
+            [1, -123.46, '-€ 123,5', MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
+            [1, -123.45, '-€ 123,5', MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
+            [1, -123.44, '-€ 123,4', MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
+            // round halves (.5) towards zero
+            [0, 1234.6, '€ 1235', MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [0, 1234.5, '€ 1234', MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [0, 1234.4, '€ 1234', MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [0, -1234.6, '-€ 1235', MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [0, -1234.5, '-€ 1234', MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [0, -1234.4, '-€ 1234', MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [1, 123.46, '€ 123,5', MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [1, 123.45, '€ 123,4', MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [1, 123.44, '€ 123,4', MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [1, -123.46, '-€ 123,5', MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [1, -123.45, '-€ 123,4', MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [1, -123.44, '-€ 123,4', MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
+        ];
+    }
+
+    /**
+     * @dataProvider transformWithRoundingProvider
+     */
+    public function testTransformWithRounding($scale, $input, $output, $roundingMode)
+    {
+        // Since we test against "de_AT", we need the full implementation
+        IntlTestHelper::requireFullIntl($this, '58.1');
+
+        \Locale::setDefault('de_AT');
+
+        $transformer = new MoneyToLocalizedStringTransformer($scale, null, $roundingMode, null, 'EUR');
+
+        $input = new MoneyValue('EUR', $input);
+        $this->assertEquals($output, $transformer->transform($input));
+    }
+
+    public function testTransformDoesNotRoundIfNoScale()
+    {
+        // Since we test against "de_AT", we need the full implementation
+        IntlTestHelper::requireFullIntl($this, '58.1');
+
+        \Locale::setDefault('de_AT');
+
+        $transformer = new MoneyToLocalizedStringTransformer(null, null, MoneyToLocalizedStringTransformer::ROUND_DOWN, null, 'EUR');
+
+        $this->assertEquals('€ 1234,55', $transformer->transform(new MoneyValue('EUR', 1234.547)));
+    }
+
+    /**
+     * @dataProvider provideTransformations
+     */
+    public function testReverseTransform($to, $from, $locale)
+    {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this, '58.1');
+
+        \Locale::setDefault($locale);
+
+        $transformer = new MoneyToLocalizedStringTransformer(null, null, null, null, 'EUR');
+
+        if (null !== $to) {
+            $to = new MoneyValue('EUR', (float) number_format($to, 2, '.', ''));
+        }
+
+        $this->assertEquals($to, $transformer->reverseTransform($from));
+    }
+
+    /**
+     * @dataProvider provideTransformations
+     */
+    public function testReverseTransformWithoutCurrency($to, $from, $locale)
+    {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault($locale);
+
+        $from = preg_replace('#(\s?\p{Sc}\s?)#u', '', $from);
+        $transformer = new MoneyToLocalizedStringTransformer(null, null, null, null, 'USD');
+
+        if (null !== $to) {
+            $to = new MoneyValue('USD', (float) number_format($to, 2, '.', ''));
+        }
+
+        $this->assertEquals($to, $transformer->reverseTransform($from));
+    }
+
+    /**
+     * @dataProvider provideTransformationsWithGrouping
+     */
+    public function testReverseTransformWithGrouping($to, $from, $locale)
+    {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this, '58.1');
+
+        \Locale::setDefault($locale);
+
+        $transformer = new MoneyToLocalizedStringTransformer(null, true, null, null, 'EUR');
+
+        $to = new MoneyValue('EUR', (float) number_format($to, 2, '.', ''));
+        $this->assertEquals($to, $transformer->reverseTransform($from));
+    }
+
+    /**
+     * @see https://github.com/symfony/symfony/issues/7609
+     */
+    public function testReverseTransformWithGroupingAndFixedSpaces()
+    {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('ru');
+
+        $transformer = new MoneyToLocalizedStringTransformer(null, true, null, null, 'EUR');
+
+        $this->assertEquals(new MoneyValue('EUR', 1234.5), $transformer->reverseTransform("1\xc2\xa0234,5"));
+    }
+
+    public function testReverseTransformWithGroupingButWithoutGroupSeparator()
+    {
+        // Since we test against "de_AT", we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('de_AT');
+
+        $transformer = new MoneyToLocalizedStringTransformer(null, true, null, null, 'EUR');
+
+        // omit group separator
+        $this->assertEquals(new MoneyValue('EUR', 1234.5), $transformer->reverseTransform('1234,5'));
+        $this->assertEquals(new MoneyValue('EUR', 12345.912), $transformer->reverseTransform('12345,912'));
+    }
+
+    public function reverseTransformWithRoundingProvider()
+    {
+        return [
+            // towards positive infinity (1.6 -> 2, -1.6 -> -1)
+            [0, '1234,5', 1235, MoneyToLocalizedStringTransformer::ROUND_CEILING],
+            [0, '1234,4', 1235, MoneyToLocalizedStringTransformer::ROUND_CEILING],
+            [0, '-1234,5', -1234, MoneyToLocalizedStringTransformer::ROUND_CEILING],
+            [0, '-1234,4', -1234, MoneyToLocalizedStringTransformer::ROUND_CEILING],
+            [1, '123,45', 123.5, MoneyToLocalizedStringTransformer::ROUND_CEILING],
+            [1, '123,44', 123.5, MoneyToLocalizedStringTransformer::ROUND_CEILING],
+            [1, '-123,45', -123.4, MoneyToLocalizedStringTransformer::ROUND_CEILING],
+            [1, '-123,44', -123.4, MoneyToLocalizedStringTransformer::ROUND_CEILING],
+            // towards negative infinity (1.6 -> 1, -1.6 -> -2)
+            [0, '1234,5', 1234, MoneyToLocalizedStringTransformer::ROUND_FLOOR],
+            [0, '1234,4', 1234, MoneyToLocalizedStringTransformer::ROUND_FLOOR],
+            [0, '-1234,5', -1235, MoneyToLocalizedStringTransformer::ROUND_FLOOR],
+            [0, '-1234,4', -1235, MoneyToLocalizedStringTransformer::ROUND_FLOOR],
+            [1, '123,45', 123.4, MoneyToLocalizedStringTransformer::ROUND_FLOOR],
+            [1, '123,44', 123.4, MoneyToLocalizedStringTransformer::ROUND_FLOOR],
+            [1, '-123,45', -123.5, MoneyToLocalizedStringTransformer::ROUND_FLOOR],
+            [1, '-123,44', -123.5, MoneyToLocalizedStringTransformer::ROUND_FLOOR],
+            // away from zero (1.6 -> 2, -1.6 -> 2)
+            [0, '1234,5', 1235, MoneyToLocalizedStringTransformer::ROUND_UP],
+            [0, '1234,4', 1235, MoneyToLocalizedStringTransformer::ROUND_UP],
+            [0, '-1234,5', -1235, MoneyToLocalizedStringTransformer::ROUND_UP],
+            [0, '-1234,4', -1235, MoneyToLocalizedStringTransformer::ROUND_UP],
+            [1, '123,45', 123.5, MoneyToLocalizedStringTransformer::ROUND_UP],
+            [1, '123,44', 123.5, MoneyToLocalizedStringTransformer::ROUND_UP],
+            [1, '-123,45', -123.5, MoneyToLocalizedStringTransformer::ROUND_UP],
+            [1, '-123,44', -123.5, MoneyToLocalizedStringTransformer::ROUND_UP],
+            // towards zero (1.6 -> 1, -1.6 -> -1)
+            [0, '1234,5', 1234, MoneyToLocalizedStringTransformer::ROUND_DOWN],
+            [0, '1234,4', 1234, MoneyToLocalizedStringTransformer::ROUND_DOWN],
+            [0, '-1234,5', -1234, MoneyToLocalizedStringTransformer::ROUND_DOWN],
+            [0, '-1234,4', -1234, MoneyToLocalizedStringTransformer::ROUND_DOWN],
+            [1, '123,45', 123.4, MoneyToLocalizedStringTransformer::ROUND_DOWN],
+            [1, '123,44', 123.4, MoneyToLocalizedStringTransformer::ROUND_DOWN],
+            [1, '-123,45', -123.4, MoneyToLocalizedStringTransformer::ROUND_DOWN],
+            [1, '-123,44', -123.4, MoneyToLocalizedStringTransformer::ROUND_DOWN],
+            // round halves (.5) to the next even number
+            [0, '1234,6', 1235, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, '1234,5', 1234, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, '1234,4', 1234, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, '1233,5', 1234, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, '1232,5', 1232, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, '-1234,6', -1235, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, '-1234,5', -1234, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, '-1234,4', -1234, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, '-1233,5', -1234, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, '-1232,5', -1232, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, '123,46', 123.5, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, '123,45', 123.4, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, '123,44', 123.4, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, '123,35', 123.4, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, '123,25', 123.2, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, '-123,46', -123.5, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, '-123,45', -123.4, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, '-123,44', -123.4, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, '-123,35', -123.4, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, '-123,25', -123.2, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            // round halves (.5) away from zero
+            [0, '1234,6', 1235, MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
+            [0, '1234,5', 1235, MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
+            [0, '1234,4', 1234, MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
+            [0, '-1234,6', -1235, MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
+            [0, '-1234,5', -1235, MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
+            [0, '-1234,4', -1234, MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
+            [1, '123,46', 123.5, MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
+            [1, '123,45', 123.5, MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
+            [1, '123,44', 123.4, MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
+            [1, '-123,46', -123.5, MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
+            [1, '-123,45', -123.5, MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
+            [1, '-123,44', -123.4, MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
+            // round halves (.5) towards zero
+            [0, '1234,6', 1235, MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [0, '1234,5', 1234, MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [0, '1234,4', 1234, MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [0, '-1234,6', -1235, MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [0, '-1234,5', -1234, MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [0, '-1234,4', -1234, MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [1, '123,46', 123.5, MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [1, '123,45', 123.4, MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [1, '123,44', 123.4, MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [1, '-123,46', -123.5, MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [1, '-123,45', -123.4, MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [1, '-123,44', -123.4, MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
+        ];
+    }
+
+    /**
+     * @dataProvider reverseTransformWithRoundingProvider
+     */
+    public function testReverseTransformWithRounding($scale, $input, $output, $roundingMode)
+    {
+        $transformer = new MoneyToLocalizedStringTransformer($scale, null, $roundingMode, null, 'EUR');
+
+        $this->assertEquals(new MoneyValue('EUR', $output), $transformer->reverseTransform($input));
+    }
+
+    public function testReverseTransformDoesNotRoundIfNoScale()
+    {
+        $transformer = new MoneyToLocalizedStringTransformer(null, null, MoneyToLocalizedStringTransformer::ROUND_DOWN, null, 'EUR');
+
+        $this->assertEquals(new MoneyValue('EUR', 1234.547), $transformer->reverseTransform('1234,547'));
+    }
+
+    public function testDecimalSeparatorMayBeDotIfGroupingSeparatorIsNotDot()
+    {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('fr');
+        $transformer = new MoneyToLocalizedStringTransformer(null, true, null, null, 'EUR');
+
+        // completely valid format
+        $this->assertEquals(new MoneyValue('EUR', 1234.5), $transformer->reverseTransform('1 234,5'));
+        // accept dots
+        $this->assertEquals(new MoneyValue('EUR', 1234.5), $transformer->reverseTransform('1 234.5'));
+        // omit group separator
+        $this->assertEquals(new MoneyValue('EUR', 1234.5), $transformer->reverseTransform('1234,5'));
+        $this->assertEquals(new MoneyValue('EUR', 1234.5), $transformer->reverseTransform('1234.5'));
+    }
+
+    public function testDecimalSeparatorMayNotBeDotIfGroupingSeparatorIsDot()
+    {
+        // Since we test against "de_DE", we need the full implementation
+        IntlTestHelper::requireFullIntl($this, '58.1');
+
+        \Locale::setDefault('de_DE');
+
+        $transformer = new MoneyToLocalizedStringTransformer(null, true, null, null, 'EUR');
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('1.234.5');
+    }
+
+    public function testDecimalSeparatorMayNotBeDotIfGroupingSeparatorIsDotWithNoGroupSep()
+    {
+        // Since we test against "de_DE", we need the full implementation
+        IntlTestHelper::requireFullIntl($this, '58.1');
+
+        \Locale::setDefault('de_DE');
+
+        $transformer = new MoneyToLocalizedStringTransformer(null, true, null, null, 'EUR');
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('1234.5');
+    }
+
+    public function testDecimalSeparatorMayBeDotIfGroupingSeparatorIsDotButNoGroupingUsed()
+    {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this, '58.1');
+
+        \Locale::setDefault('fr');
+        $transformer = new MoneyToLocalizedStringTransformer(null, null, null, null, 'EUR');
+
+        $this->assertEquals(new MoneyValue('EUR', 1234.5), $transformer->reverseTransform('1234,5'));
+        $this->assertEquals(new MoneyValue('EUR', 1234.5), $transformer->reverseTransform('1234.5'));
+    }
+
+    public function testDecimalSeparatorMayBeCommaIfGroupingSeparatorIsNotComma()
+    {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this, '58.1');
+
+        \Locale::setDefault('bg');
+        $transformer = new MoneyToLocalizedStringTransformer(null, true, null, null, 'EUR');
+
+        // completely valid format
+        $this->assertEquals(new MoneyValue('EUR', 1234.5), $transformer->reverseTransform('1 234.5'));
+        // accept commas
+        $this->assertEquals(new MoneyValue('EUR', 1234.5), $transformer->reverseTransform('1 234,5'));
+        // omit group separator
+        $this->assertEquals(new MoneyValue('EUR', 1234.5), $transformer->reverseTransform('1234.5'));
+        $this->assertEquals(new MoneyValue('EUR', 1234.5), $transformer->reverseTransform('1234,5'));
+    }
+
+    public function testDecimalSeparatorMayNotBeCommaIfGroupingSeparatorIsComma()
+    {
+        $transformer = new MoneyToLocalizedStringTransformer(null, true, null, null, 'EUR');
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('1,234,5');
+    }
+
+    public function testDecimalSeparatorMayNotBeCommaIfGroupingSeparatorIsCommaWithNoGroupSep()
+    {
+        $transformer = new MoneyToLocalizedStringTransformer(null, true, null, null, 'EUR');
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('1234,5');
+    }
+
+    public function testDecimalSeparatorMayBeCommaIfGroupingSeparatorIsCommaButNoGroupingUsed()
+    {
+        $transformer = new MoneyToLocalizedStringTransformer(null, null, null, null, 'EUR');
+
+        $this->assertEquals(new MoneyValue('EUR', 1234.5), $transformer->reverseTransform('1234,5'));
+        $this->assertEquals(new MoneyValue('EUR', 1234.5), $transformer->reverseTransform('1234.5'));
+    }
+
+    public function testTransformExpectsNumeric()
+    {
+        $transformer = new MoneyToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->transform('foo');
+    }
+
+    public function testReverseTransformExpectsString()
+    {
+        $transformer = new MoneyToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform(1);
+    }
+
+    public function testReverseTransformExpectsValidNumber()
+    {
+        $transformer = new MoneyToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('foo');
+    }
+
+    /**
+     * @see https://github.com/symfony/symfony/issues/3161
+     */
+    public function testReverseTransformDisallowsNaN()
+    {
+        $transformer = new MoneyToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('NaN');
+    }
+
+    public function testReverseTransformDisallowsNaN2()
+    {
+        $transformer = new MoneyToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('nan');
+    }
+
+    public function testReverseTransformDisallowsInfinity()
+    {
+        $transformer = new MoneyToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('∞');
+    }
+
+    public function testReverseTransformDisallowsInfinity2()
+    {
+        $transformer = new MoneyToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('∞,123');
+    }
+
+    public function testReverseTransformDisallowsNegativeInfinity()
+    {
+        $transformer = new MoneyToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('-∞');
+    }
+
+    public function testReverseTransformDisallowsLeadingExtraCharacters()
+    {
+        $transformer = new MoneyToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('foo123');
+    }
+
+    public function testReverseTransformDisallowsCenteredExtraCharacters()
+    {
+        $transformer = new MoneyToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+        $this->expectExceptionMessage('The number contains unrecognized characters: "foo3"');
+
+        $transformer->reverseTransform('12foo3');
+    }
+
+    public function testReverseTransformDisallowsCenteredExtraCharactersMultibyte()
+    {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('ru');
+
+        $transformer = new MoneyToLocalizedStringTransformer(null, true);
+
+        $this->expectException(TransformationFailedException::class);
+        $this->expectExceptionMessage('The number contains unrecognized characters: "foo8"');
+
+        $transformer->reverseTransform("12\xc2\xa0345,67foo8");
+    }
+
+    public function testReverseTransformIgnoresTrailingSpacesInExceptionMessage()
+    {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('ru');
+
+        $transformer = new MoneyToLocalizedStringTransformer(null, true);
+
+        $this->expectException(TransformationFailedException::class);
+        $this->expectExceptionMessage('The number contains unrecognized characters: "foo8"');
+
+        $transformer->reverseTransform("12\xc2\xa0345,67foo8  \xc2\xa0\t");
+    }
+
+    public function testReverseTransformDisallowsTrailingExtraCharacters()
+    {
+        $transformer = new MoneyToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+        $this->expectExceptionMessage('The number contains unrecognized characters: "foo"');
+
+        $transformer->reverseTransform('123foo');
+    }
+
+    public function testReverseTransformDisallowsTrailingExtraCharactersMultibyte()
+    {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('ru');
+
+        $transformer = new MoneyToLocalizedStringTransformer(null, true);
+
+        $this->expectException(TransformationFailedException::class);
+        $this->expectExceptionMessage('The number contains unrecognized characters: "foo"');
+
+        $transformer->reverseTransform("12\xc2\xa0345,678foo");
     }
 }

--- a/tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
+++ b/tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
@@ -1,0 +1,640 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Tests\Extension\Core\DataTransformer;
+
+use PHPUnit\Framework\TestCase;
+use Rollerworks\Component\Search\Exception\TransformationFailedException;
+use Rollerworks\Component\Search\Extension\Core\DataTransformer\NumberToLocalizedStringTransformer;
+use Symfony\Component\Intl\Util\IntlTestHelper;
+
+class NumberToLocalizedStringTransformerTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        \Locale::setDefault('en');
+    }
+
+    public function provideTransformations()
+    {
+        return [
+            [null, '', 'de_AT'],
+            [1, '1', 'de_AT'],
+            [1.5, '1,5', 'de_AT'],
+            [1234.5, '1234,5', 'de_AT'],
+            [12345.912, '12345,912', 'de_AT'],
+            [1234.5, '1234,5', 'ru'],
+            [1234.5, '1234,5', 'fi'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideTransformations
+     */
+    public function testTransform($from, $to, $locale)
+    {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault($locale);
+
+        $transformer = new NumberToLocalizedStringTransformer();
+
+        $this->assertSame($to, $transformer->transform($from));
+    }
+
+    public function provideTransformationsWithGrouping()
+    {
+        return [
+            [1234.5, '1.234,5', 'de_DE'],
+            [12345.912, '12.345,912', 'de_DE'],
+            [1234.5, '1 234,5', 'fr'],
+            [1234.5, '1 234,5', 'ru'],
+            [1234.5, '1 234,5', 'fi'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideTransformationsWithGrouping
+     */
+    public function testTransformWithGrouping($from, $to, $locale)
+    {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault($locale);
+
+        $transformer = new NumberToLocalizedStringTransformer(null, true);
+
+        $this->assertSame($to, $transformer->transform($from));
+    }
+
+    public function testTransformWithScale()
+    {
+        // Since we test against "de_AT", we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('de_AT');
+
+        $transformer = new NumberToLocalizedStringTransformer(2);
+
+        $this->assertEquals('1234,50', $transformer->transform(1234.5));
+        $this->assertEquals('678,92', $transformer->transform(678.916));
+    }
+
+    public function transformWithRoundingProvider()
+    {
+        return [
+            // towards positive infinity (1.6 -> 2, -1.6 -> -1)
+            [0, 1234.5, '1235', NumberToLocalizedStringTransformer::ROUND_CEILING],
+            [0, 1234.4, '1235', NumberToLocalizedStringTransformer::ROUND_CEILING],
+            [0, -1234.5, '-1234', NumberToLocalizedStringTransformer::ROUND_CEILING],
+            [0, -1234.4, '-1234', NumberToLocalizedStringTransformer::ROUND_CEILING],
+            [1, 123.45, '123,5', NumberToLocalizedStringTransformer::ROUND_CEILING],
+            [1, 123.44, '123,5', NumberToLocalizedStringTransformer::ROUND_CEILING],
+            [1, -123.45, '-123,4', NumberToLocalizedStringTransformer::ROUND_CEILING],
+            [1, -123.44, '-123,4', NumberToLocalizedStringTransformer::ROUND_CEILING],
+            // towards negative infinity (1.6 -> 1, -1.6 -> -2)
+            [0, 1234.5, '1234', NumberToLocalizedStringTransformer::ROUND_FLOOR],
+            [0, 1234.4, '1234', NumberToLocalizedStringTransformer::ROUND_FLOOR],
+            [0, -1234.5, '-1235', NumberToLocalizedStringTransformer::ROUND_FLOOR],
+            [0, -1234.4, '-1235', NumberToLocalizedStringTransformer::ROUND_FLOOR],
+            [1, 123.45, '123,4', NumberToLocalizedStringTransformer::ROUND_FLOOR],
+            [1, 123.44, '123,4', NumberToLocalizedStringTransformer::ROUND_FLOOR],
+            [1, -123.45, '-123,5', NumberToLocalizedStringTransformer::ROUND_FLOOR],
+            [1, -123.44, '-123,5', NumberToLocalizedStringTransformer::ROUND_FLOOR],
+            // away from zero (1.6 -> 2, -1.6 -> 2)
+            [0, 1234.5, '1235', NumberToLocalizedStringTransformer::ROUND_UP],
+            [0, 1234.4, '1235', NumberToLocalizedStringTransformer::ROUND_UP],
+            [0, -1234.5, '-1235', NumberToLocalizedStringTransformer::ROUND_UP],
+            [0, -1234.4, '-1235', NumberToLocalizedStringTransformer::ROUND_UP],
+            [1, 123.45, '123,5', NumberToLocalizedStringTransformer::ROUND_UP],
+            [1, 123.44, '123,5', NumberToLocalizedStringTransformer::ROUND_UP],
+            [1, -123.45, '-123,5', NumberToLocalizedStringTransformer::ROUND_UP],
+            [1, -123.44, '-123,5', NumberToLocalizedStringTransformer::ROUND_UP],
+            // towards zero (1.6 -> 1, -1.6 -> -1)
+            [0, 1234.5, '1234', NumberToLocalizedStringTransformer::ROUND_DOWN],
+            [0, 1234.4, '1234', NumberToLocalizedStringTransformer::ROUND_DOWN],
+            [0, -1234.5, '-1234', NumberToLocalizedStringTransformer::ROUND_DOWN],
+            [0, -1234.4, '-1234', NumberToLocalizedStringTransformer::ROUND_DOWN],
+            [1, 123.45, '123,4', NumberToLocalizedStringTransformer::ROUND_DOWN],
+            [1, 123.44, '123,4', NumberToLocalizedStringTransformer::ROUND_DOWN],
+            [1, -123.45, '-123,4', NumberToLocalizedStringTransformer::ROUND_DOWN],
+            [1, -123.44, '-123,4', NumberToLocalizedStringTransformer::ROUND_DOWN],
+            // round halves (.5) to the next even number
+            [0, 1234.6, '1235', NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, 1234.5, '1234', NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, 1234.4, '1234', NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, 1233.5, '1234', NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, 1232.5, '1232', NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, -1234.6, '-1235', NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, -1234.5, '-1234', NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, -1234.4, '-1234', NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, -1233.5, '-1234', NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, -1232.5, '-1232', NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, 123.46, '123,5', NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, 123.45, '123,4', NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, 123.44, '123,4', NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, 123.35, '123,4', NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, 123.25, '123,2', NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, -123.46, '-123,5', NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, -123.45, '-123,4', NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, -123.44, '-123,4', NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, -123.35, '-123,4', NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, -123.25, '-123,2', NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            // round halves (.5) away from zero
+            [0, 1234.6, '1235', NumberToLocalizedStringTransformer::ROUND_HALF_UP],
+            [0, 1234.5, '1235', NumberToLocalizedStringTransformer::ROUND_HALF_UP],
+            [0, 1234.4, '1234', NumberToLocalizedStringTransformer::ROUND_HALF_UP],
+            [0, -1234.6, '-1235', NumberToLocalizedStringTransformer::ROUND_HALF_UP],
+            [0, -1234.5, '-1235', NumberToLocalizedStringTransformer::ROUND_HALF_UP],
+            [0, -1234.4, '-1234', NumberToLocalizedStringTransformer::ROUND_HALF_UP],
+            [1, 123.46, '123,5', NumberToLocalizedStringTransformer::ROUND_HALF_UP],
+            [1, 123.45, '123,5', NumberToLocalizedStringTransformer::ROUND_HALF_UP],
+            [1, 123.44, '123,4', NumberToLocalizedStringTransformer::ROUND_HALF_UP],
+            [1, -123.46, '-123,5', NumberToLocalizedStringTransformer::ROUND_HALF_UP],
+            [1, -123.45, '-123,5', NumberToLocalizedStringTransformer::ROUND_HALF_UP],
+            [1, -123.44, '-123,4', NumberToLocalizedStringTransformer::ROUND_HALF_UP],
+            // round halves (.5) towards zero
+            [0, 1234.6, '1235', NumberToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [0, 1234.5, '1234', NumberToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [0, 1234.4, '1234', NumberToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [0, -1234.6, '-1235', NumberToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [0, -1234.5, '-1234', NumberToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [0, -1234.4, '-1234', NumberToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [1, 123.46, '123,5', NumberToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [1, 123.45, '123,4', NumberToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [1, 123.44, '123,4', NumberToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [1, -123.46, '-123,5', NumberToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [1, -123.45, '-123,4', NumberToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [1, -123.44, '-123,4', NumberToLocalizedStringTransformer::ROUND_HALF_DOWN],
+        ];
+    }
+
+    /**
+     * @dataProvider transformWithRoundingProvider
+     */
+    public function testTransformWithRounding($scale, $input, $output, $roundingMode)
+    {
+        // Since we test against "de_AT", we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('de_AT');
+
+        $transformer = new NumberToLocalizedStringTransformer($scale, null, $roundingMode);
+
+        $this->assertEquals($output, $transformer->transform($input));
+    }
+
+    public function testTransformDoesNotRoundIfNoScale()
+    {
+        // Since we test against "de_AT", we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('de_AT');
+
+        $transformer = new NumberToLocalizedStringTransformer(null, null, NumberToLocalizedStringTransformer::ROUND_DOWN);
+
+        $this->assertEquals('1234,547', $transformer->transform(1234.547));
+    }
+
+    /**
+     * @dataProvider provideTransformations
+     */
+    public function testReverseTransform($to, $from, $locale)
+    {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault($locale);
+
+        $transformer = new NumberToLocalizedStringTransformer();
+
+        $this->assertEquals($to, $transformer->reverseTransform($from));
+    }
+
+    /**
+     * @dataProvider provideTransformationsWithGrouping
+     */
+    public function testReverseTransformWithGrouping($to, $from, $locale)
+    {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault($locale);
+
+        $transformer = new NumberToLocalizedStringTransformer(null, true);
+
+        $this->assertEquals($to, $transformer->reverseTransform($from));
+    }
+
+    /**
+     * @see https://github.com/symfony/symfony/issues/7609
+     */
+    public function testReverseTransformWithGroupingAndFixedSpaces()
+    {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('ru');
+
+        $transformer = new NumberToLocalizedStringTransformer(null, true);
+
+        $this->assertEquals(1234.5, $transformer->reverseTransform("1\xc2\xa0234,5"));
+    }
+
+    public function testReverseTransformWithGroupingButWithoutGroupSeparator()
+    {
+        // Since we test against "de_AT", we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('de_AT');
+
+        $transformer = new NumberToLocalizedStringTransformer(null, true);
+
+        // omit group separator
+        $this->assertEquals(1234.5, $transformer->reverseTransform('1234,5'));
+        $this->assertEquals(12345.912, $transformer->reverseTransform('12345,912'));
+    }
+
+    public function reverseTransformWithRoundingProvider()
+    {
+        return [
+            // towards positive infinity (1.6 -> 2, -1.6 -> -1)
+            [0, '1234,5', 1235, NumberToLocalizedStringTransformer::ROUND_CEILING],
+            [0, '1234,4', 1235, NumberToLocalizedStringTransformer::ROUND_CEILING],
+            [0, '-1234,5', -1234, NumberToLocalizedStringTransformer::ROUND_CEILING],
+            [0, '-1234,4', -1234, NumberToLocalizedStringTransformer::ROUND_CEILING],
+            [1, '123,45', 123.5, NumberToLocalizedStringTransformer::ROUND_CEILING],
+            [1, '123,44', 123.5, NumberToLocalizedStringTransformer::ROUND_CEILING],
+            [1, '-123,45', -123.4, NumberToLocalizedStringTransformer::ROUND_CEILING],
+            [1, '-123,44', -123.4, NumberToLocalizedStringTransformer::ROUND_CEILING],
+            // towards negative infinity (1.6 -> 1, -1.6 -> -2)
+            [0, '1234,5', 1234, NumberToLocalizedStringTransformer::ROUND_FLOOR],
+            [0, '1234,4', 1234, NumberToLocalizedStringTransformer::ROUND_FLOOR],
+            [0, '-1234,5', -1235, NumberToLocalizedStringTransformer::ROUND_FLOOR],
+            [0, '-1234,4', -1235, NumberToLocalizedStringTransformer::ROUND_FLOOR],
+            [1, '123,45', 123.4, NumberToLocalizedStringTransformer::ROUND_FLOOR],
+            [1, '123,44', 123.4, NumberToLocalizedStringTransformer::ROUND_FLOOR],
+            [1, '-123,45', -123.5, NumberToLocalizedStringTransformer::ROUND_FLOOR],
+            [1, '-123,44', -123.5, NumberToLocalizedStringTransformer::ROUND_FLOOR],
+            // away from zero (1.6 -> 2, -1.6 -> 2)
+            [0, '1234,5', 1235, NumberToLocalizedStringTransformer::ROUND_UP],
+            [0, '1234,4', 1235, NumberToLocalizedStringTransformer::ROUND_UP],
+            [0, '-1234,5', -1235, NumberToLocalizedStringTransformer::ROUND_UP],
+            [0, '-1234,4', -1235, NumberToLocalizedStringTransformer::ROUND_UP],
+            [1, '123,45', 123.5, NumberToLocalizedStringTransformer::ROUND_UP],
+            [1, '123,44', 123.5, NumberToLocalizedStringTransformer::ROUND_UP],
+            [1, '-123,45', -123.5, NumberToLocalizedStringTransformer::ROUND_UP],
+            [1, '-123,44', -123.5, NumberToLocalizedStringTransformer::ROUND_UP],
+            // towards zero (1.6 -> 1, -1.6 -> -1)
+            [0, '1234,5', 1234, NumberToLocalizedStringTransformer::ROUND_DOWN],
+            [0, '1234,4', 1234, NumberToLocalizedStringTransformer::ROUND_DOWN],
+            [0, '-1234,5', -1234, NumberToLocalizedStringTransformer::ROUND_DOWN],
+            [0, '-1234,4', -1234, NumberToLocalizedStringTransformer::ROUND_DOWN],
+            [1, '123,45', 123.4, NumberToLocalizedStringTransformer::ROUND_DOWN],
+            [1, '123,44', 123.4, NumberToLocalizedStringTransformer::ROUND_DOWN],
+            [1, '-123,45', -123.4, NumberToLocalizedStringTransformer::ROUND_DOWN],
+            [1, '-123,44', -123.4, NumberToLocalizedStringTransformer::ROUND_DOWN],
+            // round halves (.5) to the next even number
+            [0, '1234,6', 1235, NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, '1234,5', 1234, NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, '1234,4', 1234, NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, '1233,5', 1234, NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, '1232,5', 1232, NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, '-1234,6', -1235, NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, '-1234,5', -1234, NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, '-1234,4', -1234, NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, '-1233,5', -1234, NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [0, '-1232,5', -1232, NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, '123,46', 123.5, NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, '123,45', 123.4, NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, '123,44', 123.4, NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, '123,35', 123.4, NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, '123,25', 123.2, NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, '-123,46', -123.5, NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, '-123,45', -123.4, NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, '-123,44', -123.4, NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, '-123,35', -123.4, NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            [1, '-123,25', -123.2, NumberToLocalizedStringTransformer::ROUND_HALF_EVEN],
+            // round halves (.5) away from zero
+            [0, '1234,6', 1235, NumberToLocalizedStringTransformer::ROUND_HALF_UP],
+            [0, '1234,5', 1235, NumberToLocalizedStringTransformer::ROUND_HALF_UP],
+            [0, '1234,4', 1234, NumberToLocalizedStringTransformer::ROUND_HALF_UP],
+            [0, '-1234,6', -1235, NumberToLocalizedStringTransformer::ROUND_HALF_UP],
+            [0, '-1234,5', -1235, NumberToLocalizedStringTransformer::ROUND_HALF_UP],
+            [0, '-1234,4', -1234, NumberToLocalizedStringTransformer::ROUND_HALF_UP],
+            [1, '123,46', 123.5, NumberToLocalizedStringTransformer::ROUND_HALF_UP],
+            [1, '123,45', 123.5, NumberToLocalizedStringTransformer::ROUND_HALF_UP],
+            [1, '123,44', 123.4, NumberToLocalizedStringTransformer::ROUND_HALF_UP],
+            [1, '-123,46', -123.5, NumberToLocalizedStringTransformer::ROUND_HALF_UP],
+            [1, '-123,45', -123.5, NumberToLocalizedStringTransformer::ROUND_HALF_UP],
+            [1, '-123,44', -123.4, NumberToLocalizedStringTransformer::ROUND_HALF_UP],
+            // round halves (.5) towards zero
+            [0, '1234,6', 1235, NumberToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [0, '1234,5', 1234, NumberToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [0, '1234,4', 1234, NumberToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [0, '-1234,6', -1235, NumberToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [0, '-1234,5', -1234, NumberToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [0, '-1234,4', -1234, NumberToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [1, '123,46', 123.5, NumberToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [1, '123,45', 123.4, NumberToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [1, '123,44', 123.4, NumberToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [1, '-123,46', -123.5, NumberToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [1, '-123,45', -123.4, NumberToLocalizedStringTransformer::ROUND_HALF_DOWN],
+            [1, '-123,44', -123.4, NumberToLocalizedStringTransformer::ROUND_HALF_DOWN],
+        ];
+    }
+
+    /**
+     * @dataProvider reverseTransformWithRoundingProvider
+     */
+    public function testReverseTransformWithRounding($scale, $input, $output, $roundingMode)
+    {
+        $transformer = new NumberToLocalizedStringTransformer($scale, null, $roundingMode);
+
+        $this->assertEquals($output, $transformer->reverseTransform($input));
+    }
+
+    public function testReverseTransformDoesNotRoundIfNoScale()
+    {
+        $transformer = new NumberToLocalizedStringTransformer(null, null, NumberToLocalizedStringTransformer::ROUND_DOWN);
+
+        $this->assertEquals(1234.547, $transformer->reverseTransform('1234,547'));
+    }
+
+    public function testDecimalSeparatorMayBeDotIfGroupingSeparatorIsNotDot()
+    {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('fr');
+        $transformer = new NumberToLocalizedStringTransformer(null, true);
+
+        // completely valid format
+        $this->assertEquals(1234.5, $transformer->reverseTransform('1 234,5'));
+        // accept dots
+        $this->assertEquals(1234.5, $transformer->reverseTransform('1 234.5'));
+        // omit group separator
+        $this->assertEquals(1234.5, $transformer->reverseTransform('1234,5'));
+        $this->assertEquals(1234.5, $transformer->reverseTransform('1234.5'));
+    }
+
+    public function testDecimalSeparatorMayNotBeDotIfGroupingSeparatorIsDot()
+    {
+        // Since we test against "de_DE", we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('de_DE');
+
+        $transformer = new NumberToLocalizedStringTransformer(null, true);
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('1.234.5');
+    }
+
+    public function testDecimalSeparatorMayNotBeDotIfGroupingSeparatorIsDotWithNoGroupSep()
+    {
+        // Since we test against "de_DE", we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('de_DE');
+
+        $transformer = new NumberToLocalizedStringTransformer(null, true);
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('1234.5');
+    }
+
+    public function testDecimalSeparatorMayBeDotIfGroupingSeparatorIsDotButNoGroupingUsed()
+    {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('fr');
+        $transformer = new NumberToLocalizedStringTransformer();
+
+        $this->assertEquals(1234.5, $transformer->reverseTransform('1234,5'));
+        $this->assertEquals(1234.5, $transformer->reverseTransform('1234.5'));
+    }
+
+    public function testDecimalSeparatorMayBeCommaIfGroupingSeparatorIsNotComma()
+    {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('bg');
+        $transformer = new NumberToLocalizedStringTransformer(null, true);
+
+        // completely valid format
+        $this->assertEquals(1234.5, $transformer->reverseTransform('1 234.5'));
+        // accept commas
+        $this->assertEquals(1234.5, $transformer->reverseTransform('1 234,5'));
+        // omit group separator
+        $this->assertEquals(1234.5, $transformer->reverseTransform('1234.5'));
+        $this->assertEquals(1234.5, $transformer->reverseTransform('1234,5'));
+    }
+
+    public function testDecimalSeparatorMayNotBeCommaIfGroupingSeparatorIsComma()
+    {
+        $transformer = new NumberToLocalizedStringTransformer(null, true);
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('1,234,5');
+    }
+
+    public function testDecimalSeparatorMayNotBeCommaIfGroupingSeparatorIsCommaWithNoGroupSep()
+    {
+        $transformer = new NumberToLocalizedStringTransformer(null, true);
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('1234,5');
+    }
+
+    public function testDecimalSeparatorMayBeCommaIfGroupingSeparatorIsCommaButNoGroupingUsed()
+    {
+        $transformer = new NumberToLocalizedStringTransformer();
+
+        $this->assertEquals(1234.5, $transformer->reverseTransform('1234,5'));
+        $this->assertEquals(1234.5, $transformer->reverseTransform('1234.5'));
+    }
+
+    public function testTransformExpectsNumeric()
+    {
+        $transformer = new NumberToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->transform('foo');
+    }
+
+    public function testReverseTransformExpectsString()
+    {
+        $transformer = new NumberToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform(1);
+    }
+
+    public function testReverseTransformExpectsValidNumber()
+    {
+        $transformer = new NumberToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('foo');
+    }
+
+    /**
+     * @see https://github.com/symfony/symfony/issues/3161
+     */
+    public function testReverseTransformDisallowsNaN()
+    {
+        $transformer = new NumberToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('NaN');
+    }
+
+    public function testReverseTransformDisallowsNaN2()
+    {
+        $transformer = new NumberToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('nan');
+    }
+
+    public function testReverseTransformDisallowsInfinity()
+    {
+        $transformer = new NumberToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('∞');
+    }
+
+    public function testReverseTransformDisallowsInfinity2()
+    {
+        $transformer = new NumberToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('∞,123');
+    }
+
+    public function testReverseTransformDisallowsNegativeInfinity()
+    {
+        $transformer = new NumberToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('-∞');
+    }
+
+    public function testReverseTransformDisallowsLeadingExtraCharacters()
+    {
+        $transformer = new NumberToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('foo123');
+    }
+
+    public function testReverseTransformDisallowsCenteredExtraCharacters()
+    {
+        $transformer = new NumberToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+        $this->expectExceptionMessage('The number contains unrecognized characters: "foo3"');
+
+        $transformer->reverseTransform('12foo3');
+    }
+
+    public function testReverseTransformDisallowsCenteredExtraCharactersMultibyte()
+    {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('ru');
+
+        $transformer = new NumberToLocalizedStringTransformer(null, true);
+
+        $this->expectException(TransformationFailedException::class);
+        $this->expectExceptionMessage('The number contains unrecognized characters: "foo8"');
+
+        $transformer->reverseTransform("12\xc2\xa0345,67foo8");
+    }
+
+    public function testReverseTransformIgnoresTrailingSpacesInExceptionMessage()
+    {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('ru');
+
+        $transformer = new NumberToLocalizedStringTransformer(null, true);
+
+        $this->expectException(TransformationFailedException::class);
+        $this->expectExceptionMessage('The number contains unrecognized characters: "foo8"');
+
+        $transformer->reverseTransform("12\xc2\xa0345,67foo8  \xc2\xa0\t");
+    }
+
+    public function testReverseTransformDisallowsTrailingExtraCharacters()
+    {
+        $transformer = new NumberToLocalizedStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+        $this->expectExceptionMessage('The number contains unrecognized characters: "foo"');
+
+        $transformer->reverseTransform('123foo');
+    }
+
+    public function testReverseTransformDisallowsTrailingExtraCharactersMultibyte()
+    {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('ru');
+
+        $transformer = new NumberToLocalizedStringTransformer(null, true);
+
+        $this->expectException(TransformationFailedException::class);
+        $this->expectExceptionMessage('The number contains unrecognized characters: "foo"');
+
+        $transformer->reverseTransform("12\xc2\xa0345,678foo");
+    }
+
+    public function testReverseTransformBigInt()
+    {
+        $transformer = new NumberToLocalizedStringTransformer(null, true);
+
+        $this->assertEquals(PHP_INT_MAX - 1, (int) $transformer->reverseTransform((string) (PHP_INT_MAX - 1)));
+    }
+
+    public function testReverseTransformSmallInt()
+    {
+        $transformer = new NumberToLocalizedStringTransformer(null, true);
+
+        $this->assertSame(1.0, $transformer->reverseTransform('1'));
+    }
+}

--- a/tests/Extension/Core/DataTransformer/NumberToStringTransformerTest.php
+++ b/tests/Extension/Core/DataTransformer/NumberToStringTransformerTest.php
@@ -1,0 +1,378 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Tests\Extension\Core\DataTransformer;
+
+use PHPUnit\Framework\TestCase;
+use Rollerworks\Component\Search\Exception\TransformationFailedException;
+use Rollerworks\Component\Search\Extension\Core\DataTransformer\NumberToStringTransformer;
+
+class NumberToStringTransformerTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        \Locale::setDefault('en');
+    }
+
+    public function provideTransformations()
+    {
+        return [
+            [null, ''],
+            [1, '1'],
+            [1.5, '1.5'],
+            [1234.5, '1234.5'],
+            [12345.912, '12345.912'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideTransformations
+     */
+    public function testTransform($from, string $to)
+    {
+        $transformer = new NumberToStringTransformer();
+
+        $this->assertSame($to, $transformer->transform($from));
+    }
+
+    public function testTransformWithScale()
+    {
+        $transformer = new NumberToStringTransformer(2);
+
+        $this->assertEquals('1234.50', $transformer->transform(1234.5));
+        $this->assertEquals('678.92', $transformer->transform(678.916));
+    }
+
+    public function transformWithRoundingProvider()
+    {
+        return [
+            // towards positive infinity (1.6 -> 2, -1.6 -> -1)
+            [0, 1234.5, '1235', NumberToStringTransformer::ROUND_CEILING],
+            [0, 1234.4, '1235', NumberToStringTransformer::ROUND_CEILING],
+            [0, -1234.5, '-1234', NumberToStringTransformer::ROUND_CEILING],
+            [0, -1234.4, '-1234', NumberToStringTransformer::ROUND_CEILING],
+            [1, 123.45, '123.5', NumberToStringTransformer::ROUND_CEILING],
+            [1, 123.44, '123.5', NumberToStringTransformer::ROUND_CEILING],
+            [1, -123.45, '-123.4', NumberToStringTransformer::ROUND_CEILING],
+            [1, -123.44, '-123.4', NumberToStringTransformer::ROUND_CEILING],
+            // towards negative infinity (1.6 -> 1, -1.6 -> -2)
+            [0, 1234.5, '1234', NumberToStringTransformer::ROUND_FLOOR],
+            [0, 1234.4, '1234', NumberToStringTransformer::ROUND_FLOOR],
+            [0, -1234.5, '-1235', NumberToStringTransformer::ROUND_FLOOR],
+            [0, -1234.4, '-1235', NumberToStringTransformer::ROUND_FLOOR],
+            [1, 123.45, '123.4', NumberToStringTransformer::ROUND_FLOOR],
+            [1, 123.44, '123.4', NumberToStringTransformer::ROUND_FLOOR],
+            [1, -123.45, '-123.5', NumberToStringTransformer::ROUND_FLOOR],
+            [1, -123.44, '-123.5', NumberToStringTransformer::ROUND_FLOOR],
+            // away from zero (1.6 -> 2, -1.6 -> 2)
+            [0, 1234.5, '1235', NumberToStringTransformer::ROUND_UP],
+            [0, 1234.4, '1235', NumberToStringTransformer::ROUND_UP],
+            [0, -1234.5, '-1235', NumberToStringTransformer::ROUND_UP],
+            [0, -1234.4, '-1235', NumberToStringTransformer::ROUND_UP],
+            [1, 123.45, '123.5', NumberToStringTransformer::ROUND_UP],
+            [1, 123.44, '123.5', NumberToStringTransformer::ROUND_UP],
+            [1, -123.45, '-123.5', NumberToStringTransformer::ROUND_UP],
+            [1, -123.44, '-123.5', NumberToStringTransformer::ROUND_UP],
+            // towards zero (1.6 -> 1, -1.6 -> -1)
+            [0, 1234.5, '1234', NumberToStringTransformer::ROUND_DOWN],
+            [0, 1234.4, '1234', NumberToStringTransformer::ROUND_DOWN],
+            [0, -1234.5, '-1234', NumberToStringTransformer::ROUND_DOWN],
+            [0, -1234.4, '-1234', NumberToStringTransformer::ROUND_DOWN],
+            [1, 123.45, '123.4', NumberToStringTransformer::ROUND_DOWN],
+            [1, 123.44, '123.4', NumberToStringTransformer::ROUND_DOWN],
+            [1, -123.45, '-123.4', NumberToStringTransformer::ROUND_DOWN],
+            [1, -123.44, '-123.4', NumberToStringTransformer::ROUND_DOWN],
+            // round halves (.5) to the next even number
+            [0, 1234.6, '1235', NumberToStringTransformer::ROUND_HALF_EVEN],
+            [0, 1234.5, '1234', NumberToStringTransformer::ROUND_HALF_EVEN],
+            [0, 1234.4, '1234', NumberToStringTransformer::ROUND_HALF_EVEN],
+            [0, 1233.5, '1234', NumberToStringTransformer::ROUND_HALF_EVEN],
+            [0, 1232.5, '1232', NumberToStringTransformer::ROUND_HALF_EVEN],
+            [0, -1234.6, '-1235', NumberToStringTransformer::ROUND_HALF_EVEN],
+            [0, -1234.5, '-1234', NumberToStringTransformer::ROUND_HALF_EVEN],
+            [0, -1234.4, '-1234', NumberToStringTransformer::ROUND_HALF_EVEN],
+            [0, -1233.5, '-1234', NumberToStringTransformer::ROUND_HALF_EVEN],
+            [0, -1232.5, '-1232', NumberToStringTransformer::ROUND_HALF_EVEN],
+            [1, 123.46, '123.5', NumberToStringTransformer::ROUND_HALF_EVEN],
+            [1, 123.45, '123.4', NumberToStringTransformer::ROUND_HALF_EVEN],
+            [1, 123.44, '123.4', NumberToStringTransformer::ROUND_HALF_EVEN],
+            [1, 123.35, '123.4', NumberToStringTransformer::ROUND_HALF_EVEN],
+            [1, 123.25, '123.2', NumberToStringTransformer::ROUND_HALF_EVEN],
+            [1, -123.46, '-123.5', NumberToStringTransformer::ROUND_HALF_EVEN],
+            [1, -123.45, '-123.4', NumberToStringTransformer::ROUND_HALF_EVEN],
+            [1, -123.44, '-123.4', NumberToStringTransformer::ROUND_HALF_EVEN],
+            [1, -123.35, '-123.4', NumberToStringTransformer::ROUND_HALF_EVEN],
+            [1, -123.25, '-123.2', NumberToStringTransformer::ROUND_HALF_EVEN],
+            // round halves (.5) away from zero
+            [0, 1234.6, '1235', NumberToStringTransformer::ROUND_HALF_UP],
+            [0, 1234.5, '1235', NumberToStringTransformer::ROUND_HALF_UP],
+            [0, 1234.4, '1234', NumberToStringTransformer::ROUND_HALF_UP],
+            [0, -1234.6, '-1235', NumberToStringTransformer::ROUND_HALF_UP],
+            [0, -1234.5, '-1235', NumberToStringTransformer::ROUND_HALF_UP],
+            [0, -1234.4, '-1234', NumberToStringTransformer::ROUND_HALF_UP],
+            [1, 123.46, '123.5', NumberToStringTransformer::ROUND_HALF_UP],
+            [1, 123.45, '123.5', NumberToStringTransformer::ROUND_HALF_UP],
+            [1, 123.44, '123.4', NumberToStringTransformer::ROUND_HALF_UP],
+            [1, -123.46, '-123.5', NumberToStringTransformer::ROUND_HALF_UP],
+            [1, -123.45, '-123.5', NumberToStringTransformer::ROUND_HALF_UP],
+            [1, -123.44, '-123.4', NumberToStringTransformer::ROUND_HALF_UP],
+            // round halves (.5) towards zero
+            [0, 1234.6, '1235', NumberToStringTransformer::ROUND_HALF_DOWN],
+            [0, 1234.5, '1234', NumberToStringTransformer::ROUND_HALF_DOWN],
+            [0, 1234.4, '1234', NumberToStringTransformer::ROUND_HALF_DOWN],
+            [0, -1234.6, '-1235', NumberToStringTransformer::ROUND_HALF_DOWN],
+            [0, -1234.5, '-1234', NumberToStringTransformer::ROUND_HALF_DOWN],
+            [0, -1234.4, '-1234', NumberToStringTransformer::ROUND_HALF_DOWN],
+            [1, 123.46, '123.5', NumberToStringTransformer::ROUND_HALF_DOWN],
+            [1, 123.45, '123.4', NumberToStringTransformer::ROUND_HALF_DOWN],
+            [1, 123.44, '123.4', NumberToStringTransformer::ROUND_HALF_DOWN],
+            [1, -123.46, '-123.5', NumberToStringTransformer::ROUND_HALF_DOWN],
+            [1, -123.45, '-123.4', NumberToStringTransformer::ROUND_HALF_DOWN],
+            [1, -123.44, '-123.4', NumberToStringTransformer::ROUND_HALF_DOWN],
+        ];
+    }
+
+    /**
+     * @dataProvider transformWithRoundingProvider
+     */
+    public function testTransformWithRounding(int $scale, $input, string $output, int $roundingMode)
+    {
+        $transformer = new NumberToStringTransformer($scale, $roundingMode);
+
+        $this->assertEquals($output, $transformer->transform($input));
+    }
+
+    public function testTransformDoesNotRoundIfNoScale()
+    {
+        $transformer = new NumberToStringTransformer(null, NumberToStringTransformer::ROUND_DOWN);
+
+        $this->assertEquals('1234.547', $transformer->transform(1234.547));
+    }
+
+    /**
+     * @dataProvider provideTransformations
+     */
+    public function testReverseTransform($to, $from)
+    {
+        $transformer = new NumberToStringTransformer();
+
+        $this->assertEquals($to, $transformer->reverseTransform($from));
+    }
+
+    public function reverseTransformWithRoundingProvider()
+    {
+        return [
+            // towards positive infinity (1.6 -> 2, -1.6 -> -1)
+            [0, '1234.5', 1235, NumberToStringTransformer::ROUND_CEILING],
+            [0, '1234.4', 1235, NumberToStringTransformer::ROUND_CEILING],
+            [0, '-1234.5', -1234, NumberToStringTransformer::ROUND_CEILING],
+            [0, '-1234.4', -1234, NumberToStringTransformer::ROUND_CEILING],
+            [1, '123.45', 123.5, NumberToStringTransformer::ROUND_CEILING],
+            [1, '123.44', 123.5, NumberToStringTransformer::ROUND_CEILING],
+            [1, '-123.45', -123.4, NumberToStringTransformer::ROUND_CEILING],
+            [1, '-123.44', -123.4, NumberToStringTransformer::ROUND_CEILING],
+            // towards negative infinity (1.6 -> 1, -1.6 -> -2)
+            [0, '1234.5', 1234, NumberToStringTransformer::ROUND_FLOOR],
+            [0, '1234.4', 1234, NumberToStringTransformer::ROUND_FLOOR],
+            [0, '-1234.5', -1235, NumberToStringTransformer::ROUND_FLOOR],
+            [0, '-1234.4', -1235, NumberToStringTransformer::ROUND_FLOOR],
+            [1, '123.45', 123.4, NumberToStringTransformer::ROUND_FLOOR],
+            [1, '123.44', 123.4, NumberToStringTransformer::ROUND_FLOOR],
+            [1, '-123.45', -123.5, NumberToStringTransformer::ROUND_FLOOR],
+            [1, '-123.44', -123.5, NumberToStringTransformer::ROUND_FLOOR],
+            // away from zero (1.6 -> 2, -1.6 -> 2)
+            [0, '1234.5', 1235, NumberToStringTransformer::ROUND_UP],
+            [0, '1234.4', 1235, NumberToStringTransformer::ROUND_UP],
+            [0, '-1234.5', -1235, NumberToStringTransformer::ROUND_UP],
+            [0, '-1234.4', -1235, NumberToStringTransformer::ROUND_UP],
+            [1, '123.45', 123.5, NumberToStringTransformer::ROUND_UP],
+            [1, '123.44', 123.5, NumberToStringTransformer::ROUND_UP],
+            [1, '-123.45', -123.5, NumberToStringTransformer::ROUND_UP],
+            [1, '-123.44', -123.5, NumberToStringTransformer::ROUND_UP],
+            // towards zero (1.6 -> 1, -1.6 -> -1)
+            [0, '1234.5', 1234, NumberToStringTransformer::ROUND_DOWN],
+            [0, '1234.4', 1234, NumberToStringTransformer::ROUND_DOWN],
+            [0, '-1234.5', -1234, NumberToStringTransformer::ROUND_DOWN],
+            [0, '-1234.4', -1234, NumberToStringTransformer::ROUND_DOWN],
+            [1, '123.45', 123.4, NumberToStringTransformer::ROUND_DOWN],
+            [1, '123.44', 123.4, NumberToStringTransformer::ROUND_DOWN],
+            [1, '-123.45', -123.4, NumberToStringTransformer::ROUND_DOWN],
+            [1, '-123.44', -123.4, NumberToStringTransformer::ROUND_DOWN],
+            // round halves (.5) to the next even number
+            [0, '1234.6', 1235, NumberToStringTransformer::ROUND_HALF_EVEN],
+            [0, '1234.5', 1234, NumberToStringTransformer::ROUND_HALF_EVEN],
+            [0, '1234.4', 1234, NumberToStringTransformer::ROUND_HALF_EVEN],
+            [0, '1233.5', 1234, NumberToStringTransformer::ROUND_HALF_EVEN],
+            [0, '1232.5', 1232, NumberToStringTransformer::ROUND_HALF_EVEN],
+            [0, '-1234.6', -1235, NumberToStringTransformer::ROUND_HALF_EVEN],
+            [0, '-1234.5', -1234, NumberToStringTransformer::ROUND_HALF_EVEN],
+            [0, '-1234.4', -1234, NumberToStringTransformer::ROUND_HALF_EVEN],
+            [0, '-1233.5', -1234, NumberToStringTransformer::ROUND_HALF_EVEN],
+            [0, '-1232.5', -1232, NumberToStringTransformer::ROUND_HALF_EVEN],
+            [1, '123.46', 123.5, NumberToStringTransformer::ROUND_HALF_EVEN],
+            [1, '123.45', 123.4, NumberToStringTransformer::ROUND_HALF_EVEN],
+            [1, '123.44', 123.4, NumberToStringTransformer::ROUND_HALF_EVEN],
+            [1, '123.35', 123.4, NumberToStringTransformer::ROUND_HALF_EVEN],
+            [1, '123.25', 123.2, NumberToStringTransformer::ROUND_HALF_EVEN],
+            [1, '-123.46', -123.5, NumberToStringTransformer::ROUND_HALF_EVEN],
+            [1, '-123.45', -123.4, NumberToStringTransformer::ROUND_HALF_EVEN],
+            [1, '-123.44', -123.4, NumberToStringTransformer::ROUND_HALF_EVEN],
+            [1, '-123.35', -123.4, NumberToStringTransformer::ROUND_HALF_EVEN],
+            [1, '-123.25', -123.2, NumberToStringTransformer::ROUND_HALF_EVEN],
+            // round halves (.5) away from zero
+            [0, '1234.6', 1235, NumberToStringTransformer::ROUND_HALF_UP],
+            [0, '1234.5', 1235, NumberToStringTransformer::ROUND_HALF_UP],
+            [0, '1234.4', 1234, NumberToStringTransformer::ROUND_HALF_UP],
+            [0, '-1234.6', -1235, NumberToStringTransformer::ROUND_HALF_UP],
+            [0, '-1234.5', -1235, NumberToStringTransformer::ROUND_HALF_UP],
+            [0, '-1234.4', -1234, NumberToStringTransformer::ROUND_HALF_UP],
+            [1, '123.46', 123.5, NumberToStringTransformer::ROUND_HALF_UP],
+            [1, '123.45', 123.5, NumberToStringTransformer::ROUND_HALF_UP],
+            [1, '123.44', 123.4, NumberToStringTransformer::ROUND_HALF_UP],
+            [1, '-123.46', -123.5, NumberToStringTransformer::ROUND_HALF_UP],
+            [1, '-123.45', -123.5, NumberToStringTransformer::ROUND_HALF_UP],
+            [1, '-123.44', -123.4, NumberToStringTransformer::ROUND_HALF_UP],
+            // round halves (.5) towards zero
+            [0, '1234.6', 1235, NumberToStringTransformer::ROUND_HALF_DOWN],
+            [0, '1234.5', 1234, NumberToStringTransformer::ROUND_HALF_DOWN],
+            [0, '1234.4', 1234, NumberToStringTransformer::ROUND_HALF_DOWN],
+            [0, '-1234.6', -1235, NumberToStringTransformer::ROUND_HALF_DOWN],
+            [0, '-1234.5', -1234, NumberToStringTransformer::ROUND_HALF_DOWN],
+            [0, '-1234.4', -1234, NumberToStringTransformer::ROUND_HALF_DOWN],
+            [1, '123.46', 123.5, NumberToStringTransformer::ROUND_HALF_DOWN],
+            [1, '123.45', 123.4, NumberToStringTransformer::ROUND_HALF_DOWN],
+            [1, '123.44', 123.4, NumberToStringTransformer::ROUND_HALF_DOWN],
+            [1, '-123.46', -123.5, NumberToStringTransformer::ROUND_HALF_DOWN],
+            [1, '-123.45', -123.4, NumberToStringTransformer::ROUND_HALF_DOWN],
+            [1, '-123.44', -123.4, NumberToStringTransformer::ROUND_HALF_DOWN],
+        ];
+    }
+
+    /**
+     * @dataProvider reverseTransformWithRoundingProvider
+     */
+    public function testReverseTransformWithRounding(int $scale, string $input, $output, int $roundingMode)
+    {
+        $transformer = new NumberToStringTransformer($scale, $roundingMode);
+
+        $this->assertEquals($output, $transformer->reverseTransform($input));
+    }
+
+    public function testReverseTransformDoesNotRoundIfNoScale()
+    {
+        $transformer = new NumberToStringTransformer(null, NumberToStringTransformer::ROUND_DOWN);
+
+        $this->assertEquals(1234.547, $transformer->reverseTransform('1234.547'));
+    }
+
+    public function testTransformExpectsNumeric()
+    {
+        $transformer = new NumberToStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->transform('foo');
+    }
+
+    public function testReverseTransformExpectsScalar()
+    {
+        $transformer = new NumberToStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform(['1']);
+    }
+
+    public function testReverseTransformExpectsValidNumber()
+    {
+        $transformer = new NumberToStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('foo');
+    }
+
+    /**
+     * @see https://github.com/symfony/symfony/issues/3161
+     */
+    public function testReverseTransformDisallowsNaN()
+    {
+        $transformer = new NumberToStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('NaN');
+    }
+
+    public function testReverseTransformDisallowsNaN2()
+    {
+        $transformer = new NumberToStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('nan');
+    }
+
+    public function testReverseTransformDisallowsInfinity()
+    {
+        $transformer = new NumberToStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('∞');
+    }
+
+    public function testReverseTransformDisallowsInfinity2()
+    {
+        $transformer = new NumberToStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('∞,123');
+    }
+
+    public function testReverseTransformDisallowsNegativeInfinity()
+    {
+        $transformer = new NumberToStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('-∞');
+    }
+
+    public function testReverseTransformDisallowsLeadingExtraCharacters()
+    {
+        $transformer = new NumberToStringTransformer();
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('foo123');
+    }
+
+    public function testReverseTransformBigInt()
+    {
+        $transformer = new NumberToStringTransformer();
+
+        $this->assertEquals(PHP_INT_MAX - 1, (int) $transformer->reverseTransform((string) (PHP_INT_MAX - 1)));
+    }
+
+    public function testReverseTransformSmallInt()
+    {
+        $transformer = new NumberToStringTransformer();
+
+        $this->assertSame(1.0, $transformer->reverseTransform('1.0'));
+        $this->assertSame(1, $transformer->reverseTransform('1'));
+    }
+}

--- a/tests/Extension/Core/Type/BirthdayTypeTest.php
+++ b/tests/Extension/Core/Type/BirthdayTypeTest.php
@@ -22,14 +22,14 @@ class BirthdayTypeTest extends SearchIntegrationTestCase
     public function testDateOnlyInput()
     {
         $field = $this->getFactory()->createField('birthday', BirthdayType::class, [
-            'format' => 'yyyy-MM-dd',
+            'pattern' => 'yyyy-MM-dd',
             'allow_age' => false,
         ]);
 
         FieldTransformationAssertion::assertThat($field)
             ->withInput('2010-06-02', '2010-06-02')
             ->successfullyTransformsTo(new \DateTime('2010-06-02'))
-            ->andReverseTransformsTo('2010-06-02', '2010-06-02T00:00:00Z');
+            ->andReverseTransformsTo('2010-06-02', '2010-06-02');
 
         FieldTransformationAssertion::assertThat($field)
             ->withInput('21')
@@ -39,13 +39,13 @@ class BirthdayTypeTest extends SearchIntegrationTestCase
     public function testAllowAgeInput()
     {
         $field = $this->getFactory()->createField('birthday', BirthdayType::class, [
-            'format' => 'yyyy-MM-dd',
+            'pattern' => 'yyyy-MM-dd',
         ]);
 
         FieldTransformationAssertion::assertThat($field)
             ->withInput('2010-06-02', '2010-06-02')
             ->successfullyTransformsTo(new \DateTime('2010-06-02'))
-            ->andReverseTransformsTo('2010-06-02', '2010-06-02T00:00:00Z');
+            ->andReverseTransformsTo('2010-06-02', '2010-06-02');
 
         FieldTransformationAssertion::assertThat($field)
             ->withInput('15')
@@ -67,7 +67,7 @@ class BirthdayTypeTest extends SearchIntegrationTestCase
     public function testAgeInTheFutureFails()
     {
         $field = $this->getFactory()->createField('birthday', BirthdayType::class, [
-            'format' => 'yyyy-MM-dd',
+            'pattern' => 'yyyy-MM-dd',
         ]);
 
         $currentDate = new \DateTime('now + 1 day', new \DateTimeZone('UTC'));
@@ -78,7 +78,7 @@ class BirthdayTypeTest extends SearchIntegrationTestCase
     public function testAgeInFutureWorksWhenAllowed()
     {
         $field = $this->getFactory()->createField('birthday', BirthdayType::class, [
-            'format' => 'yyyy-MM-dd',
+            'pattern' => 'yyyy-MM-dd',
             'allow_future_date' => true,
         ]);
 
@@ -88,9 +88,6 @@ class BirthdayTypeTest extends SearchIntegrationTestCase
         FieldTransformationAssertion::assertThat($field)
             ->withInput($currentDate->format('Y-m-d'))
             ->successfullyTransformsTo($currentDate)
-            ->andReverseTransformsTo(
-                $currentDate->format('Y-m-d'),
-                preg_replace('/\+00:00$/', 'Z', $currentDate->format('c'))
-            );
+            ->andReverseTransformsTo($currentDate->format('Y-m-d'));
     }
 }

--- a/tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -101,7 +101,7 @@ class DateTimeTypeTest extends SearchIntegrationTestCase
 
     protected function setUp()
     {
-        IntlTestHelper::requireIntl($this);
+        IntlTestHelper::requireIntl($this, '58.1');
 
         parent::setUp();
     }

--- a/tests/Extension/Core/Type/DateTypeTest.php
+++ b/tests/Extension/Core/Type/DateTypeTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Tests\Extension\Core\Type;
+
+use Rollerworks\Component\Search\Extension\Core\Type\DateType;
+use Rollerworks\Component\Search\Test\FieldTransformationAssertion;
+use Rollerworks\Component\Search\Test\SearchIntegrationTestCase;
+use Symfony\Component\Intl\Util\IntlTestHelper;
+
+class DateTypeTest extends SearchIntegrationTestCase
+{
+    public function testPatternCanBeConfigured()
+    {
+        $field = $this->getFactory()->createField('datetime', DateType::class, [
+            'pattern' => 'MM*yyyy*dd',
+        ]);
+
+        $outputTime = new \DateTime('2010-06-02T00:00:00.000000+0000');
+
+        FieldTransformationAssertion::assertThat($field)
+            ->withInput($outputTime->format('m*Y*d'), $outputTime->format('Y-m-d'))
+            ->successfullyTransformsTo($outputTime)
+            ->andReverseTransformsTo('06*2010*02', '2010-06-02');
+    }
+
+    public function testInvalidInputShouldFailTransformation()
+    {
+        $field = $this->getFactory()->createField('datetime', DateType::class, [
+            'pattern' => 'MM-yyyy-dd',
+        ]);
+
+        FieldTransformationAssertion::assertThat($field)
+            ->withInput('06*2010*02', '2010-06-02')
+            ->failsToTransforms();
+
+        FieldTransformationAssertion::assertThat($field)
+            ->withInput('06-2010-02', '2010-06*02')
+            ->failsToTransforms();
+    }
+
+    public function testViewIsConfiguredProperlyWithoutExplicitPattern()
+    {
+        $field = $this->getFactory()->createField('datetime', DateType::class, [
+            'format' => \IntlDateFormatter::SHORT,
+        ]);
+
+        $field->finalizeConfig();
+        $fieldView = $field->createView();
+
+        self::assertArrayHasKey('timezone', $fieldView->vars);
+        self::assertArrayHasKey('pattern', $fieldView->vars);
+
+        self::assertEquals(date_default_timezone_get(), $fieldView->vars['timezone']);
+        self::assertEquals('M/d/yy', $fieldView->vars['pattern']);
+    }
+
+    public function testViewIsConfiguredProperly()
+    {
+        $field = $this->getFactory()->createField('datetime', DateType::class, [
+            'pattern' => 'MM-yyyy-dd',
+        ]);
+
+        $field->finalizeConfig();
+        $fieldView = $field->createView();
+
+        self::assertArrayHasKey('timezone', $fieldView->vars);
+        self::assertArrayHasKey('pattern', $fieldView->vars);
+
+        self::assertEquals(date_default_timezone_get(), $fieldView->vars['timezone']);
+        self::assertEquals('MM-yyyy-dd', $fieldView->vars['pattern']);
+    }
+
+    protected function setUp()
+    {
+        IntlTestHelper::requireIntl($this, '58.1');
+
+        parent::setUp();
+    }
+}

--- a/tests/Extension/Core/Type/MoneyTypeTest.php
+++ b/tests/Extension/Core/Type/MoneyTypeTest.php
@@ -25,7 +25,7 @@ class MoneyTypeTest extends SearchIntegrationTestCase
     {
         // we test against different locales, so we need the full
         // implementation
-        // IntlTestHelper::requireFullIntl($this);
+        IntlTestHelper::requireFullIntl($this, '58.1');
 
         parent::setUp();
     }
@@ -37,14 +37,14 @@ class MoneyTypeTest extends SearchIntegrationTestCase
         $field = $this->getFactory()->createField('money', MoneyType::class);
 
         FieldTransformationAssertion::assertThat($field)
-            ->withInput('€ 12,00', '€12.00')
-            ->successfullyTransformsTo(new MoneyValue('EUR', '12.00'))
-            ->andReverseTransformsTo('€ 12,00', '€12.00');
+            ->withInput('€ 12,20', 'EUR 12.20')
+            ->successfullyTransformsTo(new MoneyValue('EUR', '12.20'))
+            ->andReverseTransformsTo('€ 12,20', 'EUR 12.2');
 
         FieldTransformationAssertion::assertThat($field)
-            ->withInput('12,00')
+            ->withInput('12,00', '12.00')
             ->successfullyTransformsTo(new MoneyValue('EUR', '12.00'))
-            ->andReverseTransformsTo('€ 12,00', '€12.00');
+            ->andReverseTransformsTo('€ 12,00', 'EUR 12');
     }
 
     public function testPassMoneyDe()
@@ -54,14 +54,14 @@ class MoneyTypeTest extends SearchIntegrationTestCase
         $field = $this->getFactory()->createField('money', MoneyType::class);
 
         FieldTransformationAssertion::assertThat($field)
-            ->withInput('12,00 €', '€12.00')
+            ->withInput('12,00 €', 'EUR 12.00')
             ->successfullyTransformsTo(new MoneyValue('EUR', '12.00'))
-            ->andReverseTransformsTo('12,00 €', '€12.00');
+            ->andReverseTransformsTo('12,00 €', 'EUR 12');
 
         FieldTransformationAssertion::assertThat($field)
             ->withInput('12,00', '12.00')
             ->successfullyTransformsTo(new MoneyValue('EUR', '12.00'))
-            ->andReverseTransformsTo('12,00 €', '€12.00');
+            ->andReverseTransformsTo('12,00 €', 'EUR 12');
     }
 
     public function testMoneyPatternWorksForYen()
@@ -71,24 +71,24 @@ class MoneyTypeTest extends SearchIntegrationTestCase
         $field = $this->getFactory()->createField('money', MoneyType::class, ['default_currency' => 'JPY']);
 
         FieldTransformationAssertion::assertThat($field)
-            ->withInput('¥12,00')
+            ->withInput('¥12,00', 'JPY 12.00')
             ->successfullyTransformsTo(new MoneyValue('JPY', '12.00'))
-            ->andReverseTransformsTo('¥12', '¥12');
+            ->andReverseTransformsTo('¥12', 'JPY 12');
 
         FieldTransformationAssertion::assertThat($field)
-            ->withInput('¥12')
+            ->withInput('¥12', 'JPY 12')
             ->successfullyTransformsTo(new MoneyValue('JPY', '12.00'))
-            ->andReverseTransformsTo('¥12', '¥12');
+            ->andReverseTransformsTo('¥12', 'JPY 12');
 
         FieldTransformationAssertion::assertThat($field)
-            ->withInput('12')
+            ->withInput('12', '12.00')
             ->successfullyTransformsTo(new MoneyValue('JPY', '12.00'))
-            ->andReverseTransformsTo('¥12', '¥12');
+            ->andReverseTransformsTo('¥12', 'JPY 12');
 
         FieldTransformationAssertion::assertThat($field)
-            ->withInput('€12.00')
+            ->withInput('€12.00', 'EUR 12.00')
             ->successfullyTransformsTo(new MoneyValue('EUR', '12.00'))
-            ->andReverseTransformsTo('€12.00', '€12.00');
+            ->andReverseTransformsTo('€12.00', 'EUR 12');
     }
 
     public function testViewIsConfiguredProperly()

--- a/tests/Extension/Core/Type/NumberTypeTest.php
+++ b/tests/Extension/Core/Type/NumberTypeTest.php
@@ -61,12 +61,29 @@ class NumberTypeTest extends SearchIntegrationTestCase
         FieldTransformationAssertion::assertThat($field)
             ->withInput('12345,67890', '12345.67890')
             ->successfullyTransformsTo('12345.67890')
-            ->andReverseTransformsTo('12345,679', '12345.679');
+            ->andReverseTransformsTo('12345,679', '12345.67890');
 
         FieldTransformationAssertion::assertThat($field)
             ->withInput('12345,679', '12345.679')
             ->successfullyTransformsTo('12345.679')
             ->andReverseTransformsTo('12345,679', '12345.679');
+    }
+
+    public function testNonWesternFormatting()
+    {
+        \Locale::setDefault('ar');
+
+        $field = $this->getFactory()->createField('number', NumberType::class);
+
+        FieldTransformationAssertion::assertThat($field)
+            ->withInput('١٢٣٤٥٫٦٧٨٩٠', '12345.67890')
+            ->successfullyTransformsTo('12345.6789')
+            ->andReverseTransformsTo('١٢٣٤٥٫٦٧٩', '12345.6789');
+
+        FieldTransformationAssertion::assertThat($field)
+            ->withInput('١٢٣٤٥٫٦٧٩', '12345.679')
+            ->successfullyTransformsTo('12345.679')
+            ->andReverseTransformsTo('١٢٣٤٥٫٦٧٩', '12345.679');
     }
 
     public function testDefaultFormattingWithGrouping()
@@ -76,12 +93,12 @@ class NumberTypeTest extends SearchIntegrationTestCase
         FieldTransformationAssertion::assertThat($field)
             ->withInput('12.345,679', '12345.679')
             ->successfullyTransformsTo('12345.679')
-            ->andReverseTransformsTo('12.345,679', '12,345.679');
+            ->andReverseTransformsTo('12.345,679', '12345.679');
 
         FieldTransformationAssertion::assertThat($field)
             ->withInput('12345,679', '12345.679')
             ->successfullyTransformsTo('12345.679')
-            ->andReverseTransformsTo('12.345,679', '12,345.679');
+            ->andReverseTransformsTo('12.345,679', '12345.679');
     }
 
     public function testDefaultFormattingWithPrecision()
@@ -137,7 +154,7 @@ class NumberTypeTest extends SearchIntegrationTestCase
         parent::setUp();
 
         // we test against "de_DE", so we need the full implementation
-        IntlTestHelper::requireFullIntl($this);
+        IntlTestHelper::requireFullIntl($this, '58.1');
 
         \Locale::setDefault('de_DE');
     }

--- a/tests/Extension/Core/Type/TimeTypeTest.php
+++ b/tests/Extension/Core/Type/TimeTypeTest.php
@@ -24,7 +24,7 @@ class TimeTypeTest extends SearchIntegrationTestCase
 
     protected function setUp()
     {
-        IntlTestHelper::requireIntl($this);
+        IntlTestHelper::requireIntl($this, '58.1');
 
         parent::setUp();
 

--- a/tests/Extension/Core/Type/TimestampTypeTest.php
+++ b/tests/Extension/Core/Type/TimestampTypeTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Tests\Extension\Core\Type;
+
+use Rollerworks\Component\Search\Extension\Core\Type\TimestampType;
+use Rollerworks\Component\Search\Test\FieldTransformationAssertion;
+use Rollerworks\Component\Search\Test\SearchIntegrationTestCase;
+
+class TimestampTypeTest extends SearchIntegrationTestCase
+{
+    public function testTransformWithDifferentTimezones()
+    {
+        $field = $this->getFactory()->createField('datetime', TimestampType::class, [
+            'model_timezone' => 'Asia/Hong_Kong',
+            'view_timezone' => 'America/New_York',
+        ]);
+
+        $output = new \DateTime('2010-02-03 04:05:06 America/New_York');
+        $input = $output->format('U');
+
+        $output->setTimezone(new \DateTimeZone('Asia/Hong_Kong'));
+
+        FieldTransformationAssertion::assertThat($field)
+            ->withInput($input)
+            ->successfullyTransformsTo($output)
+            ->andReverseTransformsTo($input);
+    }
+
+    public function testInvalidInputShouldFailTransformation()
+    {
+        $field = $this->getFactory()->createField('datetime', TimestampType::class);
+
+        FieldTransformationAssertion::assertThat($field)
+            ->withInput('06*2010*02', '06*2010*02')
+            ->failsToTransforms();
+    }
+}

--- a/tests/Input/InputProcessorTestCase.php
+++ b/tests/Input/InputProcessorTestCase.php
@@ -48,7 +48,7 @@ abstract class InputProcessorTestCase extends SearchIntegrationTestCase
         $fieldSet->add('id', IntegerType::class);
         $fieldSet->add('name', TextType::class);
         $fieldSet->add('lastname', TextType::class);
-        $fieldSet->add('date', DateType::class, ['format' => 'MM-dd-yyyy']);
+        $fieldSet->add('date', DateType::class, ['pattern' => 'MM-dd-yyyy']);
         $fieldSet->set(
             $this->getFactory()->createField('no-range-field', IntegerType::class)
                 ->setValueTypeSupport(Range::class, false)

--- a/tests/assertDateTimeEqualsTrait.php
+++ b/tests/assertDateTimeEqualsTrait.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Tests;
+
+trait assertDateTimeEqualsTrait
+{
+    public static function assertDateTimeEquals(\DateTimeInterface $expected, \DateTimeInterface $actual)
+    {
+        \PHPUnit_Framework_Assert::assertEquals(
+            $expected->format('U'),
+            $actual->format('U'),
+            $expected->format('c').' <=> '.$actual->format('c')
+        );
+    }
+}


### PR DESCRIPTION
[BC BREAK] The `precision` option of the IntegerType is removed, this is not possible with integer.

This is a work in progress, I'm not satisfied with the testing coverage of DataTransformers and plan to increase this to an acceptable number.

Todo:

- [x] NumberToStringTransformerTest
- [x] NumberToLocalizedStringTransformerTest
- [x] LocalizedBirthdayTransformer
- [x] IntegerToStringTransformerTest
- [x] IntegerToLocalizedStringTransformerTest