### PR TITLE
Fix MoneyType precision related problems

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "symfony/property-access": "^3.0",
         "symfony/intl": "^3.0",
         "seld/jsonlint": "^1.3.1",
-        "doctrine/lexer": "^1.0.1"
+        "doctrine/lexer": "^1.0.1",
+        "moneyphp/money": "^3.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7.2",

--- a/src/Extension/Core/DataTransformer/BaseNumberTransformer.php
+++ b/src/Extension/Core/DataTransformer/BaseNumberTransformer.php
@@ -90,11 +90,6 @@ abstract class BaseNumberTransformer implements DataTransformerInterface
     protected $roundingMode;
 
     /**
-     * @var int
-     */
-    protected $type;
-
-    /**
      * Rounds a number according to the configured scale and rounding mode.
      *
      * @param int|float $number A number

--- a/src/Extension/Core/DataTransformer/NumberToStringTransformer.php
+++ b/src/Extension/Core/DataTransformer/NumberToStringTransformer.php
@@ -18,8 +18,6 @@ use Rollerworks\Component\Search\Exception\TransformationFailedException;
 /**
  * Transforms between a number type and a number with rounding.
  *
- * @author Bernhard Schussek <bschussek@gmail.com>
- * @author Florian Eckerstorfer <florian@eckerstorfer.org>
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
 class NumberToStringTransformer extends BaseNumberTransformer
@@ -33,7 +31,6 @@ class NumberToStringTransformer extends BaseNumberTransformer
     {
         $this->scale = $scale;
         $this->roundingMode = $roundingMode ?? self::ROUND_HALF_UP;
-        $this->type = $type;
     }
 
     /**
@@ -66,15 +63,14 @@ class NumberToStringTransformer extends BaseNumberTransformer
     /**
      * Transforms a normalized number into an integer or float.
      *
-     * @param string $value    The localized value
-     * @param string $currency The parsed currency value
+     * @param string $value The localized value
      *
      * @throws TransformationFailedException If the given value is not a string
      *                                       or if the value can not be transformed
      *
      * @return int|float|null The numeric value
      */
-    public function reverseTransform($value, &$currency = null)
+    public function reverseTransform($value)
     {
         if (!is_scalar($value)) {
             throw new TransformationFailedException('Expected a scalar.');
@@ -84,18 +80,7 @@ class NumberToStringTransformer extends BaseNumberTransformer
             return null;
         }
 
-        $currency = false;
         $result = $value;
-
-        if (\NumberFormatter::TYPE_CURRENCY === $this->type && false !== strpos($value, ' ')) {
-            list($currency, $result) = explode(' ', $value, 2);
-
-            if (strlen($currency) !== 3) {
-                throw new TransformationFailedException(
-                    sprintf('Value does not contain a valid 3 character currency code, got "%s".', $currency)
-                );
-            }
-        }
 
         if (!is_numeric($result)) {
             throw new TransformationFailedException('Value is not numeric.');

--- a/src/Extension/Core/Model/MoneyValue.php
+++ b/src/Extension/Core/Model/MoneyValue.php
@@ -13,30 +13,33 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Extension\Core\Model;
 
+use Money\Money;
+
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
 class MoneyValue
 {
     /**
-     * @var string
-     */
-    public $currency;
-
-    /**
-     * @var float|string
+     * @var Money
      */
     public $value;
 
     /**
+     * @var bool
+     */
+    public $withCurrency;
+
+    /**
      * Constructor.
      *
-     * @param string       $currency
-     * @param float|string $value
+     * @param Money $value
+     * @param bool  $withCurrency Indicate the input was provided with a currency.
+     *                            This is only used for exporting
      */
-    public function __construct($currency, $value)
+    public function __construct(Money $value, bool $withCurrency = true)
     {
-        $this->currency = $currency;
+        $this->withCurrency = $withCurrency;
         $this->value = $value;
     }
 }

--- a/src/Extension/Core/Type/MoneyType.php
+++ b/src/Extension/Core/Type/MoneyType.php
@@ -54,21 +54,13 @@ class MoneyType extends AbstractFieldType
 
         $config->setViewTransformer(
             new MoneyToLocalizedStringTransformer(
-                $options['precision'],
-                $options['grouping'],
-                null,
-                $options['divisor'],
-                $options['default_currency']
+                $options['default_currency'],
+                $options['grouping']
             )
         );
 
         $config->setNormTransformer(
-            new MoneyToStringTransformer(
-                $options['precision'],
-                null,
-                $options['divisor'],
-                $options['default_currency']
-            )
+            new MoneyToStringTransformer($options['default_currency'])
         );
     }
 
@@ -77,10 +69,9 @@ class MoneyType extends AbstractFieldType
      */
     public function buildView(SearchFieldView $view, FieldConfigInterface $config, array $options)
     {
-        $view->vars['precision'] = $options['precision'];
         $view->vars['grouping'] = $options['grouping'];
-        $view->vars['divisor'] = $options['divisor'];
         $view->vars['default_currency'] = $options['default_currency'];
+        $view->vars['increase_by'] = $options['increase_by'];
     }
 
     /**
@@ -90,11 +81,12 @@ class MoneyType extends AbstractFieldType
     {
         $resolver->setDefaults(
             [
-                'precision' => 2,
                 'grouping' => false,
-                'divisor' => 1,
                 'default_currency' => 'EUR',
+                'increase_by' => 'cents',
             ]
         );
+
+        $resolver->setAllowedValues('increase_by', ['cents', 'amount']);
     }
 }

--- a/tests/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformerTest.php
+++ b/tests/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformerTest.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Tests\Extension\Core\DataTransformer;
 
+use Money\Currencies\ISOCurrencies;
+use Money\Parser\DecimalMoneyParser;
 use PHPUnit\Framework\TestCase;
 use Rollerworks\Component\Search\Exception\TransformationFailedException;
 use Rollerworks\Component\Search\Extension\Core\DataTransformer\MoneyToLocalizedStringTransformer;
@@ -26,6 +28,18 @@ class MoneyToLocalizedStringTransformerTest extends TestCase
         parent::setUp();
 
         \Locale::setDefault('en');
+    }
+
+    private function parseMoneyAsDecimal($input, string $currency = 'EUR')
+    {
+        static $moneyParser;
+
+        if (!$moneyParser) {
+            $currencies = new ISOCurrencies();
+            $moneyParser = new DecimalMoneyParser($currencies);
+        }
+
+        return $moneyParser->parse((string) $input, $currency);
     }
 
     public function provideTransformations()
@@ -51,13 +65,48 @@ class MoneyToLocalizedStringTransformerTest extends TestCase
 
         \Locale::setDefault($locale);
 
-        $transformer = new MoneyToLocalizedStringTransformer(null, null, null, null, 'EUR');
+        $transformer = new MoneyToLocalizedStringTransformer('EUR');
 
         if (null !== $from) {
-            $from = new MoneyValue('EUR', $from);
+            $from = new MoneyValue($this->parseMoneyAsDecimal($from));
         }
 
-        $this->assertEquals($to, $transformer->transform($from));
+        self::assertEquals($to, $transformer->transform($from));
+    }
+
+    /**
+     * @dataProvider provideTransformations
+     */
+    public function testTransformWithoutCurrency($from, $to, $locale)
+    {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault($locale);
+
+        $transformer = new MoneyToLocalizedStringTransformer('EUR');
+
+        if (null !== $from) {
+            $from = new MoneyValue($this->parseMoneyAsDecimal($from), false);
+        }
+
+        $to = preg_replace('#(\s?\p{Sc}\s?)#u', '', $to);
+
+        self::assertEquals($to, $transformer->transform($from));
+    }
+
+    public function testTransformWithoutCurrencyAndDifferentDefaultCurrency()
+    {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('de_DE');
+
+        $transformer = new MoneyToLocalizedStringTransformer('EUR');
+
+        $from = new MoneyValue($this->parseMoneyAsDecimal(1234.5, 'USD'), false);
+
+        self::assertEquals('1234,50', $transformer->transform($from));
     }
 
     public function provideTransformationsWithGrouping()
@@ -81,140 +130,10 @@ class MoneyToLocalizedStringTransformerTest extends TestCase
 
         \Locale::setDefault($locale);
 
-        $transformer = new MoneyToLocalizedStringTransformer(null, true, null, null, 'EUR');
+        $transformer = new MoneyToLocalizedStringTransformer('EUR', true);
 
-        $from = new MoneyValue('EUR', $from);
-        $this->assertEquals($to, $transformer->transform($from));
-    }
-
-    public function testTransformWithScale()
-    {
-        // Since we test against "de_AT", we need the full implementation
-        IntlTestHelper::requireFullIntl($this, '58.1');
-
-        \Locale::setDefault('de_AT');
-
-        $transformer = new MoneyToLocalizedStringTransformer(2, null, null, null, 'EUR');
-
-        $this->assertEquals('€ 1234,50', $transformer->transform(new MoneyValue('EUR', 1234.5)));
-        $this->assertEquals('€ 678,92', $transformer->transform(new MoneyValue('EUR', 678.916)));
-    }
-
-    public function transformWithRoundingProvider()
-    {
-        return [
-            // towards positive infinity (1.6 -> 2, -1.6 -> -1)
-            [0, 1234.5, '€ 1235', MoneyToLocalizedStringTransformer::ROUND_CEILING],
-            [0, 1234.4, '€ 1235', MoneyToLocalizedStringTransformer::ROUND_CEILING],
-            [0, -1234.5, '-€ 1234', MoneyToLocalizedStringTransformer::ROUND_CEILING],
-            [0, -1234.4, '-€ 1234', MoneyToLocalizedStringTransformer::ROUND_CEILING],
-            [1, 123.45, '€ 123,5', MoneyToLocalizedStringTransformer::ROUND_CEILING],
-            [1, 123.44, '€ 123,5', MoneyToLocalizedStringTransformer::ROUND_CEILING],
-            [1, -123.45, '-€ 123,4', MoneyToLocalizedStringTransformer::ROUND_CEILING],
-            [1, -123.44, '-€ 123,4', MoneyToLocalizedStringTransformer::ROUND_CEILING],
-            // towards negative infinity (1.6 -> 1, -1.6 -> -2)
-            [0, 1234.5, '€ 1234', MoneyToLocalizedStringTransformer::ROUND_FLOOR],
-            [0, 1234.4, '€ 1234', MoneyToLocalizedStringTransformer::ROUND_FLOOR],
-            [0, -1234.5, '-€ 1235', MoneyToLocalizedStringTransformer::ROUND_FLOOR],
-            [0, -1234.4, '-€ 1235', MoneyToLocalizedStringTransformer::ROUND_FLOOR],
-            [1, 123.45, '€ 123,4', MoneyToLocalizedStringTransformer::ROUND_FLOOR],
-            [1, 123.44, '€ 123,4', MoneyToLocalizedStringTransformer::ROUND_FLOOR],
-            [1, -123.45, '-€ 123,5', MoneyToLocalizedStringTransformer::ROUND_FLOOR],
-            [1, -123.44, '-€ 123,5', MoneyToLocalizedStringTransformer::ROUND_FLOOR],
-            // away from zero (1.6 -> 2, -1.6 -> 2)
-            [0, 1234.5, '€ 1235', MoneyToLocalizedStringTransformer::ROUND_UP],
-            [0, 1234.4, '€ 1235', MoneyToLocalizedStringTransformer::ROUND_UP],
-            [0, -1234.5, '-€ 1235', MoneyToLocalizedStringTransformer::ROUND_UP],
-            [0, -1234.4, '-€ 1235', MoneyToLocalizedStringTransformer::ROUND_UP],
-            [1, 123.45, '€ 123,5', MoneyToLocalizedStringTransformer::ROUND_UP],
-            [1, 123.44, '€ 123,5', MoneyToLocalizedStringTransformer::ROUND_UP],
-            [1, -123.45, '-€ 123,5', MoneyToLocalizedStringTransformer::ROUND_UP],
-            [1, -123.44, '-€ 123,5', MoneyToLocalizedStringTransformer::ROUND_UP],
-            // towards zero (1.6 -> 1, -1.6 -> -1)
-            [0, 1234.5, '€ 1234', MoneyToLocalizedStringTransformer::ROUND_DOWN],
-            [0, 1234.4, '€ 1234', MoneyToLocalizedStringTransformer::ROUND_DOWN],
-            [0, -1234.5, '-€ 1234', MoneyToLocalizedStringTransformer::ROUND_DOWN],
-            [0, -1234.4, '-€ 1234', MoneyToLocalizedStringTransformer::ROUND_DOWN],
-            [1, 123.45, '€ 123,4', MoneyToLocalizedStringTransformer::ROUND_DOWN],
-            [1, 123.44, '€ 123,4', MoneyToLocalizedStringTransformer::ROUND_DOWN],
-            [1, -123.45, '-€ 123,4', MoneyToLocalizedStringTransformer::ROUND_DOWN],
-            [1, -123.44, '-€ 123,4', MoneyToLocalizedStringTransformer::ROUND_DOWN],
-            // round halves (.5) to the next even number
-            [0, 1234.6, '€ 1235', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [0, 1234.5, '€ 1234', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [0, 1234.4, '€ 1234', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [0, 1233.5, '€ 1234', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [0, 1232.5, '€ 1232', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [0, -1234.6, '-€ 1235', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [0, -1234.5, '-€ 1234', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [0, -1234.4, '-€ 1234', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [0, -1233.5, '-€ 1234', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [0, -1232.5, '-€ 1232', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [1, 123.46, '€ 123,5', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [1, 123.45, '€ 123,4', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [1, 123.44, '€ 123,4', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [1, 123.35, '€ 123,4', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [1, 123.25, '€ 123,2', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [1, -123.46, '-€ 123,5', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [1, -123.45, '-€ 123,4', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [1, -123.44, '-€ 123,4', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [1, -123.35, '-€ 123,4', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [1, -123.25, '-€ 123,2', MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            // round halves (.5) away from zero
-            [0, 1234.6, '€ 1235', MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
-            [0, 1234.5, '€ 1235', MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
-            [0, 1234.4, '€ 1234', MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
-            [0, -1234.6, '-€ 1235', MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
-            [0, -1234.5, '-€ 1235', MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
-            [0, -1234.4, '-€ 1234', MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
-            [1, 123.46, '€ 123,5', MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
-            [1, 123.45, '€ 123,5', MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
-            [1, 123.44, '€ 123,4', MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
-            [1, -123.46, '-€ 123,5', MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
-            [1, -123.45, '-€ 123,5', MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
-            [1, -123.44, '-€ 123,4', MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
-            // round halves (.5) towards zero
-            [0, 1234.6, '€ 1235', MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
-            [0, 1234.5, '€ 1234', MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
-            [0, 1234.4, '€ 1234', MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
-            [0, -1234.6, '-€ 1235', MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
-            [0, -1234.5, '-€ 1234', MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
-            [0, -1234.4, '-€ 1234', MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
-            [1, 123.46, '€ 123,5', MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
-            [1, 123.45, '€ 123,4', MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
-            [1, 123.44, '€ 123,4', MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
-            [1, -123.46, '-€ 123,5', MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
-            [1, -123.45, '-€ 123,4', MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
-            [1, -123.44, '-€ 123,4', MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
-        ];
-    }
-
-    /**
-     * @dataProvider transformWithRoundingProvider
-     */
-    public function testTransformWithRounding($scale, $input, $output, $roundingMode)
-    {
-        // Since we test against "de_AT", we need the full implementation
-        IntlTestHelper::requireFullIntl($this, '58.1');
-
-        \Locale::setDefault('de_AT');
-
-        $transformer = new MoneyToLocalizedStringTransformer($scale, null, $roundingMode, null, 'EUR');
-
-        $input = new MoneyValue('EUR', $input);
-        $this->assertEquals($output, $transformer->transform($input));
-    }
-
-    public function testTransformDoesNotRoundIfNoScale()
-    {
-        // Since we test against "de_AT", we need the full implementation
-        IntlTestHelper::requireFullIntl($this, '58.1');
-
-        \Locale::setDefault('de_AT');
-
-        $transformer = new MoneyToLocalizedStringTransformer(null, null, MoneyToLocalizedStringTransformer::ROUND_DOWN, null, 'EUR');
-
-        $this->assertEquals('€ 1234,55', $transformer->transform(new MoneyValue('EUR', 1234.547)));
+        $from = new MoneyValue($this->parseMoneyAsDecimal($from));
+        self::assertEquals($to, $transformer->transform($from));
     }
 
     /**
@@ -227,13 +146,13 @@ class MoneyToLocalizedStringTransformerTest extends TestCase
 
         \Locale::setDefault($locale);
 
-        $transformer = new MoneyToLocalizedStringTransformer(null, null, null, null, 'EUR');
+        $transformer = new MoneyToLocalizedStringTransformer('EUR');
 
         if (null !== $to) {
-            $to = new MoneyValue('EUR', (float) number_format($to, 2, '.', ''));
+            $to = new MoneyValue($this->parseMoneyAsDecimal($to));
         }
 
-        $this->assertEquals($to, $transformer->reverseTransform($from));
+        self::assertEquals($to, $transformer->reverseTransform($from));
     }
 
     /**
@@ -247,13 +166,13 @@ class MoneyToLocalizedStringTransformerTest extends TestCase
         \Locale::setDefault($locale);
 
         $from = preg_replace('#(\s?\p{Sc}\s?)#u', '', $from);
-        $transformer = new MoneyToLocalizedStringTransformer(null, null, null, null, 'USD');
+        $transformer = new MoneyToLocalizedStringTransformer('USD');
 
         if (null !== $to) {
-            $to = new MoneyValue('USD', (float) number_format($to, 2, '.', ''));
+            $to = new MoneyValue($this->parseMoneyAsDecimal($to, 'USD'), false);
         }
 
-        $this->assertEquals($to, $transformer->reverseTransform($from));
+        self::assertEquals($to, $transformer->reverseTransform($from));
     }
 
     /**
@@ -266,10 +185,10 @@ class MoneyToLocalizedStringTransformerTest extends TestCase
 
         \Locale::setDefault($locale);
 
-        $transformer = new MoneyToLocalizedStringTransformer(null, true, null, null, 'EUR');
+        $transformer = new MoneyToLocalizedStringTransformer('EUR', true);
 
-        $to = new MoneyValue('EUR', (float) number_format($to, 2, '.', ''));
-        $this->assertEquals($to, $transformer->reverseTransform($from));
+        $to = new MoneyValue($this->parseMoneyAsDecimal($to));
+        self::assertEquals($to, $transformer->reverseTransform($from));
     }
 
     /**
@@ -282,9 +201,12 @@ class MoneyToLocalizedStringTransformerTest extends TestCase
 
         \Locale::setDefault('ru');
 
-        $transformer = new MoneyToLocalizedStringTransformer(null, true, null, null, 'EUR');
+        $transformer = new MoneyToLocalizedStringTransformer('EUR', true);
 
-        $this->assertEquals(new MoneyValue('EUR', 1234.5), $transformer->reverseTransform("1\xc2\xa0234,5"));
+        self::assertEquals(
+            new MoneyValue($this->parseMoneyAsDecimal(1234.5), false),
+            $transformer->reverseTransform("1\xc2\xa0234,5")
+        );
     }
 
     public function testReverseTransformWithGroupingButWithoutGroupSeparator()
@@ -294,117 +216,18 @@ class MoneyToLocalizedStringTransformerTest extends TestCase
 
         \Locale::setDefault('de_AT');
 
-        $transformer = new MoneyToLocalizedStringTransformer(null, true, null, null, 'EUR');
+        $transformer = new MoneyToLocalizedStringTransformer('EUR', true);
 
         // omit group separator
-        $this->assertEquals(new MoneyValue('EUR', 1234.5), $transformer->reverseTransform('1234,5'));
-        $this->assertEquals(new MoneyValue('EUR', 12345.912), $transformer->reverseTransform('12345,912'));
-    }
+        self::assertEquals(
+            new MoneyValue($this->parseMoneyAsDecimal(1234.5), false),
+            $transformer->reverseTransform('1234,5')
+        );
 
-    public function reverseTransformWithRoundingProvider()
-    {
-        return [
-            // towards positive infinity (1.6 -> 2, -1.6 -> -1)
-            [0, '1234,5', 1235, MoneyToLocalizedStringTransformer::ROUND_CEILING],
-            [0, '1234,4', 1235, MoneyToLocalizedStringTransformer::ROUND_CEILING],
-            [0, '-1234,5', -1234, MoneyToLocalizedStringTransformer::ROUND_CEILING],
-            [0, '-1234,4', -1234, MoneyToLocalizedStringTransformer::ROUND_CEILING],
-            [1, '123,45', 123.5, MoneyToLocalizedStringTransformer::ROUND_CEILING],
-            [1, '123,44', 123.5, MoneyToLocalizedStringTransformer::ROUND_CEILING],
-            [1, '-123,45', -123.4, MoneyToLocalizedStringTransformer::ROUND_CEILING],
-            [1, '-123,44', -123.4, MoneyToLocalizedStringTransformer::ROUND_CEILING],
-            // towards negative infinity (1.6 -> 1, -1.6 -> -2)
-            [0, '1234,5', 1234, MoneyToLocalizedStringTransformer::ROUND_FLOOR],
-            [0, '1234,4', 1234, MoneyToLocalizedStringTransformer::ROUND_FLOOR],
-            [0, '-1234,5', -1235, MoneyToLocalizedStringTransformer::ROUND_FLOOR],
-            [0, '-1234,4', -1235, MoneyToLocalizedStringTransformer::ROUND_FLOOR],
-            [1, '123,45', 123.4, MoneyToLocalizedStringTransformer::ROUND_FLOOR],
-            [1, '123,44', 123.4, MoneyToLocalizedStringTransformer::ROUND_FLOOR],
-            [1, '-123,45', -123.5, MoneyToLocalizedStringTransformer::ROUND_FLOOR],
-            [1, '-123,44', -123.5, MoneyToLocalizedStringTransformer::ROUND_FLOOR],
-            // away from zero (1.6 -> 2, -1.6 -> 2)
-            [0, '1234,5', 1235, MoneyToLocalizedStringTransformer::ROUND_UP],
-            [0, '1234,4', 1235, MoneyToLocalizedStringTransformer::ROUND_UP],
-            [0, '-1234,5', -1235, MoneyToLocalizedStringTransformer::ROUND_UP],
-            [0, '-1234,4', -1235, MoneyToLocalizedStringTransformer::ROUND_UP],
-            [1, '123,45', 123.5, MoneyToLocalizedStringTransformer::ROUND_UP],
-            [1, '123,44', 123.5, MoneyToLocalizedStringTransformer::ROUND_UP],
-            [1, '-123,45', -123.5, MoneyToLocalizedStringTransformer::ROUND_UP],
-            [1, '-123,44', -123.5, MoneyToLocalizedStringTransformer::ROUND_UP],
-            // towards zero (1.6 -> 1, -1.6 -> -1)
-            [0, '1234,5', 1234, MoneyToLocalizedStringTransformer::ROUND_DOWN],
-            [0, '1234,4', 1234, MoneyToLocalizedStringTransformer::ROUND_DOWN],
-            [0, '-1234,5', -1234, MoneyToLocalizedStringTransformer::ROUND_DOWN],
-            [0, '-1234,4', -1234, MoneyToLocalizedStringTransformer::ROUND_DOWN],
-            [1, '123,45', 123.4, MoneyToLocalizedStringTransformer::ROUND_DOWN],
-            [1, '123,44', 123.4, MoneyToLocalizedStringTransformer::ROUND_DOWN],
-            [1, '-123,45', -123.4, MoneyToLocalizedStringTransformer::ROUND_DOWN],
-            [1, '-123,44', -123.4, MoneyToLocalizedStringTransformer::ROUND_DOWN],
-            // round halves (.5) to the next even number
-            [0, '1234,6', 1235, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [0, '1234,5', 1234, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [0, '1234,4', 1234, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [0, '1233,5', 1234, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [0, '1232,5', 1232, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [0, '-1234,6', -1235, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [0, '-1234,5', -1234, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [0, '-1234,4', -1234, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [0, '-1233,5', -1234, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [0, '-1232,5', -1232, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [1, '123,46', 123.5, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [1, '123,45', 123.4, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [1, '123,44', 123.4, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [1, '123,35', 123.4, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [1, '123,25', 123.2, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [1, '-123,46', -123.5, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [1, '-123,45', -123.4, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [1, '-123,44', -123.4, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [1, '-123,35', -123.4, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            [1, '-123,25', -123.2, MoneyToLocalizedStringTransformer::ROUND_HALF_EVEN],
-            // round halves (.5) away from zero
-            [0, '1234,6', 1235, MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
-            [0, '1234,5', 1235, MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
-            [0, '1234,4', 1234, MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
-            [0, '-1234,6', -1235, MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
-            [0, '-1234,5', -1235, MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
-            [0, '-1234,4', -1234, MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
-            [1, '123,46', 123.5, MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
-            [1, '123,45', 123.5, MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
-            [1, '123,44', 123.4, MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
-            [1, '-123,46', -123.5, MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
-            [1, '-123,45', -123.5, MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
-            [1, '-123,44', -123.4, MoneyToLocalizedStringTransformer::ROUND_HALF_UP],
-            // round halves (.5) towards zero
-            [0, '1234,6', 1235, MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
-            [0, '1234,5', 1234, MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
-            [0, '1234,4', 1234, MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
-            [0, '-1234,6', -1235, MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
-            [0, '-1234,5', -1234, MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
-            [0, '-1234,4', -1234, MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
-            [1, '123,46', 123.5, MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
-            [1, '123,45', 123.4, MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
-            [1, '123,44', 123.4, MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
-            [1, '-123,46', -123.5, MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
-            [1, '-123,45', -123.4, MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
-            [1, '-123,44', -123.4, MoneyToLocalizedStringTransformer::ROUND_HALF_DOWN],
-        ];
-    }
-
-    /**
-     * @dataProvider reverseTransformWithRoundingProvider
-     */
-    public function testReverseTransformWithRounding($scale, $input, $output, $roundingMode)
-    {
-        $transformer = new MoneyToLocalizedStringTransformer($scale, null, $roundingMode, null, 'EUR');
-
-        $this->assertEquals(new MoneyValue('EUR', $output), $transformer->reverseTransform($input));
-    }
-
-    public function testReverseTransformDoesNotRoundIfNoScale()
-    {
-        $transformer = new MoneyToLocalizedStringTransformer(null, null, MoneyToLocalizedStringTransformer::ROUND_DOWN, null, 'EUR');
-
-        $this->assertEquals(new MoneyValue('EUR', 1234.547), $transformer->reverseTransform('1234,547'));
+        self::assertEquals(
+            new MoneyValue($this->parseMoneyAsDecimal(12345.912), false),
+            $transformer->reverseTransform('12345,912')
+        );
     }
 
     public function testDecimalSeparatorMayBeDotIfGroupingSeparatorIsNotDot()
@@ -413,15 +236,30 @@ class MoneyToLocalizedStringTransformerTest extends TestCase
         IntlTestHelper::requireFullIntl($this, false);
 
         \Locale::setDefault('fr');
-        $transformer = new MoneyToLocalizedStringTransformer(null, true, null, null, 'EUR');
+        $transformer = new MoneyToLocalizedStringTransformer('EUR', true);
 
         // completely valid format
-        $this->assertEquals(new MoneyValue('EUR', 1234.5), $transformer->reverseTransform('1 234,5'));
+        self::assertEquals(
+            new MoneyValue($this->parseMoneyAsDecimal(1234.5), false),
+            $transformer->reverseTransform('1 234,5')
+        );
+
         // accept dots
-        $this->assertEquals(new MoneyValue('EUR', 1234.5), $transformer->reverseTransform('1 234.5'));
+        self::assertEquals(
+            new MoneyValue($this->parseMoneyAsDecimal(1234.5), false),
+            $transformer->reverseTransform('1 234.5')
+        );
+
         // omit group separator
-        $this->assertEquals(new MoneyValue('EUR', 1234.5), $transformer->reverseTransform('1234,5'));
-        $this->assertEquals(new MoneyValue('EUR', 1234.5), $transformer->reverseTransform('1234.5'));
+        self::assertEquals(
+            new MoneyValue($this->parseMoneyAsDecimal(1234.5), false),
+            $transformer->reverseTransform('1234,5')
+        );
+
+        self::assertEquals(
+            new MoneyValue($this->parseMoneyAsDecimal(1234.5), false),
+            $transformer->reverseTransform('1234.5')
+        );
     }
 
     public function testDecimalSeparatorMayNotBeDotIfGroupingSeparatorIsDot()
@@ -431,7 +269,7 @@ class MoneyToLocalizedStringTransformerTest extends TestCase
 
         \Locale::setDefault('de_DE');
 
-        $transformer = new MoneyToLocalizedStringTransformer(null, true, null, null, 'EUR');
+        $transformer = new MoneyToLocalizedStringTransformer('EUR', true);
 
         $this->expectException(TransformationFailedException::class);
 
@@ -445,7 +283,7 @@ class MoneyToLocalizedStringTransformerTest extends TestCase
 
         \Locale::setDefault('de_DE');
 
-        $transformer = new MoneyToLocalizedStringTransformer(null, true, null, null, 'EUR');
+        $transformer = new MoneyToLocalizedStringTransformer('EUR', true);
 
         $this->expectException(TransformationFailedException::class);
 
@@ -458,10 +296,17 @@ class MoneyToLocalizedStringTransformerTest extends TestCase
         IntlTestHelper::requireFullIntl($this, '58.1');
 
         \Locale::setDefault('fr');
-        $transformer = new MoneyToLocalizedStringTransformer(null, null, null, null, 'EUR');
+        $transformer = new MoneyToLocalizedStringTransformer('EUR');
 
-        $this->assertEquals(new MoneyValue('EUR', 1234.5), $transformer->reverseTransform('1234,5'));
-        $this->assertEquals(new MoneyValue('EUR', 1234.5), $transformer->reverseTransform('1234.5'));
+        self::assertEquals(
+            new MoneyValue($this->parseMoneyAsDecimal(1234.5), false),
+            $transformer->reverseTransform('1234,5')
+        );
+
+        self::assertEquals(
+            new MoneyValue($this->parseMoneyAsDecimal(1234.5), false),
+            $transformer->reverseTransform('1234.5')
+        );
     }
 
     public function testDecimalSeparatorMayBeCommaIfGroupingSeparatorIsNotComma()
@@ -470,20 +315,35 @@ class MoneyToLocalizedStringTransformerTest extends TestCase
         IntlTestHelper::requireFullIntl($this, '58.1');
 
         \Locale::setDefault('bg');
-        $transformer = new MoneyToLocalizedStringTransformer(null, true, null, null, 'EUR');
+        $transformer = new MoneyToLocalizedStringTransformer('EUR', true);
 
         // completely valid format
-        $this->assertEquals(new MoneyValue('EUR', 1234.5), $transformer->reverseTransform('1 234.5'));
+        self::assertEquals(
+            new MoneyValue($this->parseMoneyAsDecimal(1234.5), false),
+            $transformer->reverseTransform('1 234,5')
+        );
+
         // accept commas
-        $this->assertEquals(new MoneyValue('EUR', 1234.5), $transformer->reverseTransform('1 234,5'));
+        self::assertEquals(
+            new MoneyValue($this->parseMoneyAsDecimal(1234.5), false),
+            $transformer->reverseTransform('1234.5')
+        );
+
         // omit group separator
-        $this->assertEquals(new MoneyValue('EUR', 1234.5), $transformer->reverseTransform('1234.5'));
-        $this->assertEquals(new MoneyValue('EUR', 1234.5), $transformer->reverseTransform('1234,5'));
+        self::assertEquals(
+            new MoneyValue($this->parseMoneyAsDecimal(1234.5), false),
+            $transformer->reverseTransform('1234.5')
+        );
+
+        self::assertEquals(
+            new MoneyValue($this->parseMoneyAsDecimal(1234.5), false),
+            $transformer->reverseTransform('1234,5')
+        );
     }
 
     public function testDecimalSeparatorMayNotBeCommaIfGroupingSeparatorIsComma()
     {
-        $transformer = new MoneyToLocalizedStringTransformer(null, true, null, null, 'EUR');
+        $transformer = new MoneyToLocalizedStringTransformer('EUR', true);
 
         $this->expectException(TransformationFailedException::class);
 
@@ -492,7 +352,7 @@ class MoneyToLocalizedStringTransformerTest extends TestCase
 
     public function testDecimalSeparatorMayNotBeCommaIfGroupingSeparatorIsCommaWithNoGroupSep()
     {
-        $transformer = new MoneyToLocalizedStringTransformer(null, true, null, null, 'EUR');
+        $transformer = new MoneyToLocalizedStringTransformer('EUR', true);
 
         $this->expectException(TransformationFailedException::class);
 
@@ -501,15 +361,22 @@ class MoneyToLocalizedStringTransformerTest extends TestCase
 
     public function testDecimalSeparatorMayBeCommaIfGroupingSeparatorIsCommaButNoGroupingUsed()
     {
-        $transformer = new MoneyToLocalizedStringTransformer(null, null, null, null, 'EUR');
+        $transformer = new MoneyToLocalizedStringTransformer('EUR');
 
-        $this->assertEquals(new MoneyValue('EUR', 1234.5), $transformer->reverseTransform('1234,5'));
-        $this->assertEquals(new MoneyValue('EUR', 1234.5), $transformer->reverseTransform('1234.5'));
+        self::assertEquals(
+            new MoneyValue($this->parseMoneyAsDecimal(1234.5), false),
+            $transformer->reverseTransform('1234,50')
+        );
+
+        self::assertEquals(
+            new MoneyValue($this->parseMoneyAsDecimal(1234.5), false),
+            $transformer->reverseTransform('1234.50')
+        );
     }
 
-    public function testTransformExpectsNumeric()
+    public function testTransformExpectsMoneyValue()
     {
-        $transformer = new MoneyToLocalizedStringTransformer();
+        $transformer = new MoneyToLocalizedStringTransformer('EUR');
 
         $this->expectException(TransformationFailedException::class);
 
@@ -518,7 +385,7 @@ class MoneyToLocalizedStringTransformerTest extends TestCase
 
     public function testReverseTransformExpectsString()
     {
-        $transformer = new MoneyToLocalizedStringTransformer();
+        $transformer = new MoneyToLocalizedStringTransformer('EUR');
 
         $this->expectException(TransformationFailedException::class);
 
@@ -527,19 +394,16 @@ class MoneyToLocalizedStringTransformerTest extends TestCase
 
     public function testReverseTransformExpectsValidNumber()
     {
-        $transformer = new MoneyToLocalizedStringTransformer();
+        $transformer = new MoneyToLocalizedStringTransformer('EUR');
 
         $this->expectException(TransformationFailedException::class);
 
         $transformer->reverseTransform('foo');
     }
 
-    /**
-     * @see https://github.com/symfony/symfony/issues/3161
-     */
     public function testReverseTransformDisallowsNaN()
     {
-        $transformer = new MoneyToLocalizedStringTransformer();
+        $transformer = new MoneyToLocalizedStringTransformer('EUR');
 
         $this->expectException(TransformationFailedException::class);
 
@@ -548,7 +412,7 @@ class MoneyToLocalizedStringTransformerTest extends TestCase
 
     public function testReverseTransformDisallowsNaN2()
     {
-        $transformer = new MoneyToLocalizedStringTransformer();
+        $transformer = new MoneyToLocalizedStringTransformer('EUR');
 
         $this->expectException(TransformationFailedException::class);
 
@@ -557,7 +421,7 @@ class MoneyToLocalizedStringTransformerTest extends TestCase
 
     public function testReverseTransformDisallowsInfinity()
     {
-        $transformer = new MoneyToLocalizedStringTransformer();
+        $transformer = new MoneyToLocalizedStringTransformer('EUR');
 
         $this->expectException(TransformationFailedException::class);
 
@@ -566,7 +430,7 @@ class MoneyToLocalizedStringTransformerTest extends TestCase
 
     public function testReverseTransformDisallowsInfinity2()
     {
-        $transformer = new MoneyToLocalizedStringTransformer();
+        $transformer = new MoneyToLocalizedStringTransformer('EUR');
 
         $this->expectException(TransformationFailedException::class);
 
@@ -575,84 +439,10 @@ class MoneyToLocalizedStringTransformerTest extends TestCase
 
     public function testReverseTransformDisallowsNegativeInfinity()
     {
-        $transformer = new MoneyToLocalizedStringTransformer();
+        $transformer = new MoneyToLocalizedStringTransformer('EUR');
 
         $this->expectException(TransformationFailedException::class);
 
         $transformer->reverseTransform('-∞');
-    }
-
-    public function testReverseTransformDisallowsLeadingExtraCharacters()
-    {
-        $transformer = new MoneyToLocalizedStringTransformer();
-
-        $this->expectException(TransformationFailedException::class);
-
-        $transformer->reverseTransform('foo123');
-    }
-
-    public function testReverseTransformDisallowsCenteredExtraCharacters()
-    {
-        $transformer = new MoneyToLocalizedStringTransformer();
-
-        $this->expectException(TransformationFailedException::class);
-        $this->expectExceptionMessage('The number contains unrecognized characters: "foo3"');
-
-        $transformer->reverseTransform('12foo3');
-    }
-
-    public function testReverseTransformDisallowsCenteredExtraCharactersMultibyte()
-    {
-        // Since we test against other locales, we need the full implementation
-        IntlTestHelper::requireFullIntl($this, false);
-
-        \Locale::setDefault('ru');
-
-        $transformer = new MoneyToLocalizedStringTransformer(null, true);
-
-        $this->expectException(TransformationFailedException::class);
-        $this->expectExceptionMessage('The number contains unrecognized characters: "foo8"');
-
-        $transformer->reverseTransform("12\xc2\xa0345,67foo8");
-    }
-
-    public function testReverseTransformIgnoresTrailingSpacesInExceptionMessage()
-    {
-        // Since we test against other locales, we need the full implementation
-        IntlTestHelper::requireFullIntl($this, false);
-
-        \Locale::setDefault('ru');
-
-        $transformer = new MoneyToLocalizedStringTransformer(null, true);
-
-        $this->expectException(TransformationFailedException::class);
-        $this->expectExceptionMessage('The number contains unrecognized characters: "foo8"');
-
-        $transformer->reverseTransform("12\xc2\xa0345,67foo8  \xc2\xa0\t");
-    }
-
-    public function testReverseTransformDisallowsTrailingExtraCharacters()
-    {
-        $transformer = new MoneyToLocalizedStringTransformer();
-
-        $this->expectException(TransformationFailedException::class);
-        $this->expectExceptionMessage('The number contains unrecognized characters: "foo"');
-
-        $transformer->reverseTransform('123foo');
-    }
-
-    public function testReverseTransformDisallowsTrailingExtraCharactersMultibyte()
-    {
-        // Since we test against other locales, we need the full implementation
-        IntlTestHelper::requireFullIntl($this, false);
-
-        \Locale::setDefault('ru');
-
-        $transformer = new MoneyToLocalizedStringTransformer(null, true);
-
-        $this->expectException(TransformationFailedException::class);
-        $this->expectExceptionMessage('The number contains unrecognized characters: "foo"');
-
-        $transformer->reverseTransform("12\xc2\xa0345,678foo");
     }
 }

--- a/tests/Extension/Core/DataTransformer/MoneyToStringTransformerTest.php
+++ b/tests/Extension/Core/DataTransformer/MoneyToStringTransformerTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Tests\Extension\Core\DataTransformer;
+
+use Money\Currencies\ISOCurrencies;
+use Money\Parser\DecimalMoneyParser;
+use PHPUnit\Framework\TestCase;
+use Rollerworks\Component\Search\Exception\TransformationFailedException;
+use Rollerworks\Component\Search\Extension\Core\DataTransformer\MoneyToStringTransformer;
+use Rollerworks\Component\Search\Extension\Core\Model\MoneyValue;
+
+class MoneyToStringTransformerTest extends TestCase
+{
+    private function parseMoneyAsDecimal($input, string $currency = 'EUR')
+    {
+        static $moneyParser;
+
+        if (!$moneyParser) {
+            $currencies = new ISOCurrencies();
+            $moneyParser = new DecimalMoneyParser($currencies);
+        }
+
+        return $moneyParser->parse((string) $input, $currency);
+    }
+
+    public function provideTransformations()
+    {
+        return [
+            [null, ''],
+            [1, 'EUR 1.00'],
+            [1.5, 'EUR 1.50'],
+            [1234.5, 'EUR 1234.50'],
+            [12345.912, 'EUR 12345.91'],
+            [1234.5, 'EUR 1234.50'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideTransformations
+     */
+    public function testTransform($from, $to)
+    {
+        $transformer = new MoneyToStringTransformer('EUR');
+
+        if (null !== $from) {
+            $from = new MoneyValue($this->parseMoneyAsDecimal($from));
+        }
+
+        self::assertEquals($to, $transformer->transform($from));
+    }
+
+    /**
+     * @dataProvider provideTransformations
+     */
+    public function testTransformWithoutCurrency($from, $to)
+    {
+        $transformer = new MoneyToStringTransformer('EUR');
+
+        if (null !== $from) {
+            $from = new MoneyValue($this->parseMoneyAsDecimal($from), false);
+        }
+
+        $to = substr($to, 4);
+
+        self::assertEquals($to, $transformer->transform($from));
+    }
+
+    /**
+     * @dataProvider provideTransformations
+     */
+    public function testReverseTransform($to, $from)
+    {
+        $transformer = new MoneyToStringTransformer('EUR');
+
+        if (null !== $to) {
+            $to = new MoneyValue($this->parseMoneyAsDecimal($to));
+        }
+
+        self::assertEquals($to, $transformer->reverseTransform($from));
+    }
+
+    /**
+     * @dataProvider provideTransformations
+     */
+    public function testReverseTransformWithoutCurrency($to, $from)
+    {
+        $transformer = new MoneyToStringTransformer('USD');
+
+        if (null !== $to) {
+            $to = new MoneyValue($this->parseMoneyAsDecimal($to, 'USD'), false);
+            $from = substr($from, 4);
+        }
+
+        self::assertEquals($to, $transformer->reverseTransform($from));
+    }
+
+    public function testTransformExpectsMoneyValue()
+    {
+        $transformer = new MoneyToStringTransformer('EUR');
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->transform('foo');
+    }
+
+    public function testReverseTransformExpectsString()
+    {
+        $transformer = new MoneyToStringTransformer('EUR');
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform(1);
+    }
+
+    public function testReverseTransformExpectsValidNumber()
+    {
+        $transformer = new MoneyToStringTransformer('EUR');
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('foo');
+    }
+
+    public function testReverseTransformDisallowsNaN()
+    {
+        $transformer = new MoneyToStringTransformer('EUR');
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('NaN');
+    }
+
+    public function testReverseTransformDisallowsNaN2()
+    {
+        $transformer = new MoneyToStringTransformer('EUR');
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('nan');
+    }
+
+    public function testReverseTransformDisallowsInfinity()
+    {
+        $transformer = new MoneyToStringTransformer('EUR');
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('∞');
+    }
+
+    public function testReverseTransformDisallowsInfinity2()
+    {
+        $transformer = new MoneyToStringTransformer('EUR');
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('∞,123');
+    }
+
+    public function testReverseTransformDisallowsNegativeInfinity()
+    {
+        $transformer = new MoneyToStringTransformer('EUR');
+
+        $this->expectException(TransformationFailedException::class);
+
+        $transformer->reverseTransform('-∞');
+    }
+
+    public function testReverseTransformExpectsValidNumberOrCurrencyWithNumber()
+    {
+        $transformer = new MoneyToStringTransformer('EUR');
+
+        $this->expectException(TransformationFailedException::class);
+        $this->expectExceptionMessage('Value does not contain a valid 3 character currency code, got "fool".');
+
+        $transformer->reverseTransform('fool 12.00');
+    }
+
+    public function testReverseTransformExpectsValidNumberOrCurrencyWithNumber2()
+    {
+        $transformer = new MoneyToStringTransformer('EUR');
+
+        $this->expectException(TransformationFailedException::class);
+        $this->expectExceptionMessage('Value does not contain a valid 3 character currency code, got "fo".');
+
+        $transformer->reverseTransform('fo ol 12.00');
+    }
+
+    public function testReverseTransformExpectsCurrencyWithNumber()
+    {
+        $transformer = new MoneyToStringTransformer('EUR');
+
+        $this->expectException(TransformationFailedException::class);
+        $transformer->reverseTransform('foo 12.00');
+    }
+}

--- a/tests/Extension/Core/ValueComparison/MoneyValueComparisonTest.php
+++ b/tests/Extension/Core/ValueComparison/MoneyValueComparisonTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Tests\Extension\Core\ValueComparison;
+
+use Money\Currency;
+use Money\Money;
+use PHPUnit\Framework\TestCase;
+use Rollerworks\Component\Search\Extension\Core\Model\MoneyValue;
+use Rollerworks\Component\Search\Extension\Core\ValueComparison\MoneyValueComparison;
+
+final class MoneyValueComparisonTest extends TestCase
+{
+    /** @var MoneyValueComparison */
+    private $comparison;
+
+    protected function setUp()
+    {
+        $this->comparison = new MoneyValueComparison();
+    }
+
+    /** @test */
+    public function it_returns_true_equal()
+    {
+        $value1 = new MoneyValue(Money::EUR(1200));
+        $value2 = new MoneyValue(Money::EUR(1200));
+
+        self::assertTrue($this->comparison->isEqual($value1, $value2, []));
+
+        $value1 = new MoneyValue(Money::EUR(1200));
+        $value2 = new MoneyValue(Money::EUR(1200), false);
+
+        self::assertTrue($this->comparison->isEqual($value1, $value2, []));
+    }
+
+    /** @test */
+    public function it_returns_false_when_not_equal()
+    {
+        $value1 = new MoneyValue(Money::EUR(1200));
+        $value2 = new MoneyValue(Money::EUR(1215));
+
+        self::assertFalse($this->comparison->isEqual($value1, $value2, []));
+
+        // Compare with same amount but different currency
+        $value1 = new MoneyValue(Money::EUR(1200));
+        $value2 = new MoneyValue(Money::USD(1200));
+
+        self::assertFalse($this->comparison->isEqual($value1, $value2, []));
+    }
+
+    /** @test */
+    public function it_returns_true_when_first_value_is_higher()
+    {
+        $value1 = new MoneyValue(Money::EUR(1500));
+        $value2 = new MoneyValue(Money::EUR(1200));
+
+        self::assertTrue($this->comparison->isHigher($value1, $value2, []));
+
+        $value1 = new MoneyValue(Money::EUR(1210));
+        $value2 = new MoneyValue(Money::EUR(1200));
+
+        self::assertTrue($this->comparison->isHigher($value1, $value2, []));
+    }
+
+    /** @test */
+    public function it_returns_true_when_first_value_is_lower()
+    {
+        $value1 = new MoneyValue(Money::EUR(1000));
+        $value2 = new MoneyValue(Money::EUR(1200));
+
+        self::assertTrue($this->comparison->isLower($value1, $value2, []));
+
+        $value1 = new MoneyValue(Money::EUR(1200));
+        $value2 = new MoneyValue(Money::EUR(1210));
+
+        self::assertTrue($this->comparison->isLower($value1, $value2, []));
+    }
+
+    /** @test */
+    public function it_returns_false_when_first_value_is_not_higher()
+    {
+        $value1 = new MoneyValue(Money::EUR(1200));
+        $value2 = new MoneyValue(Money::EUR(1500));
+
+        self::assertFalse($this->comparison->isHigher($value1, $value2, []));
+
+        // Diff currency.
+        $value1 = new MoneyValue(Money::EUR(1210));
+        $value2 = new MoneyValue(Money::USD(1200));
+
+        self::assertFalse($this->comparison->isHigher($value1, $value2, []));
+    }
+
+    /** @test */
+    public function it_returns_false_when_first_value_is_not_lower()
+    {
+        $value1 = new MoneyValue(Money::EUR(1200));
+        $value2 = new MoneyValue(Money::EUR(1000));
+
+        self::assertFalse($this->comparison->isLower($value1, $value2, []));
+
+        $value1 = new MoneyValue(Money::EUR(1000));
+        $value2 = new MoneyValue(Money::USD(1200));
+
+        self::assertFalse($this->comparison->isLower($value1, $value2, []));
+    }
+
+    /** @test */
+    public function it_increments_value_by_amount()
+    {
+        $value = new MoneyValue(Money::EUR(1210));
+        $valueBak = clone $value;
+
+        self::assertEquals(
+            new MoneyValue(Money::EUR(1300)),
+            $this->comparison->getIncrementedValue($value, ['increase_by' => 'amount'])
+        );
+
+        self::assertEquals(
+            new MoneyValue(Money::EUR(1400)),
+            $this->comparison->getIncrementedValue($value, ['increase_by' => 'amount'], 2)
+        );
+
+        // Check original value is not changed.
+        self::assertEquals($valueBak, $value);
+    }
+
+    /** @test */
+    public function it_increments_value_by_cents()
+    {
+        $value = new MoneyValue(Money::EUR(1210));
+        $valueBak = clone $value;
+
+        self::assertEquals(
+            new MoneyValue(Money::EUR(1211)),
+            $this->comparison->getIncrementedValue($value, [])
+        );
+
+        self::assertEquals(
+            new MoneyValue(Money::EUR(1212)),
+            $this->comparison->getIncrementedValue($value, [], 2)
+        );
+
+        // Check original value is not changed.
+        self::assertEquals($valueBak, $value);
+    }
+}


### PR DESCRIPTION
The MoneyType and related DataTransformers now use the PhpMoney library for
handling money amounts.

- The precision (scale) and devisor options are removed as this is now handled by
the money library.
- MoneyValueComparison now allows to increase by cents or full amounts
- Some problems with space grouped money amounts are fixed (edge case)
- Only export currency when it was actually provided (feature)

Todo:

- [x] MoneyToStringTransformerTest

