### PR TITLE
Rename FilterQuery to StringQuery

### DIFF
--- a/src/Exporter/StringQueryExporter.php
+++ b/src/Exporter/StringQueryExporter.php
@@ -25,11 +25,11 @@ use Rollerworks\Component\Search\Value\ValuesBag;
 use Rollerworks\Component\Search\Value\ValuesGroup;
 
 /**
- * Exports the SearchCondition as FilterQuery string.
+ * Exports the SearchCondition as StringQuery string.
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class FilterQueryExporter extends AbstractExporter
+class StringQueryExporter extends AbstractExporter
 {
     private $labelResolver;
     private $fields = [];

--- a/src/Input/StringQuery/Lexer.php
+++ b/src/Input/StringQuery/Lexer.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Component\Search\Input\FilterQuery;
+namespace Rollerworks\Component\Search\Input\StringQuery;
 
 use Doctrine\Common\Lexer\AbstractLexer;
 

--- a/src/Input/StringQuery/QueryException.php
+++ b/src/Input/StringQuery/QueryException.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Component\Search\Input\FilterQuery;
+namespace Rollerworks\Component\Search\Input\StringQuery;
 
 use Rollerworks\Component\Search\Exception\InputProcessorException;
 

--- a/src/Input/StringQueryInput.php
+++ b/src/Input/StringQueryInput.php
@@ -20,18 +20,18 @@ use Rollerworks\Component\Search\Exception\UnexpectedTypeException;
 use Rollerworks\Component\Search\Exception\UnknownFieldException;
 use Rollerworks\Component\Search\FieldConfigInterface;
 use Rollerworks\Component\Search\FieldSet;
-use Rollerworks\Component\Search\Input\FilterQuery\Lexer;
-use Rollerworks\Component\Search\Input\FilterQuery\QueryException;
+use Rollerworks\Component\Search\Input\StringQuery\Lexer;
+use Rollerworks\Component\Search\Input\StringQuery\QueryException;
 use Rollerworks\Component\Search\SearchCondition;
 use Rollerworks\Component\Search\Value\ValuesBag;
 use Rollerworks\Component\Search\Value\ValuesGroup;
 
 /**
- * FilterQuery - processes input in the FilterQuery format.
+ * StringQuery - processes input in the StringQuery format.
  *
  * The formats works as follow (spaced are ignored).
  *
- * Every query-pair is a 'field-name: value1, value2;'.
+ * Each query-pair is a 'field-name: value1, value2;'.
  *
  *  Query-pairs can be nested inside a group "(field-name: value1, value2;)"
  *    Subgroups are threaded as AND-case to there parent,
@@ -69,10 +69,10 @@ use Rollerworks\Component\Search\Value\ValuesGroup;
  *
  * You can also the use '[' to mark it inclusive (explicitly).
  *
- *    ]1-100 is equal to (> 1 and <= 100)
- *    [1-100 is equal to (>= 1 and <= 100)
- *    [1-100[ is equal to (>= 1 and < 100)
- *    ]1-100[ is equal to (> 1 and < 100)
+ *    `]1-100` is equal to (> 1 and <= 100)
+ *    `[1-100` is equal to (>= 1 and <= 100)
+ *    `[1-100[` is equal to (>= 1 and < 100)
+ *    `]1-100[` is equal to (> 1 and < 100)
  *
  *   Example:
  *     field: ]1 - 100;
@@ -126,7 +126,7 @@ use Rollerworks\Component\Search\Value\ValuesGroup;
  *
  * Caution: Regex delimiters are not used.
  */
-class FilterQueryInput extends AbstractInput
+class StringQueryInput extends AbstractInput
 {
     /**
      * @var FieldValuesByViewFactory

--- a/tests/Exporter/StringQueryExporterTest.php
+++ b/tests/Exporter/StringQueryExporterTest.php
@@ -13,18 +13,18 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Tests\Exporter;
 
-use Rollerworks\Component\Search\Exporter\FilterQueryExporter;
+use Rollerworks\Component\Search\Exporter\StringQueryExporter;
 use Rollerworks\Component\Search\ExporterInterface;
 use Rollerworks\Component\Search\FieldConfigInterface;
-use Rollerworks\Component\Search\Input\FilterQueryInput;
 use Rollerworks\Component\Search\Input\ProcessorConfig;
+use Rollerworks\Component\Search\Input\StringQueryInput;
 use Rollerworks\Component\Search\InputProcessorInterface;
 use Rollerworks\Component\Search\SearchCondition;
 use Rollerworks\Component\Search\Test\SearchConditionExporterTestCase;
 use Rollerworks\Component\Search\Value\ValuesBag;
 use Rollerworks\Component\Search\Value\ValuesGroup;
 
-final class FilterQueryExporterTest extends SearchConditionExporterTestCase
+final class StringQueryExporterTest extends SearchConditionExporterTestCase
 {
     /**
      * @test
@@ -111,11 +111,11 @@ final class FilterQueryExporterTest extends SearchConditionExporterTestCase
 
     protected function getExporter(callable $labelResolver = null): ExporterInterface
     {
-        return new FilterQueryExporter($labelResolver);
+        return new StringQueryExporter($labelResolver);
     }
 
     protected function getInputProcessor(callable $labelResolver = null): InputProcessorInterface
     {
-        return new FilterQueryInput(null, $labelResolver);
+        return new StringQueryInput(null, $labelResolver);
     }
 }

--- a/tests/Input/StringQueryInputTest.php
+++ b/tests/Input/StringQueryInputTest.php
@@ -16,9 +16,9 @@ namespace Rollerworks\Component\Search\Tests\Input;
 use Rollerworks\Component\Search\ConditionErrorMessage;
 use Rollerworks\Component\Search\Extension\Core\Type\TextType;
 use Rollerworks\Component\Search\FieldConfigInterface;
-use Rollerworks\Component\Search\Input\FilterQuery\QueryException;
-use Rollerworks\Component\Search\Input\FilterQueryInput;
 use Rollerworks\Component\Search\Input\ProcessorConfig;
+use Rollerworks\Component\Search\Input\StringQuery\QueryException;
+use Rollerworks\Component\Search\Input\StringQueryInput;
 use Rollerworks\Component\Search\InputProcessorInterface;
 use Rollerworks\Component\Search\SearchCondition;
 use Rollerworks\Component\Search\Value\Compare;
@@ -27,11 +27,11 @@ use Rollerworks\Component\Search\Value\Range;
 use Rollerworks\Component\Search\Value\ValuesBag;
 use Rollerworks\Component\Search\Value\ValuesGroup;
 
-final class FilterQueryInputTest extends InputProcessorTestCase
+final class StringQueryInputTest extends InputProcessorTestCase
 {
     protected function getProcessor(callable $labelResolver = null): InputProcessorInterface
     {
-        return new FilterQueryInput(null, $labelResolver);
+        return new StringQueryInput(null, $labelResolver);
     }
 
     /**


### PR DESCRIPTION
FilterQuery still carries the old name used when this library was still a Bundle,
but the name tells nothing. This library is about searching, not filtering.

I tried a number of names but string is the most descriptive.