### PR TITLE
Remove "Interface" suffix usage

### DIFF
--- a/src/AbstractExtension.php
+++ b/src/AbstractExtension.php
@@ -25,7 +25,7 @@ use Rollerworks\Component\Search\Exception\UnexpectedTypeException;
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-abstract class AbstractExtension implements SearchExtensionInterface
+abstract class AbstractExtension implements SearchExtension
 {
     private $typesExtensions;
     private $types;
@@ -33,7 +33,7 @@ abstract class AbstractExtension implements SearchExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public function getType(string $name): FieldTypeInterface
+    public function getType(string $name): FieldType
     {
         if (null === $this->types) {
             $this->initTypes();
@@ -86,12 +86,12 @@ abstract class AbstractExtension implements SearchExtensionInterface
 
     /**
      * If extension needs to provide new field types this function
-     * should be overloaded in child class and return an array of FieldTypeInterface
+     * should be overloaded in child class and return an array of FieldType
      * instances.
      *
      * This is only required for types that have a constructor with (required) arguments.
      *
-     * @return FieldTypeInterface[]
+     * @return FieldType[]
      */
     protected function loadTypes(): array
     {
@@ -100,7 +100,7 @@ abstract class AbstractExtension implements SearchExtensionInterface
 
     /**
      * If extension needs to provide field type extensions this function
-     * should be overloaded in child class and return array of FieldTypeExtensionInterface
+     * should be overloaded in child class and return array of FieldTypeExtension
      * instances per type: `TypeClassName => [FieldTypeExtensionInterface, ...]`.
      *
      * @return array
@@ -115,8 +115,8 @@ abstract class AbstractExtension implements SearchExtensionInterface
         $this->types = [];
 
         foreach ($this->loadTypes() as $type) {
-            if (!$type instanceof FieldTypeInterface) {
-                throw new UnexpectedTypeException($type, FieldTypeInterface::class);
+            if (!$type instanceof FieldType) {
+                throw new UnexpectedTypeException($type, FieldType::class);
             }
 
             $this->types[get_class($type)] = $type;
@@ -128,8 +128,8 @@ abstract class AbstractExtension implements SearchExtensionInterface
         $this->typesExtensions = [];
 
         foreach ($this->loadTypesExtensions() as $extension) {
-            if (!$extension instanceof FieldTypeExtensionInterface) {
-                throw new UnexpectedTypeException($extension, FieldTypeExtensionInterface::class);
+            if (!$extension instanceof FieldTypeExtension) {
+                throw new UnexpectedTypeException($extension, FieldTypeExtension::class);
             }
 
             $this->typesExtensions[$extension->getExtendedType()][] = $extension;

--- a/src/AbstractFieldType.php
+++ b/src/AbstractFieldType.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search;
 
-use Rollerworks\Component\Search\Extension\Core\Type\FieldType;
+use Rollerworks\Component\Search\Extension\Core\Type\SearchFieldType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -25,19 +25,19 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-abstract class AbstractFieldType implements FieldTypeInterface
+abstract class AbstractFieldType implements FieldType
 {
     /**
      * {@inheritdoc}
      */
-    public function buildType(FieldConfigInterface $config, array $options)
+    public function buildType(FieldConfig $config, array $options)
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function buildView(SearchFieldView $view, FieldConfigInterface $config, array $options)
+    public function buildView(SearchFieldView $view, FieldConfig $config, array $options)
     {
     }
 
@@ -53,6 +53,6 @@ abstract class AbstractFieldType implements FieldTypeInterface
      */
     public function getParent()
     {
-        return FieldType::class;
+        return SearchFieldType::class;
     }
 }

--- a/src/AbstractFieldTypeExtension.php
+++ b/src/AbstractFieldTypeExtension.php
@@ -23,19 +23,19 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * {@link FieldTypeExtensionInterface} is that any new methods added the
  * FieldTypeExtensionInterface will not break existing implementations.
  */
-abstract class AbstractFieldTypeExtension implements FieldTypeExtensionInterface
+abstract class AbstractFieldTypeExtension implements FieldTypeExtension
 {
     /**
      * {@inheritdoc}
      */
-    public function buildType(FieldConfigInterface $builder, array $options)
+    public function buildType(FieldConfig $builder, array $options)
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function buildView(FieldConfigInterface $config, SearchFieldView $view)
+    public function buildView(FieldConfig $config, SearchFieldView $view)
     {
     }
 

--- a/src/ConditionExporter.php
+++ b/src/ConditionExporter.php
@@ -14,11 +14,11 @@ declare(strict_types=1);
 namespace Rollerworks\Component\Search;
 
 /**
- * ExporterInterface defines the interface for SearchCondition exporters.
+ * ConditionExporter defines the interface for SearchCondition exporters.
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-interface ExporterInterface
+interface ConditionExporter
 {
     /**
      * Exports the SearchCondition to a portable format.

--- a/src/ConditionOptimizer/ChainOptimizer.php
+++ b/src/ConditionOptimizer/ChainOptimizer.php
@@ -14,14 +14,14 @@ declare(strict_types=1);
 namespace Rollerworks\Component\Search\ConditionOptimizer;
 
 use Rollerworks\Component\Search\SearchCondition;
-use Rollerworks\Component\Search\SearchConditionOptimizerInterface;
+use Rollerworks\Component\Search\SearchConditionOptimizer;
 
 /**
  * ChainOptimizer performs the registered optimizers in order of priority.
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class ChainOptimizer implements SearchConditionOptimizerInterface
+class ChainOptimizer implements SearchConditionOptimizer
 {
     /**
      * @var array<SearchConditionOptimizerInterface[]>
@@ -45,13 +45,13 @@ class ChainOptimizer implements SearchConditionOptimizerInterface
     }
 
     /**
-     * @param SearchConditionOptimizerInterface $optimizer
+     * @param SearchConditionOptimizer $optimizer
      *
      * @throws \InvalidArgumentException
      *
      * @return self
      */
-    public function addOptimizer(SearchConditionOptimizerInterface $optimizer)
+    public function addOptimizer(SearchConditionOptimizer $optimizer)
     {
         // Ensure we got no end-less loops
         if ($optimizer === $this) {
@@ -77,7 +77,7 @@ class ChainOptimizer implements SearchConditionOptimizerInterface
         krsort($this->optimizers, SORT_NUMERIC);
 
         foreach ($this->optimizers as $optimizers) {
-            /** @var SearchConditionOptimizerInterface[] $optimizers */
+            /** @var SearchConditionOptimizer[] $optimizers */
             foreach ($optimizers as $optimizer) {
                 $optimizer->process($condition);
             }

--- a/src/ConditionOptimizer/DuplicateRemover.php
+++ b/src/ConditionOptimizer/DuplicateRemover.php
@@ -13,17 +13,17 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\ConditionOptimizer;
 
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\FieldConfig;
 use Rollerworks\Component\Search\FieldSet;
 use Rollerworks\Component\Search\SearchCondition;
-use Rollerworks\Component\Search\SearchConditionOptimizerInterface;
+use Rollerworks\Component\Search\SearchConditionOptimizer;
 use Rollerworks\Component\Search\Value\Compare;
 use Rollerworks\Component\Search\Value\ExcludedRange;
 use Rollerworks\Component\Search\Value\PatternMatch;
 use Rollerworks\Component\Search\Value\Range;
 use Rollerworks\Component\Search\Value\ValuesBag;
 use Rollerworks\Component\Search\Value\ValuesGroup;
-use Rollerworks\Component\Search\ValueComparisonInterface;
+use Rollerworks\Component\Search\ValueComparator;
 
 /**
  * Removes duplicated values.
@@ -38,7 +38,7 @@ use Rollerworks\Component\Search\ValueComparisonInterface;
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class DuplicateRemover implements SearchConditionOptimizerInterface
+class DuplicateRemover implements SearchConditionOptimizer
 {
     /**
      * {@inheritdoc}
@@ -68,7 +68,7 @@ class DuplicateRemover implements SearchConditionOptimizerInterface
         }
     }
 
-    private function removeDuplicatesInValuesBag(FieldConfigInterface $config, ValuesBag $valuesBag)
+    private function removeDuplicatesInValuesBag(FieldConfig $config, ValuesBag $valuesBag)
     {
         $comparison = $config->getValueComparison();
         $options = $config->getOptions();
@@ -84,16 +84,16 @@ class DuplicateRemover implements SearchConditionOptimizerInterface
     }
 
     /**
-     * @param array                    $values
-     * @param ValuesBag                $valuesBag
-     * @param ValueComparisonInterface $comparison
-     * @param array                    $options
-     * @param bool                     $exclude
+     * @param array           $values
+     * @param ValuesBag       $valuesBag
+     * @param ValueComparator $comparison
+     * @param array           $options
+     * @param bool            $exclude
      */
     private function removeDuplicateValues(
         array $values,
         ValuesBag $valuesBag,
-        ValueComparisonInterface $comparison,
+        ValueComparator $comparison,
         array $options,
         $exclude = false
     ) {
@@ -115,16 +115,16 @@ class DuplicateRemover implements SearchConditionOptimizerInterface
     }
 
     /**
-     * @param Range[]                  $ranges
-     * @param ValuesBag                $valuesBag
-     * @param ValueComparisonInterface $comparison
-     * @param array                    $options
-     * @param bool                     $exclude
+     * @param Range[]         $ranges
+     * @param ValuesBag       $valuesBag
+     * @param ValueComparator $comparison
+     * @param array           $options
+     * @param bool            $exclude
      */
     private function removeDuplicateRanges(
         array $ranges,
         ValuesBag $valuesBag,
-        ValueComparisonInterface $comparison,
+        ValueComparator $comparison,
         array $options,
         $exclude = false
     ) {
@@ -155,11 +155,11 @@ class DuplicateRemover implements SearchConditionOptimizerInterface
     }
 
     /**
-     * @param ValuesBag                $valuesBag
-     * @param ValueComparisonInterface $comparison
-     * @param array                    $options
+     * @param ValuesBag       $valuesBag
+     * @param ValueComparator $comparison
+     * @param array           $options
      */
-    private function removeDuplicateComparisons(ValuesBag $valuesBag, ValueComparisonInterface $comparison, array $options)
+    private function removeDuplicateComparisons(ValuesBag $valuesBag, ValueComparator $comparison, array $options)
     {
         /** @var Compare[] $comparisons */
         $comparisons = $valuesBag->get(Compare::class);
@@ -181,11 +181,11 @@ class DuplicateRemover implements SearchConditionOptimizerInterface
     }
 
     /**
-     * @param ValuesBag                $valuesBag
-     * @param ValueComparisonInterface $comparison
-     * @param array                    $options
+     * @param ValuesBag       $valuesBag
+     * @param ValueComparator $comparison
+     * @param array           $options
      */
-    private function removeDuplicateMatchers(ValuesBag $valuesBag, ValueComparisonInterface $comparison, array $options)
+    private function removeDuplicateMatchers(ValuesBag $valuesBag, ValueComparator $comparison, array $options)
     {
         /** @var PatternMatch[] $matchers */
         $matchers = $valuesBag->get(PatternMatch::class);

--- a/src/ConditionOptimizer/RangeOptimizer.php
+++ b/src/ConditionOptimizer/RangeOptimizer.php
@@ -13,22 +13,22 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\ConditionOptimizer;
 
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\FieldConfig;
 use Rollerworks\Component\Search\FieldSet;
 use Rollerworks\Component\Search\SearchCondition;
-use Rollerworks\Component\Search\SearchConditionOptimizerInterface;
+use Rollerworks\Component\Search\SearchConditionOptimizer;
 use Rollerworks\Component\Search\Value\ExcludedRange;
 use Rollerworks\Component\Search\Value\Range;
 use Rollerworks\Component\Search\Value\ValuesBag;
 use Rollerworks\Component\Search\Value\ValuesGroup;
-use Rollerworks\Component\Search\ValueComparisonInterface;
+use Rollerworks\Component\Search\ValueComparator;
 
 /**
  * Removes overlapping ranges/values and merges connected ranges.
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class RangeOptimizer implements SearchConditionOptimizerInterface
+class RangeOptimizer implements SearchConditionOptimizer
 {
     /**
      * {@inheritdoc}
@@ -77,7 +77,7 @@ class RangeOptimizer implements SearchConditionOptimizerInterface
         }
     }
 
-    private function normalizeRangesInValuesBag(FieldConfigInterface $config, ValuesBag $valuesBag)
+    private function normalizeRangesInValuesBag(FieldConfig $config, ValuesBag $valuesBag)
     {
         $comparison = $config->getValueComparison();
         $options = $config->getOptions();
@@ -143,18 +143,18 @@ class RangeOptimizer implements SearchConditionOptimizerInterface
      *
      * For example: 5 overlaps in 1 - 10
      *
-     * @param array                    $singleValues
-     * @param Range[]                  $ranges
-     * @param ValuesBag                $valuesBag
-     * @param ValueComparisonInterface $comparison
-     * @param array                    $options
-     * @param bool                     $exclude
+     * @param array           $singleValues
+     * @param Range[]         $ranges
+     * @param ValuesBag       $valuesBag
+     * @param ValueComparator $comparison
+     * @param array           $options
+     * @param bool            $exclude
      */
     private function removeOverlappingSingleValues(
         array $singleValues,
         array $ranges,
         ValuesBag $valuesBag,
-        ValueComparisonInterface $comparison,
+        ValueComparator $comparison,
         array $options,
         bool $exclude = false
     ) {
@@ -176,15 +176,15 @@ class RangeOptimizer implements SearchConditionOptimizerInterface
      *
      * For example: 5 - 10 overlaps in 1 - 20
      *
-     * @param Range[]                  $ranges
-     * @param ValuesBag                $valuesBag
-     * @param ValueComparisonInterface $comparison
-     * @param array                    $options
+     * @param Range[]         $ranges
+     * @param ValuesBag       $valuesBag
+     * @param ValueComparator $comparison
+     * @param array           $options
      */
     private function removeOverlappingRanges(
         array $ranges,
         ValuesBag $valuesBag,
-        ValueComparisonInterface $comparison,
+        ValueComparator $comparison,
         array $options
     ) {
         foreach ($ranges as $i => $range) {
@@ -213,16 +213,16 @@ class RangeOptimizer implements SearchConditionOptimizerInterface
      * A range is connected when the upper-bound is equal to the lower-bound of the
      * second range, but only when the bounds inclusiveness are equal they can be optimized.
      *
-     * @param Range[]                  $ranges
-     * @param ValuesBag                $valuesBag
-     * @param ValueComparisonInterface $comparison
-     * @param array                    $options
-     * @param bool                     $exclude
+     * @param Range[]         $ranges
+     * @param ValuesBag       $valuesBag
+     * @param ValueComparator $comparison
+     * @param array           $options
+     * @param bool            $exclude
      */
     private function optimizeConnectedRanges(
         array $ranges,
         ValuesBag $valuesBag,
-        ValueComparisonInterface $comparison,
+        ValueComparator $comparison,
         array $options,
         bool $exclude = false
     ) {
@@ -263,7 +263,7 @@ class RangeOptimizer implements SearchConditionOptimizerInterface
         }
     }
 
-    private function isValInRange($value, Range $range, ValueComparisonInterface $comparison, array $options): bool
+    private function isValInRange($value, Range $range, ValueComparator $comparison, array $options): bool
     {
         // Test it's not overlapping, when this fails then its save to assert there is an overlap.
 
@@ -277,7 +277,7 @@ class RangeOptimizer implements SearchConditionOptimizerInterface
             (!$range->isUpperInclusive() xor !$comparison->isEqual($value, $range->getUpper(), $options)));
     }
 
-    private function isRangeInRange(Range $range1, Range $range, ValueComparisonInterface $comparison, array $options): bool
+    private function isRangeInRange(Range $range1, Range $range, ValueComparator $comparison, array $options): bool
     {
         if (!$comparison->isHigher($range1->getLower(), $range->getLower(), $options) &&
             !$this->isBoundEqual(
@@ -305,7 +305,7 @@ class RangeOptimizer implements SearchConditionOptimizerInterface
     }
 
     private function isBoundEqual(
-        ValueComparisonInterface $comparison,
+        ValueComparator $comparison,
         $options,
         $value1,
         $value2,

--- a/src/ConditionOptimizer/ValueSortCompare.php
+++ b/src/ConditionOptimizer/ValueSortCompare.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\ConditionOptimizer;
 
-use Rollerworks\Component\Search\ValueComparisonInterface;
+use Rollerworks\Component\Search\ValueComparator;
 
 /**
  * The ValueSortCompare compares value for the uasort() function.
@@ -27,7 +27,7 @@ final class ValueSortCompare
     private $comparison;
     private $options;
 
-    public function __construct(ValueComparisonInterface $comparison, array $options)
+    public function __construct(ValueComparator $comparison, array $options)
     {
         $this->comparison = $comparison;
         $this->options = $options;

--- a/src/ConditionOptimizer/ValuesToRange.php
+++ b/src/ConditionOptimizer/ValuesToRange.php
@@ -13,22 +13,22 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\ConditionOptimizer;
 
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\FieldConfig;
 use Rollerworks\Component\Search\FieldSet;
 use Rollerworks\Component\Search\SearchCondition;
-use Rollerworks\Component\Search\SearchConditionOptimizerInterface;
+use Rollerworks\Component\Search\SearchConditionOptimizer;
 use Rollerworks\Component\Search\Value\ExcludedRange;
 use Rollerworks\Component\Search\Value\Range;
 use Rollerworks\Component\Search\Value\ValuesBag;
 use Rollerworks\Component\Search\Value\ValuesGroup;
-use Rollerworks\Component\Search\ValueIncrementerInterface;
+use Rollerworks\Component\Search\ValueIncrementer;
 
 /**
  * Converts incremented values to inclusive ranges.
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class ValuesToRange implements SearchConditionOptimizerInterface
+class ValuesToRange implements SearchConditionOptimizer
 {
     private $comparators = [];
 
@@ -85,7 +85,7 @@ class ValuesToRange implements SearchConditionOptimizerInterface
         }
     }
 
-    private function optimizeValuesInValuesBag(FieldConfigInterface $config, ValueSortCompare $comparisonFunc, ValuesBag $valuesBag)
+    private function optimizeValuesInValuesBag(FieldConfig $config, ValueSortCompare $comparisonFunc, ValuesBag $valuesBag)
     {
         if ($valuesBag->hasSimpleValues()) {
             $values = $valuesBag->getSimpleValues();
@@ -102,10 +102,10 @@ class ValuesToRange implements SearchConditionOptimizerInterface
         }
     }
 
-    private function listToRanges(array $values, ValuesBag $valuesBag, FieldConfigInterface $config, bool $exclude = false)
+    private function listToRanges(array $values, ValuesBag $valuesBag, FieldConfig $config, bool $exclude = false)
     {
         $class = $exclude ? ExcludedRange::class : Range::class;
-        /** @var ValueIncrementerInterface $comparison */
+        /** @var ValueIncrementer $comparison */
         $comparison = $config->getValueComparison();
         $options = $config->getOptions();
 

--- a/src/DataTransformer.php
+++ b/src/DataTransformer.php
@@ -20,7 +20,7 @@ use Rollerworks\Component\Search\Exception\TransformationFailedException;
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-interface DataTransformerInterface
+interface DataTransformer
 {
     /**
      * Transforms a value from the original representation to a transformed representation.

--- a/src/Exception/BadMethodCallException.php
+++ b/src/Exception/BadMethodCallException.php
@@ -13,6 +13,6 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Exception;
 
-class BadMethodCallException extends \BadMethodCallException implements ExceptionInterface
+class BadMethodCallException extends \BadMethodCallException implements SearchException
 {
 }

--- a/src/Exception/InputProcessorException.php
+++ b/src/Exception/InputProcessorException.php
@@ -18,7 +18,7 @@ use Rollerworks\Component\Search\ConditionErrorMessage;
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class InputProcessorException extends \InvalidArgumentException implements ExceptionInterface
+class InputProcessorException extends \InvalidArgumentException implements SearchException
 {
     public $path = '';
     public $messageTemplate;

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -16,6 +16,6 @@ namespace Rollerworks\Component\Search\Exception;
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+class InvalidArgumentException extends \InvalidArgumentException implements SearchException
 {
 }

--- a/src/Exception/InvalidSearchConditionException.php
+++ b/src/Exception/InvalidSearchConditionException.php
@@ -15,7 +15,7 @@ namespace Rollerworks\Component\Search\Exception;
 
 use Rollerworks\Component\Search\ConditionErrorMessage;
 
-final class InvalidSearchConditionException extends \InvalidArgumentException implements ExceptionInterface
+final class InvalidSearchConditionException extends \InvalidArgumentException implements SearchException
 {
     private $errors;
 

--- a/src/Exception/SearchException.php
+++ b/src/Exception/SearchException.php
@@ -16,6 +16,6 @@ namespace Rollerworks\Component\Search\Exception;
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-interface ExceptionInterface
+interface SearchException
 {
 }

--- a/src/Exception/TransformationFailedException.php
+++ b/src/Exception/TransformationFailedException.php
@@ -16,6 +16,6 @@ namespace Rollerworks\Component\Search\Exception;
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class TransformationFailedException extends \RuntimeException implements ExceptionInterface
+class TransformationFailedException extends \RuntimeException implements SearchException
 {
 }

--- a/src/Exception/UnexpectedTypeException.php
+++ b/src/Exception/UnexpectedTypeException.php
@@ -16,7 +16,7 @@ namespace Rollerworks\Component\Search\Exception;
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class UnexpectedTypeException extends \InvalidArgumentException implements ExceptionInterface
+class UnexpectedTypeException extends \InvalidArgumentException implements SearchException
 {
     /**
      * Constructor.

--- a/src/Exporter/AbstractExporter.php
+++ b/src/Exporter/AbstractExporter.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Exporter;
 
-use Rollerworks\Component\Search\ExporterInterface;
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\ConditionExporter;
+use Rollerworks\Component\Search\FieldConfig;
 use Rollerworks\Component\Search\FieldSet;
 use Rollerworks\Component\Search\SearchCondition;
 use Rollerworks\Component\Search\Value\PatternMatch;
@@ -25,7 +25,7 @@ use Rollerworks\Component\Search\Value\ValuesGroup;
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-abstract class AbstractExporter implements ExporterInterface
+abstract class AbstractExporter implements ConditionExporter
 {
     /**
      * Exports a search condition.
@@ -104,12 +104,12 @@ abstract class AbstractExporter implements ExporterInterface
     /**
      * Transforms the model value to a view representation.
      *
-     * @param mixed                $value
-     * @param FieldConfigInterface $field
+     * @param mixed       $value
+     * @param FieldConfig $field
      *
      * @return string
      */
-    protected function modelToView($value, FieldConfigInterface $field): string
+    protected function modelToView($value, FieldConfig $field): string
     {
         $transformer = $field->getViewTransformer();
 
@@ -137,12 +137,12 @@ abstract class AbstractExporter implements ExporterInterface
     /**
      * Transforms the model value to a normalized version.
      *
-     * @param mixed                $value
-     * @param FieldConfigInterface $field
+     * @param mixed       $value
+     * @param FieldConfig $field
      *
      * @return string
      */
-    protected function modelToNorm($value, FieldConfigInterface $field): string
+    protected function modelToNorm($value, FieldConfig $field): string
     {
         $transformer = $field->getNormTransformer();
 

--- a/src/Exporter/ArrayExporter.php
+++ b/src/Exporter/ArrayExporter.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Exporter;
 
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\FieldConfig;
 use Rollerworks\Component\Search\FieldSet;
 use Rollerworks\Component\Search\Value\Compare;
 use Rollerworks\Component\Search\Value\ExcludedRange;
@@ -65,7 +65,7 @@ class ArrayExporter extends AbstractExporter
         return $result;
     }
 
-    protected function exportValues(ValuesBag $valuesBag, FieldConfigInterface $field): array
+    protected function exportValues(ValuesBag $valuesBag, FieldConfig $field): array
     {
         $exportedValues = [];
 
@@ -103,7 +103,7 @@ class ArrayExporter extends AbstractExporter
         return $exportedValues;
     }
 
-    protected function exportRangeValue(Range $range, FieldConfigInterface $field): array
+    protected function exportRangeValue(Range $range, FieldConfig $field): array
     {
         $result = [
             'lower' => $this->modelToNorm($range->getLower(), $field),

--- a/src/Exporter/StringQueryExporter.php
+++ b/src/Exporter/StringQueryExporter.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Rollerworks\Component\Search\Exporter;
 
 use Rollerworks\Component\Search\Exception\UnknownFieldException;
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\FieldConfig;
 use Rollerworks\Component\Search\FieldSet;
 use Rollerworks\Component\Search\SearchCondition;
 use Rollerworks\Component\Search\Value\Compare;
@@ -45,7 +45,7 @@ class StringQueryExporter extends AbstractExporter
      */
     public function __construct(callable $labelResolver = null)
     {
-        $this->labelResolver = $labelResolver ?? function (FieldConfigInterface $field) {
+        $this->labelResolver = $labelResolver ?? function (FieldConfig $field) {
             return $field->getOption('label', $field->getName());
         };
     }
@@ -128,7 +128,7 @@ class StringQueryExporter extends AbstractExporter
         throw new UnknownFieldException($name);
     }
 
-    private function exportValues(ValuesBag $valuesBag, FieldConfigInterface $field): string
+    private function exportValues(ValuesBag $valuesBag, FieldConfig $field): string
     {
         $exportedValues = '';
 
@@ -205,7 +205,7 @@ class StringQueryExporter extends AbstractExporter
         return $operator;
     }
 
-    private function exportRangeValue(Range $range, FieldConfigInterface $field): string
+    private function exportRangeValue(Range $range, FieldConfig $field): string
     {
         $result = !$range->isLowerInclusive() ? ']' : '';
         $result .= $this->exportValuePart($this->modelToView($range->getLower(), $field));

--- a/src/Exporter/XmlExporter.php
+++ b/src/Exporter/XmlExporter.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Exporter;
 
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\FieldConfig;
 use Rollerworks\Component\Search\FieldSet;
 use Rollerworks\Component\Search\SearchCondition;
 use Rollerworks\Component\Search\Value\Compare;
@@ -113,7 +113,7 @@ class XmlExporter extends AbstractExporter
         }
     }
 
-    private function exportValuesToNode(ValuesBag $valuesBag, \DOMNode $parent, FieldConfigInterface $field)
+    private function exportValuesToNode(ValuesBag $valuesBag, \DOMNode $parent, FieldConfig $field)
     {
         if ($valuesBag->hasSimpleValues()) {
             $valuesNode = $this->document->createElement('simple-values');
@@ -203,7 +203,7 @@ class XmlExporter extends AbstractExporter
         }
     }
 
-    private function exportRangeValueToNode(\DOMNode $parent, Range $range, FieldConfigInterface $field)
+    private function exportRangeValueToNode(\DOMNode $parent, Range $range, FieldConfig $field)
     {
         $rangeNode = $this->document->createElement('range');
 

--- a/src/Extension/Core/CoreExtension.php
+++ b/src/Extension/Core/CoreExtension.php
@@ -31,7 +31,7 @@ class CoreExtension extends AbstractExtension
         $numberComparison = new ValueComparison\NumberValueComparison();
 
         return [
-            new Type\FieldType(new ValueComparison\SimpleValueComparison()),
+            new Type\SearchFieldType(new ValueComparison\SimpleValueComparison()),
             new Type\DateType(new ValueComparison\DateValueComparison()),
             new Type\DateTimeType($dateTimeComparison),
             new Type\TimeType($dateTimeComparison),

--- a/src/Extension/Core/DataTransformer/BaseDateTimeTransformer.php
+++ b/src/Extension/Core/DataTransformer/BaseDateTimeTransformer.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Extension\Core\DataTransformer;
 
-use Rollerworks\Component\Search\DataTransformerInterface;
+use Rollerworks\Component\Search\DataTransformer;
 use Rollerworks\Component\Search\Exception\InvalidArgumentException;
 use Rollerworks\Component\Search\Exception\UnexpectedTypeException;
 
@@ -21,7 +21,7 @@ use Rollerworks\Component\Search\Exception\UnexpectedTypeException;
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @author Florian Eckerstorfer <florian@eckerstorfer.org>
  */
-abstract class BaseDateTimeTransformer implements DataTransformerInterface
+abstract class BaseDateTimeTransformer implements DataTransformer
 {
     /**
      * @var string

--- a/src/Extension/Core/DataTransformer/BaseNumberTransformer.php
+++ b/src/Extension/Core/DataTransformer/BaseNumberTransformer.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Extension\Core\DataTransformer;
 
-use Rollerworks\Component\Search\DataTransformerInterface;
+use Rollerworks\Component\Search\DataTransformer;
 
 /**
  * Transforms between a number type and a number with grouping
@@ -23,7 +23,7 @@ use Rollerworks\Component\Search\DataTransformerInterface;
  * @author Florian Eckerstorfer <florian@eckerstorfer.org>
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-abstract class BaseNumberTransformer implements DataTransformerInterface
+abstract class BaseNumberTransformer implements DataTransformer
 {
     /**
      * Rounds a number towards positive infinity.

--- a/src/Extension/Core/DataTransformer/BirthdayTransformer.php
+++ b/src/Extension/Core/DataTransformer/BirthdayTransformer.php
@@ -13,17 +13,17 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Extension\Core\DataTransformer;
 
-use Rollerworks\Component\Search\DataTransformerInterface;
+use Rollerworks\Component\Search\DataTransformer;
 use Rollerworks\Component\Search\Exception\TransformationFailedException;
 
 /**
  * Transforms between a date string and a DateTime object
  * and between a ISO string and an integer.
  */
-class BirthdayTransformer implements DataTransformerInterface
+class BirthdayTransformer implements DataTransformer
 {
     /**
-     * @var DataTransformerInterface
+     * @var DataTransformer
      */
     private $transformer;
 
@@ -38,11 +38,11 @@ class BirthdayTransformer implements DataTransformerInterface
     private $allowFutureDate;
 
     /**
-     * @param DataTransformerInterface $transformer
-     * @param bool                     $allowAge
-     * @param bool                     $allowFutureDate
+     * @param DataTransformer $transformer
+     * @param bool            $allowAge
+     * @param bool            $allowFutureDate
      */
-    public function __construct(DataTransformerInterface $transformer, bool $allowAge = true, bool $allowFutureDate = false)
+    public function __construct(DataTransformer $transformer, bool $allowAge = true, bool $allowFutureDate = false)
     {
         $this->transformer = $transformer;
         $this->allowFutureDate = $allowFutureDate;

--- a/src/Extension/Core/DataTransformer/ChoiceToLabelTransformer.php
+++ b/src/Extension/Core/DataTransformer/ChoiceToLabelTransformer.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Extension\Core\DataTransformer;
 
-use Rollerworks\Component\Search\DataTransformerInterface;
+use Rollerworks\Component\Search\DataTransformer;
 use Rollerworks\Component\Search\Exception\TransformationFailedException;
 use Rollerworks\Component\Search\Extension\Core\ChoiceList\ChoiceList;
 use Rollerworks\Component\Search\Extension\Core\ChoiceList\View\ChoiceListView;
@@ -21,7 +21,7 @@ use Rollerworks\Component\Search\Extension\Core\ChoiceList\View\ChoiceListView;
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class ChoiceToLabelTransformer implements DataTransformerInterface
+class ChoiceToLabelTransformer implements DataTransformer
 {
     private $choiceList;
     private $choiceListView;

--- a/src/Extension/Core/DataTransformer/ChoiceToValueTransformer.php
+++ b/src/Extension/Core/DataTransformer/ChoiceToValueTransformer.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Extension\Core\DataTransformer;
 
-use Rollerworks\Component\Search\DataTransformerInterface;
+use Rollerworks\Component\Search\DataTransformer;
 use Rollerworks\Component\Search\Exception\TransformationFailedException;
 use Rollerworks\Component\Search\Extension\Core\ChoiceList\ChoiceList;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class ChoiceToValueTransformer implements DataTransformerInterface
+class ChoiceToValueTransformer implements DataTransformer
 {
     private $choiceList;
 

--- a/src/Extension/Core/DataTransformer/LocalizedBirthdayTransformer.php
+++ b/src/Extension/Core/DataTransformer/LocalizedBirthdayTransformer.php
@@ -13,17 +13,17 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Extension\Core\DataTransformer;
 
-use Rollerworks\Component\Search\DataTransformerInterface;
+use Rollerworks\Component\Search\DataTransformer;
 use Rollerworks\Component\Search\Exception\TransformationFailedException;
 
 /**
  * Transforms between a date string and a DateTime object
  * and between a localized string and a integer.
  */
-class LocalizedBirthdayTransformer implements DataTransformerInterface
+class LocalizedBirthdayTransformer implements DataTransformer
 {
     /**
-     * @var DataTransformerInterface
+     * @var DataTransformer
      */
     private $transformer;
 
@@ -38,11 +38,11 @@ class LocalizedBirthdayTransformer implements DataTransformerInterface
     private $allowFutureDate;
 
     /**
-     * @param DataTransformerInterface $transformer
-     * @param bool                     $allowAge
-     * @param bool                     $allowFutureDate
+     * @param DataTransformer $transformer
+     * @param bool            $allowAge
+     * @param bool            $allowFutureDate
      */
-    public function __construct(DataTransformerInterface $transformer, bool $allowAge = true, bool $allowFutureDate = false)
+    public function __construct(DataTransformer $transformer, bool $allowAge = true, bool $allowFutureDate = false)
     {
         $this->transformer = $transformer;
         $this->allowFutureDate = $allowFutureDate;

--- a/src/Extension/Core/DataTransformer/MoneyToStringTransformer.php
+++ b/src/Extension/Core/DataTransformer/MoneyToStringTransformer.php
@@ -16,7 +16,7 @@ namespace Rollerworks\Component\Search\Extension\Core\DataTransformer;
 use Money\Currencies\ISOCurrencies;
 use Money\Formatter\DecimalMoneyFormatter;
 use Money\Parser\DecimalMoneyParser;
-use Rollerworks\Component\Search\DataTransformerInterface;
+use Rollerworks\Component\Search\DataTransformer;
 use Rollerworks\Component\Search\Exception\TransformationFailedException;
 use Rollerworks\Component\Search\Extension\Core\Model\MoneyValue;
 
@@ -27,7 +27,7 @@ use Rollerworks\Component\Search\Extension\Core\Model\MoneyValue;
  * @author Florian Eckerstorfer <florian@eckerstorfer.org>
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class MoneyToStringTransformer implements DataTransformerInterface
+class MoneyToStringTransformer implements DataTransformer
 {
     private $defaultCurrency;
     private $moneyParser;

--- a/src/Extension/Core/Type/BaseDateTimeType.php
+++ b/src/Extension/Core/Type/BaseDateTimeType.php
@@ -15,7 +15,7 @@ namespace Rollerworks\Component\Search\Extension\Core\Type;
 
 use Rollerworks\Component\Search\AbstractFieldType;
 use Rollerworks\Component\Search\Exception\InvalidConfigurationException;
-use Rollerworks\Component\Search\ValueComparisonInterface;
+use Rollerworks\Component\Search\ValueComparator;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
@@ -26,7 +26,7 @@ abstract class BaseDateTimeType extends AbstractFieldType
     const DEFAULT_TIME_FORMAT = \IntlDateFormatter::MEDIUM;
 
     /**
-     * @var ValueComparisonInterface
+     * @var ValueComparator
      */
     protected $valueComparison;
 
@@ -43,9 +43,9 @@ abstract class BaseDateTimeType extends AbstractFieldType
     /**
      * Constructor.
      *
-     * @param ValueComparisonInterface $valueComparison
+     * @param ValueComparator $valueComparison
      */
-    public function __construct(ValueComparisonInterface $valueComparison)
+    public function __construct(ValueComparator $valueComparison)
     {
         $this->valueComparison = $valueComparison;
     }

--- a/src/Extension/Core/Type/BirthdayType.php
+++ b/src/Extension/Core/Type/BirthdayType.php
@@ -16,11 +16,11 @@ namespace Rollerworks\Component\Search\Extension\Core\Type;
 use Rollerworks\Component\Search\AbstractFieldType;
 use Rollerworks\Component\Search\Extension\Core\DataTransformer\BirthdayTransformer;
 use Rollerworks\Component\Search\Extension\Core\DataTransformer\LocalizedBirthdayTransformer;
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\FieldConfig;
 use Rollerworks\Component\Search\SearchFieldView;
 use Rollerworks\Component\Search\Value\Compare;
 use Rollerworks\Component\Search\Value\Range;
-use Rollerworks\Component\Search\ValueComparisonInterface;
+use Rollerworks\Component\Search\ValueComparator;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -30,16 +30,16 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class BirthdayType extends AbstractFieldType
 {
     /**
-     * @var ValueComparisonInterface
+     * @var ValueComparator
      */
     private $valueComparison;
 
     /**
      * Constructor.
      *
-     * @param ValueComparisonInterface $valueComparison
+     * @param ValueComparator $valueComparison
      */
-    public function __construct(ValueComparisonInterface $valueComparison)
+    public function __construct(ValueComparator $valueComparison)
     {
         $this->valueComparison = $valueComparison;
     }
@@ -47,7 +47,7 @@ class BirthdayType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildType(FieldConfigInterface $config, array $options)
+    public function buildType(FieldConfig $config, array $options)
     {
         $config->setValueComparison($this->valueComparison);
         $config->setValueTypeSupport(Range::class, true);
@@ -73,7 +73,7 @@ class BirthdayType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildView(SearchFieldView $view, FieldConfigInterface $config, array $options)
+    public function buildView(SearchFieldView $view, FieldConfig $config, array $options)
     {
         $view->vars['allow_age'] = $options['allow_age'];
         $view->vars['allow_future_date'] = $options['allow_future_date'];

--- a/src/Extension/Core/Type/ChoiceType.php
+++ b/src/Extension/Core/Type/ChoiceType.php
@@ -23,7 +23,7 @@ use Rollerworks\Component\Search\Extension\Core\ChoiceList\Loader\ChoiceLoader;
 use Rollerworks\Component\Search\Extension\Core\ChoiceList\View\ChoiceListView;
 use Rollerworks\Component\Search\Extension\Core\DataTransformer\ChoiceToLabelTransformer;
 use Rollerworks\Component\Search\Extension\Core\DataTransformer\ChoiceToValueTransformer;
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\FieldConfig;
 use Rollerworks\Component\Search\SearchFieldView;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -53,7 +53,7 @@ class ChoiceType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildType(FieldConfigInterface $config, array $options)
+    public function buildType(FieldConfig $config, array $options)
     {
         $choiceList = $this->createChoiceList($options);
         $config->setAttribute('choice_list', $choiceList);
@@ -90,7 +90,7 @@ class ChoiceType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildView(SearchFieldView $view, FieldConfigInterface $config, array $options)
+    public function buildView(SearchFieldView $view, FieldConfig $config, array $options)
     {
         /** @var ChoiceListView $choiceListView */
         $choiceListView = $config->getAttribute('choice_list_view');

--- a/src/Extension/Core/Type/DateTimeType.php
+++ b/src/Extension/Core/Type/DateTimeType.php
@@ -15,7 +15,7 @@ namespace Rollerworks\Component\Search\Extension\Core\Type;
 
 use Rollerworks\Component\Search\Extension\Core\DataTransformer\DateTimeToLocalizedStringTransformer;
 use Rollerworks\Component\Search\Extension\Core\DataTransformer\DateTimeToRfc3339Transformer;
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\FieldConfig;
 use Rollerworks\Component\Search\SearchFieldView;
 use Rollerworks\Component\Search\Value\Compare;
 use Rollerworks\Component\Search\Value\Range;
@@ -57,7 +57,7 @@ class DateTimeType extends BaseDateTimeType
     /**
      * {@inheritdoc}
      */
-    public function buildType(FieldConfigInterface $config, array $options)
+    public function buildType(FieldConfig $config, array $options)
     {
         $config->setValueComparison($this->valueComparison);
         $config->setValueTypeSupport(Range::class, true);
@@ -99,7 +99,7 @@ class DateTimeType extends BaseDateTimeType
     /**
      * {@inheritdoc}
      */
-    public function buildView(SearchFieldView $view, FieldConfigInterface $config, array $options)
+    public function buildView(SearchFieldView $view, FieldConfig $config, array $options)
     {
         $pattern = $options['pattern'];
 

--- a/src/Extension/Core/Type/DateType.php
+++ b/src/Extension/Core/Type/DateType.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Rollerworks\Component\Search\Extension\Core\Type;
 
 use Rollerworks\Component\Search\Extension\Core\DataTransformer\DateTimeToLocalizedStringTransformer;
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\FieldConfig;
 use Rollerworks\Component\Search\SearchFieldView;
 use Rollerworks\Component\Search\Value\Compare;
 use Rollerworks\Component\Search\Value\Range;
@@ -33,7 +33,7 @@ class DateType extends BaseDateTimeType
     /**
      * {@inheritdoc}
      */
-    public function buildType(FieldConfigInterface $config, array $options)
+    public function buildType(FieldConfig $config, array $options)
     {
         $config->setValueComparison($this->valueComparison);
         $config->setValueTypeSupport(Range::class, true);
@@ -71,7 +71,7 @@ class DateType extends BaseDateTimeType
     /**
      * {@inheritdoc}
      */
-    public function buildView(SearchFieldView $view, FieldConfigInterface $config, array $options)
+    public function buildView(SearchFieldView $view, FieldConfig $config, array $options)
     {
         $pattern = $options['pattern'];
 

--- a/src/Extension/Core/Type/IntegerType.php
+++ b/src/Extension/Core/Type/IntegerType.php
@@ -16,11 +16,11 @@ namespace Rollerworks\Component\Search\Extension\Core\Type;
 use Rollerworks\Component\Search\AbstractFieldType;
 use Rollerworks\Component\Search\Extension\Core\DataTransformer\IntegerToLocalizedStringTransformer;
 use Rollerworks\Component\Search\Extension\Core\DataTransformer\IntegerToStringTransformer;
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\FieldConfig;
 use Rollerworks\Component\Search\SearchFieldView;
 use Rollerworks\Component\Search\Value\Compare;
 use Rollerworks\Component\Search\Value\Range;
-use Rollerworks\Component\Search\ValueComparisonInterface;
+use Rollerworks\Component\Search\ValueComparator;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -29,16 +29,16 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class IntegerType extends AbstractFieldType
 {
     /**
-     * @var ValueComparisonInterface
+     * @var ValueComparator
      */
     protected $valueComparison;
 
     /**
      * Constructor.
      *
-     * @param ValueComparisonInterface $valueComparison
+     * @param ValueComparator $valueComparison
      */
-    public function __construct(ValueComparisonInterface $valueComparison)
+    public function __construct(ValueComparator $valueComparison)
     {
         $this->valueComparison = $valueComparison;
     }
@@ -46,7 +46,7 @@ class IntegerType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildType(FieldConfigInterface $config, array $options)
+    public function buildType(FieldConfig $config, array $options)
     {
         $config->setValueComparison($this->valueComparison);
         $config->setValueTypeSupport(Range::class, true);
@@ -61,7 +61,7 @@ class IntegerType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildView(SearchFieldView $view, FieldConfigInterface $config, array $options)
+    public function buildView(SearchFieldView $view, FieldConfig $config, array $options)
     {
         $view->vars['grouping'] = $options['grouping'];
     }

--- a/src/Extension/Core/Type/MoneyType.php
+++ b/src/Extension/Core/Type/MoneyType.php
@@ -16,11 +16,11 @@ namespace Rollerworks\Component\Search\Extension\Core\Type;
 use Rollerworks\Component\Search\AbstractFieldType;
 use Rollerworks\Component\Search\Extension\Core\DataTransformer\MoneyToLocalizedStringTransformer;
 use Rollerworks\Component\Search\Extension\Core\DataTransformer\MoneyToStringTransformer;
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\FieldConfig;
 use Rollerworks\Component\Search\SearchFieldView;
 use Rollerworks\Component\Search\Value\Compare;
 use Rollerworks\Component\Search\Value\Range;
-use Rollerworks\Component\Search\ValueComparisonInterface;
+use Rollerworks\Component\Search\ValueComparator;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -29,16 +29,16 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class MoneyType extends AbstractFieldType
 {
     /**
-     * @var ValueComparisonInterface
+     * @var ValueComparator
      */
     protected $valueComparison;
 
     /**
      * Constructor.
      *
-     * @param ValueComparisonInterface $valueComparison
+     * @param ValueComparator $valueComparison
      */
-    public function __construct(ValueComparisonInterface $valueComparison)
+    public function __construct(ValueComparator $valueComparison)
     {
         $this->valueComparison = $valueComparison;
     }
@@ -46,7 +46,7 @@ class MoneyType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildType(FieldConfigInterface $config, array $options)
+    public function buildType(FieldConfig $config, array $options)
     {
         $config->setValueComparison($this->valueComparison);
         $config->setValueTypeSupport(Range::class, true);
@@ -67,7 +67,7 @@ class MoneyType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildView(SearchFieldView $view, FieldConfigInterface $config, array $options)
+    public function buildView(SearchFieldView $view, FieldConfig $config, array $options)
     {
         $view->vars['grouping'] = $options['grouping'];
         $view->vars['default_currency'] = $options['default_currency'];

--- a/src/Extension/Core/Type/NumberType.php
+++ b/src/Extension/Core/Type/NumberType.php
@@ -16,11 +16,11 @@ namespace Rollerworks\Component\Search\Extension\Core\Type;
 use Rollerworks\Component\Search\AbstractFieldType;
 use Rollerworks\Component\Search\Extension\Core\DataTransformer\NumberToLocalizedStringTransformer;
 use Rollerworks\Component\Search\Extension\Core\DataTransformer\NumberToStringTransformer;
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\FieldConfig;
 use Rollerworks\Component\Search\SearchFieldView;
 use Rollerworks\Component\Search\Value\Compare;
 use Rollerworks\Component\Search\Value\Range;
-use Rollerworks\Component\Search\ValueComparisonInterface;
+use Rollerworks\Component\Search\ValueComparator;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -29,16 +29,16 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class NumberType extends AbstractFieldType
 {
     /**
-     * @var ValueComparisonInterface
+     * @var ValueComparator
      */
     protected $valueComparison;
 
     /**
      * Constructor.
      *
-     * @param ValueComparisonInterface $valueComparison
+     * @param ValueComparator $valueComparison
      */
-    public function __construct(ValueComparisonInterface $valueComparison)
+    public function __construct(ValueComparator $valueComparison)
     {
         $this->valueComparison = $valueComparison;
     }
@@ -46,7 +46,7 @@ class NumberType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildType(FieldConfigInterface $config, array $options)
+    public function buildType(FieldConfig $config, array $options)
     {
         $config->setValueComparison($this->valueComparison);
         $config->setValueTypeSupport(Range::class, true);
@@ -71,7 +71,7 @@ class NumberType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildView(SearchFieldView $view, FieldConfigInterface $config, array $options)
+    public function buildView(SearchFieldView $view, FieldConfig $config, array $options)
     {
         $view->vars['precision'] = $options['precision'];
         $view->vars['grouping'] = $options['grouping'];

--- a/src/Extension/Core/Type/SearchFieldType.php
+++ b/src/Extension/Core/Type/SearchFieldType.php
@@ -14,26 +14,26 @@ declare(strict_types=1);
 namespace Rollerworks\Component\Search\Extension\Core\Type;
 
 use Rollerworks\Component\Search\AbstractFieldType;
-use Rollerworks\Component\Search\FieldConfigInterface;
-use Rollerworks\Component\Search\ValueComparisonInterface;
+use Rollerworks\Component\Search\FieldConfig;
+use Rollerworks\Component\Search\ValueComparator;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class FieldType extends AbstractFieldType
+class SearchFieldType extends AbstractFieldType
 {
     /**
-     * @var ValueComparisonInterface
+     * @var ValueComparator
      */
     private $valueComparison;
 
     /**
      * Constructor.
      *
-     * @param ValueComparisonInterface $valueComparison
+     * @param ValueComparator $valueComparison
      */
-    public function __construct(ValueComparisonInterface $valueComparison)
+    public function __construct(ValueComparator $valueComparison)
     {
         $this->valueComparison = $valueComparison;
     }
@@ -49,7 +49,7 @@ class FieldType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildType(FieldConfigInterface $config, array $options)
+    public function buildType(FieldConfig $config, array $options)
     {
         $config->setValueComparison($this->valueComparison);
     }

--- a/src/Extension/Core/Type/TextType.php
+++ b/src/Extension/Core/Type/TextType.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Rollerworks\Component\Search\Extension\Core\Type;
 
 use Rollerworks\Component\Search\AbstractFieldType;
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\FieldConfig;
 use Rollerworks\Component\Search\Value\PatternMatch;
 
 /**
@@ -25,7 +25,7 @@ class TextType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildType(FieldConfigInterface $config, array $options)
+    public function buildType(FieldConfig $config, array $options)
     {
         $config->setValueTypeSupport(PatternMatch::class, true);
     }

--- a/src/Extension/Core/Type/TimeType.php
+++ b/src/Extension/Core/Type/TimeType.php
@@ -16,11 +16,11 @@ namespace Rollerworks\Component\Search\Extension\Core\Type;
 use Rollerworks\Component\Search\AbstractFieldType;
 use Rollerworks\Component\Search\Exception\InvalidConfigurationException;
 use Rollerworks\Component\Search\Extension\Core\DataTransformer\DateTimeToStringTransformer;
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\FieldConfig;
 use Rollerworks\Component\Search\SearchFieldView;
 use Rollerworks\Component\Search\Value\Compare;
 use Rollerworks\Component\Search\Value\Range;
-use Rollerworks\Component\Search\ValueComparisonInterface;
+use Rollerworks\Component\Search\ValueComparator;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -29,16 +29,16 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class TimeType extends AbstractFieldType
 {
     /**
-     * @var ValueComparisonInterface
+     * @var ValueComparator
      */
     private $valueComparison;
 
     /**
      * Constructor.
      *
-     * @param ValueComparisonInterface $valueComparison
+     * @param ValueComparator $valueComparison
      */
-    public function __construct(ValueComparisonInterface $valueComparison)
+    public function __construct(ValueComparator $valueComparison)
     {
         $this->valueComparison = $valueComparison;
     }
@@ -46,7 +46,7 @@ class TimeType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildType(FieldConfigInterface $config, array $options)
+    public function buildType(FieldConfig $config, array $options)
     {
         $format = 'H';
 
@@ -86,7 +86,7 @@ class TimeType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildView(SearchFieldView $view, FieldConfigInterface $config, array $options)
+    public function buildView(SearchFieldView $view, FieldConfig $config, array $options)
     {
         $pattern = 'H';
 

--- a/src/Extension/Core/Type/TimestampType.php
+++ b/src/Extension/Core/Type/TimestampType.php
@@ -15,10 +15,10 @@ namespace Rollerworks\Component\Search\Extension\Core\Type;
 
 use Rollerworks\Component\Search\AbstractFieldType;
 use Rollerworks\Component\Search\Extension\Core\DataTransformer\DateTimeToTimestampTransformer;
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\FieldConfig;
 use Rollerworks\Component\Search\Value\Compare;
 use Rollerworks\Component\Search\Value\Range;
-use Rollerworks\Component\Search\ValueComparisonInterface;
+use Rollerworks\Component\Search\ValueComparator;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -28,16 +28,16 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class TimestampType extends AbstractFieldType
 {
     /**
-     * @var ValueComparisonInterface
+     * @var ValueComparator
      */
     protected $valueComparison;
 
     /**
      * Constructor.
      *
-     * @param ValueComparisonInterface $valueComparison
+     * @param ValueComparator $valueComparison
      */
-    public function __construct(ValueComparisonInterface $valueComparison)
+    public function __construct(ValueComparator $valueComparison)
     {
         $this->valueComparison = $valueComparison;
     }
@@ -45,7 +45,7 @@ class TimestampType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildType(FieldConfigInterface $config, array $options)
+    public function buildType(FieldConfig $config, array $options)
     {
         $config->setValueComparison($this->valueComparison);
         $config->setValueTypeSupport(Range::class, true);

--- a/src/Extension/Core/ValueComparison/BirthdayValueComparison.php
+++ b/src/Extension/Core/ValueComparison/BirthdayValueComparison.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Extension\Core\ValueComparison;
 
-use Rollerworks\Component\Search\ValueIncrementerInterface;
+use Rollerworks\Component\Search\ValueIncrementer;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class BirthdayValueComparison implements ValueIncrementerInterface
+class BirthdayValueComparison implements ValueIncrementer
 {
     /**
      * Returns whether the first value is higher then the second value.

--- a/src/Extension/Core/ValueComparison/DateValueComparison.php
+++ b/src/Extension/Core/ValueComparison/DateValueComparison.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Extension\Core\ValueComparison;
 
-use Rollerworks\Component\Search\ValueIncrementerInterface;
+use Rollerworks\Component\Search\ValueIncrementer;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class DateValueComparison implements ValueIncrementerInterface
+class DateValueComparison implements ValueIncrementer
 {
     /**
      * Returns whether the first value is higher then the second value.

--- a/src/Extension/Core/ValueComparison/MoneyValueComparison.php
+++ b/src/Extension/Core/ValueComparison/MoneyValueComparison.php
@@ -15,12 +15,12 @@ namespace Rollerworks\Component\Search\Extension\Core\ValueComparison;
 
 use Money\Money;
 use Rollerworks\Component\Search\Extension\Core\Model\MoneyValue;
-use Rollerworks\Component\Search\ValueIncrementerInterface;
+use Rollerworks\Component\Search\ValueIncrementer;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class MoneyValueComparison implements ValueIncrementerInterface
+class MoneyValueComparison implements ValueIncrementer
 {
     /**
      * Returns whether the first value is higher then the second value.

--- a/src/Extension/Core/ValueComparison/NumberValueComparison.php
+++ b/src/Extension/Core/ValueComparison/NumberValueComparison.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Extension\Core\ValueComparison;
 
-use Rollerworks\Component\Search\ValueIncrementerInterface;
+use Rollerworks\Component\Search\ValueIncrementer;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class NumberValueComparison implements ValueIncrementerInterface
+class NumberValueComparison implements ValueIncrementer
 {
     /**
      * Returns whether the first value is higher then the second value.

--- a/src/Extension/Core/ValueComparison/SimpleValueComparison.php
+++ b/src/Extension/Core/ValueComparison/SimpleValueComparison.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Extension\Core\ValueComparison;
 
-use Rollerworks\Component\Search\ValueComparisonInterface;
+use Rollerworks\Component\Search\ValueComparator;
 
 /**
  * Default ValueComparison implementation, only able to compare equality.
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class SimpleValueComparison implements ValueComparisonInterface
+class SimpleValueComparison implements ValueComparator
 {
     /**
      * {@inheritdoc}

--- a/src/FieldConfig.php
+++ b/src/FieldConfig.php
@@ -18,7 +18,7 @@ namespace Rollerworks\Component\Search;
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-interface FieldConfigInterface
+interface FieldConfig
 {
     /**
      * Returns the name of field.
@@ -30,9 +30,9 @@ interface FieldConfigInterface
     /**
      * Returns the field type used to construct the field.
      *
-     * @return ResolvedFieldTypeInterface The field's type
+     * @return ResolvedFieldType The field's type
      */
-    public function getType(): ResolvedFieldTypeInterface;
+    public function getType(): ResolvedFieldType;
 
     /**
      * Returns whether value-type $type is accepted by the field.
@@ -61,14 +61,14 @@ interface FieldConfigInterface
      * Set the {@link ValueComparisonInterface} instance for optimizing
      * and validation.
      *
-     * @param ValueComparisonInterface $comparisonObj
+     * @param ValueComparator $comparisonObj
      */
-    public function setValueComparison(ValueComparisonInterface $comparisonObj);
+    public function setValueComparison(ValueComparator $comparisonObj);
 
     /**
      * Returns the configured {@link ValueComparisonInterface} instance.
      *
-     * @return ValueComparisonInterface|null
+     * @return ValueComparator|null
      */
     public function getValueComparison();
 
@@ -80,15 +80,15 @@ interface FieldConfigInterface
      * The transform method of the transformer is used to convert from the
      * view to the model format.
      *
-     * @param DataTransformerInterface|null $viewTransformer Use null to remove the
-     *                                                       transformer
+     * @param DataTransformer|null $viewTransformer Use null to remove the
+     *                                              transformer
      */
-    public function setViewTransformer(DataTransformerInterface $viewTransformer = null);
+    public function setViewTransformer(DataTransformer $viewTransformer = null);
 
     /**
      * Returns the view transformer of the field.
      *
-     * @return DataTransformerInterface|null
+     * @return DataTransformer|null
      */
     public function getViewTransformer();
 
@@ -100,15 +100,15 @@ interface FieldConfigInterface
      * The reverseTransform method of the transformer is used to convert from the
      * model to the normalized format.
      *
-     * @param DataTransformerInterface|null $viewTransformer Use null to remove the
-     *                                                       transformer
+     * @param DataTransformer|null $viewTransformer Use null to remove the
+     *                                              transformer
      */
-    public function setNormTransformer(DataTransformerInterface $viewTransformer = null);
+    public function setNormTransformer(DataTransformer $viewTransformer = null);
 
     /**
      * Returns the normalize transformer of the field.
      *
-     * @return DataTransformerInterface|null
+     * @return DataTransformer|null
      */
     public function getNormTransformer();
 

--- a/src/FieldSet.php
+++ b/src/FieldSet.php
@@ -28,8 +28,8 @@ class FieldSet implements \IteratorAggregate
     /**
      * Constructor.
      *
-     * @param FieldConfigInterface[] $fields
-     * @param string|null            $name   FQCN of the FieldSet configurator
+     * @param FieldConfig[] $fields
+     * @param string|null   $name   FQCN of the FieldSet configurator
      */
     public function __construct(array $fields, string $name = null)
     {
@@ -54,7 +54,7 @@ class FieldSet implements \IteratorAggregate
      *
      * @throws \RuntimeException When the field is not registered at this Fieldset
      *
-     * @return FieldConfigInterface
+     * @return FieldConfig
      */
     public function get(string $name)
     {
@@ -68,7 +68,7 @@ class FieldSet implements \IteratorAggregate
     /**
      * Returns all the registered fields in the set.
      *
-     * @return FieldConfigInterface[] [name] => {FieldConfigInterface object})
+     * @return FieldConfig[] [name] => {FieldConfigInterface object})
      */
     public function all(): array
     {

--- a/src/FieldSetBuilder.php
+++ b/src/FieldSetBuilder.php
@@ -18,7 +18,7 @@ use Rollerworks\Component\Search\Exception\BadMethodCallException;
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-interface FieldSetBuilderInterface
+interface FieldSetBuilder
 {
     /**
      * Add a field to the builder.
@@ -34,11 +34,11 @@ interface FieldSetBuilderInterface
     /**
      * Set a field on the builder.
      *
-     * @param FieldConfigInterface $field
+     * @param FieldConfig $field
      *
-     * @return FieldSetBuilderInterface
+     * @return FieldSetBuilder
      */
-    public function set(FieldConfigInterface $field);
+    public function set(FieldConfig $field);
 
     /**
      * Remove a field from the set-builder.
@@ -65,7 +65,7 @@ interface FieldSetBuilderInterface
      *
      * @param string $name
      *
-     * @return FieldConfigInterface
+     * @return FieldConfig
      */
     public function get(string $name);
 

--- a/src/FieldSetConfigurator.php
+++ b/src/FieldSetConfigurator.php
@@ -24,14 +24,14 @@ namespace Rollerworks\Component\Search;
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-interface FieldSetConfiguratorInterface
+interface FieldSetConfigurator
 {
     /**
      * Configure the FieldSet builder.
      *
-     * @param FieldSetBuilderInterface $builder
+     * @param FieldSetBuilder $builder
      *
      * @return void
      */
-    public function buildFieldSet(FieldSetBuilderInterface $builder);
+    public function buildFieldSet(FieldSetBuilder $builder);
 }

--- a/src/FieldSetRegistry.php
+++ b/src/FieldSetRegistry.php
@@ -15,7 +15,7 @@ namespace Rollerworks\Component\Search;
 
 use Rollerworks\Component\Search\Exception\InvalidArgumentException;
 
-interface FieldSetRegistryInterface
+interface FieldSetRegistry
 {
     /**
      * Returns a FieldSetConfiguratorInterface by name.
@@ -24,9 +24,9 @@ interface FieldSetRegistryInterface
      *
      * @throws InvalidArgumentException if the configurator can not be retrieved
      *
-     * @return FieldSetConfiguratorInterface
+     * @return FieldSetConfigurator
      */
-    public function getConfigurator(string $name): FieldSetConfiguratorInterface;
+    public function getConfigurator(string $name): FieldSetConfigurator;
 
     /**
      * Returns whether the given FieldSetConfigurator is supported.

--- a/src/FieldType.php
+++ b/src/FieldType.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-interface FieldTypeInterface
+interface FieldType
 {
     /**
      * Returns the name of the parent type.
@@ -40,10 +40,10 @@ interface FieldTypeInterface
      * This method is called for each type in the hierarchy starting from the
      * top most type. Type extensions can further modify the field.
      *
-     * @param FieldConfigInterface $config
-     * @param array                $options
+     * @param FieldConfig $config
+     * @param array       $options
      */
-    public function buildType(FieldConfigInterface $config, array $options);
+    public function buildType(FieldConfig $config, array $options);
 
     /**
      * Configures the SearchFieldView instance.
@@ -51,11 +51,11 @@ interface FieldTypeInterface
      * This method is called for each type in the hierarchy starting from the
      * top most type. Type extensions can further modify the view.
      *
-     * @see FieldTypeExtensionInterface::buildView()
+     * @see FieldTypeExtension::buildView()
      *
-     * @param SearchFieldView      $view
-     * @param FieldConfigInterface $config
-     * @param array                $options
+     * @param SearchFieldView $view
+     * @param FieldConfig     $config
+     * @param array           $options
      */
-    public function buildView(SearchFieldView $view, FieldConfigInterface $config, array $options);
+    public function buildView(SearchFieldView $view, FieldConfig $config, array $options);
 }

--- a/src/FieldTypeExtension.php
+++ b/src/FieldTypeExtension.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-interface FieldTypeExtensionInterface
+interface FieldTypeExtension
 {
     /**
      * Builds the type.
@@ -26,12 +26,12 @@ interface FieldTypeExtensionInterface
      * This method is called after the extended type has built the type to
      * further modify it.
      *
-     * @see FieldTypeInterface::buildType()
+     * @see SearchFieldType::buildType()
      *
-     * @param FieldConfigInterface $builder The config builder
-     * @param array                $options The options
+     * @param FieldConfig $builder The config builder
+     * @param array       $options The options
      */
-    public function buildType(FieldConfigInterface $builder, array $options);
+    public function buildType(FieldConfig $builder, array $options);
 
     /**
      * Builds the SearchFieldView.
@@ -39,10 +39,10 @@ interface FieldTypeExtensionInterface
      * This method is called after the extended type has built the view to
      * further modify it.
      *
-     * @param FieldConfigInterface $config
-     * @param SearchFieldView      $view
+     * @param FieldConfig     $config
+     * @param SearchFieldView $view
      */
-    public function buildView(FieldConfigInterface $config, SearchFieldView $view);
+    public function buildView(FieldConfig $config, SearchFieldView $view);
 
     /**
      * Overrides the default options from the extended type.

--- a/src/GenericFieldSetBuilder.php
+++ b/src/GenericFieldSetBuilder.php
@@ -20,10 +20,10 @@ use Rollerworks\Component\Search\Exception\InvalidArgumentException;
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-final class GenericFieldSetBuilder implements FieldSetBuilderInterface
+final class GenericFieldSetBuilder implements FieldSetBuilder
 {
     /**
-     * @var FieldConfigInterface[]
+     * @var FieldConfig[]
      */
     private $fields = [];
 
@@ -33,11 +33,11 @@ final class GenericFieldSetBuilder implements FieldSetBuilderInterface
     private $unresolvedFields = [];
 
     /**
-     * @var SearchFactoryInterface
+     * @var SearchFactory
      */
     private $searchFactory;
 
-    public function __construct(SearchFactoryInterface $searchFactory)
+    public function __construct(SearchFactory $searchFactory)
     {
         $this->searchFactory = $searchFactory;
     }
@@ -45,7 +45,7 @@ final class GenericFieldSetBuilder implements FieldSetBuilderInterface
     /**
      * {@inheritdoc}
      */
-    public function set(FieldConfigInterface $field)
+    public function set(FieldConfig $field)
     {
         $this->fields[$field->getName()] = $field;
 

--- a/src/GenericFieldSetBuilder.php
+++ b/src/GenericFieldSetBuilder.php
@@ -20,7 +20,7 @@ use Rollerworks\Component\Search\Exception\InvalidArgumentException;
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class FieldSetBuilder implements FieldSetBuilderInterface
+final class GenericFieldSetBuilder implements FieldSetBuilderInterface
 {
     /**
      * @var FieldConfigInterface[]

--- a/src/GenericResolvedFieldType.php
+++ b/src/GenericResolvedFieldType.php
@@ -22,7 +22,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class ResolvedFieldType implements ResolvedFieldTypeInterface
+class GenericResolvedFieldType implements ResolvedFieldTypeInterface
 {
     /**
      * @var FieldTypeInterface
@@ -35,7 +35,7 @@ class ResolvedFieldType implements ResolvedFieldTypeInterface
     private $typeExtensions;
 
     /**
-     * @var ResolvedFieldType
+     * @var GenericResolvedFieldType
      */
     private $parent;
 

--- a/src/GenericResolvedFieldType.php
+++ b/src/GenericResolvedFieldType.php
@@ -22,15 +22,15 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class GenericResolvedFieldType implements ResolvedFieldTypeInterface
+class GenericResolvedFieldType implements ResolvedFieldType
 {
     /**
-     * @var FieldTypeInterface
+     * @var FieldType
      */
     private $innerType;
 
     /**
-     * @var FieldTypeExtensionInterface[]
+     * @var FieldTypeExtension[]
      */
     private $typeExtensions;
 
@@ -47,17 +47,17 @@ class GenericResolvedFieldType implements ResolvedFieldTypeInterface
     /**
      * Constructor.
      *
-     * @param FieldTypeInterface         $innerType
-     * @param array                      $typeExtensions
-     * @param ResolvedFieldTypeInterface $parent
+     * @param FieldType         $innerType
+     * @param array             $typeExtensions
+     * @param ResolvedFieldType $parent
      *
-     * @throws UnexpectedTypeException When at least one of the given extensions is not an FieldTypeExtensionInterface
+     * @throws UnexpectedTypeException When at least one of the given extensions is not an FieldTypeExtension
      */
-    public function __construct(FieldTypeInterface $innerType, array $typeExtensions = [], ResolvedFieldTypeInterface $parent = null)
+    public function __construct(FieldType $innerType, array $typeExtensions = [], ResolvedFieldType $parent = null)
     {
         foreach ($typeExtensions as $extension) {
-            if (!$extension instanceof FieldTypeExtensionInterface) {
-                throw new UnexpectedTypeException($extension, FieldTypeExtensionInterface::class);
+            if (!$extension instanceof FieldTypeExtension) {
+                throw new UnexpectedTypeException($extension, FieldTypeExtension::class);
             }
         }
 
@@ -77,7 +77,7 @@ class GenericResolvedFieldType implements ResolvedFieldTypeInterface
     /**
      * {@inheritdoc}
      */
-    public function getInnerType(): FieldTypeInterface
+    public function getInnerType(): FieldType
     {
         return $this->innerType;
     }
@@ -93,7 +93,7 @@ class GenericResolvedFieldType implements ResolvedFieldTypeInterface
     /**
      * {@inheritdoc}
      */
-    public function createField(string $name, array $options = []): FieldConfigInterface
+    public function createField(string $name, array $options = []): FieldConfig
     {
         $options = $this->getOptionsResolver()->resolve($options);
 
@@ -103,7 +103,7 @@ class GenericResolvedFieldType implements ResolvedFieldTypeInterface
     /**
      * {@inheritdoc}
      */
-    public function buildType(FieldConfigInterface $config, array $options)
+    public function buildType(FieldConfig $config, array $options)
     {
         if (null !== $this->parent) {
             $this->parent->buildType($config, $options);
@@ -119,7 +119,7 @@ class GenericResolvedFieldType implements ResolvedFieldTypeInterface
     /**
      * {@inheritdoc}
      */
-    public function createFieldView(FieldConfigInterface $config)
+    public function createFieldView(FieldConfig $config)
     {
         $view = $this->newFieldView($config);
         $view->vars = array_merge($view->vars, [
@@ -135,7 +135,7 @@ class GenericResolvedFieldType implements ResolvedFieldTypeInterface
     /**
      * {@inheritdoc}
      */
-    public function buildFieldView(SearchFieldView $view, FieldConfigInterface $config, array $options)
+    public function buildFieldView(SearchFieldView $view, FieldConfig $config, array $options)
     {
         if (null !== $this->parent) {
             $this->parent->buildFieldView($view, $config, $options);
@@ -178,9 +178,9 @@ class GenericResolvedFieldType implements ResolvedFieldTypeInterface
      * @param string $name    The name of the field
      * @param array  $options The builder options
      *
-     * @return FieldConfigInterface The new field instance
+     * @return FieldConfig The new field instance
      */
-    protected function newField($name, array $options): FieldConfigInterface
+    protected function newField($name, array $options): FieldConfig
     {
         return new SearchField($name, $this, $options);
     }
@@ -190,11 +190,11 @@ class GenericResolvedFieldType implements ResolvedFieldTypeInterface
      *
      * Override this method if you want to customize the view class.
      *
-     * @param FieldConfigInterface $config The search field
+     * @param FieldConfig $config The search field
      *
      * @return SearchFieldView The new view instance
      */
-    protected function newFieldView(FieldConfigInterface $config): SearchFieldView
+    protected function newFieldView(FieldConfig $config): SearchFieldView
     {
         return new SearchFieldView($config);
     }

--- a/src/GenericResolvedFieldTypeFactory.php
+++ b/src/GenericResolvedFieldTypeFactory.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search;
 
-class GenericResolvedFieldTypeFactory implements ResolvedFieldTypeFactoryInterface
+class GenericResolvedFieldTypeFactory implements ResolvedFieldTypeFactory
 {
     /**
      * {@inheritdoc}
      */
-    public function createResolvedType(FieldTypeInterface $type, array $typeExtensions, ResolvedFieldTypeInterface $parent = null): ResolvedFieldTypeInterface
+    public function createResolvedType(FieldType $type, array $typeExtensions, ResolvedFieldType $parent = null): ResolvedFieldType
     {
         return new GenericResolvedFieldType($type, $typeExtensions, $parent);
     }

--- a/src/GenericResolvedFieldTypeFactory.php
+++ b/src/GenericResolvedFieldTypeFactory.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search;
 
-class ResolvedFieldTypeFactory implements ResolvedFieldTypeFactoryInterface
+class GenericResolvedFieldTypeFactory implements ResolvedFieldTypeFactoryInterface
 {
     /**
      * {@inheritdoc}
      */
     public function createResolvedType(FieldTypeInterface $type, array $typeExtensions, ResolvedFieldTypeInterface $parent = null): ResolvedFieldTypeInterface
     {
-        return new ResolvedFieldType($type, $typeExtensions, $parent);
+        return new GenericResolvedFieldType($type, $typeExtensions, $parent);
     }
 }

--- a/src/GenericSearchFactory.php
+++ b/src/GenericSearchFactory.php
@@ -18,14 +18,14 @@ use Rollerworks\Component\Search\ConditionOptimizer\ChainOptimizer;
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-final class GenericSearchFactory implements SearchFactoryInterface
+final class GenericSearchFactory implements SearchFactory
 {
     private $registry;
     private $fieldSetRegistry;
     private $serializer;
     private $optimizer;
 
-    public function __construct(FieldRegistryInterface $registry, FieldSetRegistryInterface $fieldSetRegistry, SearchConditionOptimizerInterface $optimizer = null)
+    public function __construct(TypeRegistry $registry, FieldSetRegistry $fieldSetRegistry, SearchConditionOptimizer $optimizer = null)
     {
         $this->registry = $registry;
         $this->fieldSetRegistry = $fieldSetRegistry;
@@ -38,7 +38,7 @@ final class GenericSearchFactory implements SearchFactoryInterface
      */
     public function createFieldSet($configurator): FieldSet
     {
-        if (!$configurator instanceof FieldSetConfiguratorInterface) {
+        if (!$configurator instanceof FieldSetConfigurator) {
             $configurator = $this->fieldSetRegistry->getConfigurator($configurator);
         }
 
@@ -51,7 +51,7 @@ final class GenericSearchFactory implements SearchFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createField(string $name, string $type, array $options = []): FieldConfigInterface
+    public function createField(string $name, string $type, array $options = []): FieldConfig
     {
         $type = $this->registry->getType($type);
         $field = $type->createField($name, $options);
@@ -66,7 +66,7 @@ final class GenericSearchFactory implements SearchFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createFieldSetBuilder(): FieldSetBuilderInterface
+    public function createFieldSetBuilder(): FieldSetBuilder
     {
         return new GenericFieldSetBuilder($this);
     }

--- a/src/GenericSearchFactory.php
+++ b/src/GenericSearchFactory.php
@@ -18,7 +18,7 @@ use Rollerworks\Component\Search\ConditionOptimizer\ChainOptimizer;
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class SearchFactory implements SearchFactoryInterface
+final class GenericSearchFactory implements SearchFactoryInterface
 {
     private $registry;
     private $fieldSetRegistry;
@@ -68,7 +68,7 @@ class SearchFactory implements SearchFactoryInterface
      */
     public function createFieldSetBuilder(): FieldSetBuilderInterface
     {
-        return new FieldSetBuilder($this);
+        return new GenericFieldSetBuilder($this);
     }
 
     /**

--- a/src/GenericTypeRegistry.php
+++ b/src/GenericTypeRegistry.php
@@ -20,7 +20,7 @@ use Rollerworks\Component\Search\Exception\UnexpectedTypeException;
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class FieldRegistry implements FieldRegistryInterface
+final class GenericTypeRegistry implements FieldRegistryInterface
 {
     /**
      * Extensions.

--- a/src/GenericTypeRegistry.php
+++ b/src/GenericTypeRegistry.php
@@ -13,45 +13,45 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search;
 
-use Rollerworks\Component\Search\Exception\ExceptionInterface;
 use Rollerworks\Component\Search\Exception\InvalidArgumentException;
+use Rollerworks\Component\Search\Exception\SearchException;
 use Rollerworks\Component\Search\Exception\UnexpectedTypeException;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-final class GenericTypeRegistry implements FieldRegistryInterface
+final class GenericTypeRegistry implements TypeRegistry
 {
     /**
      * Extensions.
      *
-     * @var SearchExtensionInterface[]
+     * @var SearchExtension[]
      */
     private $extensions = [];
 
     /**
-     * @var ResolvedFieldTypeInterface[]
+     * @var ResolvedFieldType[]
      */
     private $types = [];
 
     /**
-     * @var ResolvedFieldTypeFactoryInterface
+     * @var ResolvedFieldTypeFactory
      */
     private $resolvedTypeFactory;
 
     /**
      * Constructor.
      *
-     * @param SearchExtensionInterface[]        $extensions          An array of SearchExtensionInterface
-     * @param ResolvedFieldTypeFactoryInterface $resolvedTypeFactory The factory for resolved field types
+     * @param SearchExtension[]        $extensions          An array of SearchExtension
+     * @param ResolvedFieldTypeFactory $resolvedTypeFactory The factory for resolved field types
      *
-     * @throws UnexpectedTypeException if an extension does not implement SearchExtensionInterface
+     * @throws UnexpectedTypeException if an extension does not implement SearchExtension
      */
-    public function __construct(array $extensions, ResolvedFieldTypeFactoryInterface $resolvedTypeFactory)
+    public function __construct(array $extensions, ResolvedFieldTypeFactory $resolvedTypeFactory)
     {
         foreach ($extensions as $extension) {
-            if (!$extension instanceof SearchExtensionInterface) {
-                throw new UnexpectedTypeException($extension, SearchExtensionInterface::class);
+            if (!$extension instanceof SearchExtension) {
+                throw new UnexpectedTypeException($extension, SearchExtension::class);
             }
         }
 
@@ -62,7 +62,7 @@ final class GenericTypeRegistry implements FieldRegistryInterface
     /**
      * {@inheritdoc}
      */
-    public function getType(string $name): ResolvedFieldTypeInterface
+    public function getType(string $name): ResolvedFieldType
     {
         if (!isset($this->types[$name])) {
             $type = null;
@@ -77,7 +77,7 @@ final class GenericTypeRegistry implements FieldRegistryInterface
 
             if (!$type) {
                 // Support fully-qualified class names.
-                if (!class_exists($name) || !in_array(FieldTypeInterface::class, class_implements($name), true)) {
+                if (!class_exists($name) || !in_array(FieldType::class, class_implements($name), true)) {
                     throw new InvalidArgumentException(sprintf('Could not load type "%s"', $name));
                 }
 
@@ -101,7 +101,7 @@ final class GenericTypeRegistry implements FieldRegistryInterface
 
         try {
             $this->getType($name);
-        } catch (ExceptionInterface $e) {
+        } catch (SearchException $e) {
             return false;
         }
 
@@ -116,7 +116,7 @@ final class GenericTypeRegistry implements FieldRegistryInterface
         return $this->extensions;
     }
 
-    private function resolveType(FieldTypeInterface $type): ResolvedFieldTypeInterface
+    private function resolveType(FieldType $type): ResolvedFieldType
     {
         $parentType = $type->getParent();
         $fqcn = get_class($type);

--- a/src/Input/AbstractInput.php
+++ b/src/Input/AbstractInput.php
@@ -17,14 +17,14 @@ use Rollerworks\Component\Search\ConditionErrorMessage;
 use Rollerworks\Component\Search\ErrorList;
 use Rollerworks\Component\Search\Exception\GroupsNestingException;
 use Rollerworks\Component\Search\Exception\GroupsOverflowException;
-use Rollerworks\Component\Search\InputProcessorInterface;
+use Rollerworks\Component\Search\InputProcessor;
 
 /**
  * AbstractInput provides the shared logic for the InputProcessors.
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-abstract class AbstractInput implements InputProcessorInterface
+abstract class AbstractInput implements InputProcessor
 {
     /**
      * @var ProcessorConfig

--- a/src/Input/ArrayInput.php
+++ b/src/Input/ArrayInput.php
@@ -17,7 +17,7 @@ use Rollerworks\Component\Search\ErrorList;
 use Rollerworks\Component\Search\Exception\InputProcessorException;
 use Rollerworks\Component\Search\Exception\InvalidSearchConditionException;
 use Rollerworks\Component\Search\Exception\UnexpectedTypeException;
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\FieldConfig;
 use Rollerworks\Component\Search\SearchCondition;
 use Rollerworks\Component\Search\Value\ValuesBag;
 use Rollerworks\Component\Search\Value\ValuesGroup;
@@ -155,7 +155,7 @@ class ArrayInput extends AbstractInput
         }
     }
 
-    private function valuesToBag(FieldConfigInterface $field, array $values, ValuesBag $valuesBag, string $path)
+    private function valuesToBag(FieldConfig $field, array $values, ValuesBag $valuesBag, string $path)
     {
         $this->valuesFactory->initContext($field, $valuesBag, $path);
 

--- a/src/Input/FieldValuesFactory.php
+++ b/src/Input/FieldValuesFactory.php
@@ -14,19 +14,19 @@ declare(strict_types=1);
 namespace Rollerworks\Component\Search\Input;
 
 use Rollerworks\Component\Search\ConditionErrorMessage;
-use Rollerworks\Component\Search\DataTransformerInterface;
+use Rollerworks\Component\Search\DataTransformer;
 use Rollerworks\Component\Search\ErrorList;
 use Rollerworks\Component\Search\Exception\InvalidArgumentException;
 use Rollerworks\Component\Search\Exception\TransformationFailedException;
 use Rollerworks\Component\Search\Exception\UnsupportedValueTypeException;
 use Rollerworks\Component\Search\Exception\ValuesOverflowException;
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\FieldConfig;
 use Rollerworks\Component\Search\Value\Compare;
 use Rollerworks\Component\Search\Value\ExcludedRange;
 use Rollerworks\Component\Search\Value\PatternMatch;
 use Rollerworks\Component\Search\Value\Range;
 use Rollerworks\Component\Search\Value\ValuesBag;
-use Rollerworks\Component\Search\ValueComparisonInterface;
+use Rollerworks\Component\Search\ValueComparator;
 
 /**
  * The FieldValuesFactory works as a wrapper around the ValuesBag
@@ -37,17 +37,17 @@ use Rollerworks\Component\Search\ValueComparisonInterface;
 class FieldValuesFactory
 {
     /**
-     * @var FieldConfigInterface
+     * @var FieldConfig
      */
     protected $config;
 
     /**
-     * @var DataTransformerInterface|null
+     * @var DataTransformer|null
      */
     protected $normTransformer;
 
     /**
-     * @var DataTransformerInterface|null
+     * @var DataTransformer|null
      */
     protected $viewTransformer;
 
@@ -63,7 +63,7 @@ class FieldValuesFactory
     private $valuesBag;
 
     /**
-     * @var ValueComparisonInterface
+     * @var ValueComparator
      */
     private $valueComparison;
 
@@ -79,7 +79,7 @@ class FieldValuesFactory
         $this->validator = $validator;
     }
 
-    public function initContext(FieldConfigInterface $field, ValuesBag $valuesBag, string $path)
+    public function initContext(FieldConfig $field, ValuesBag $valuesBag, string $path)
     {
         $this->config = $field;
         $this->valuesBag = $valuesBag;

--- a/src/Input/NullValidator.php
+++ b/src/Input/NullValidator.php
@@ -14,14 +14,14 @@ declare(strict_types=1);
 namespace Rollerworks\Component\Search\Input;
 
 use Rollerworks\Component\Search\ErrorList;
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\FieldConfig;
 
 final class NullValidator implements Validator
 {
     /**
      * {@inheritdoc}
      */
-    public function initializeContext(FieldConfigInterface $field, ErrorList $errorList)
+    public function initializeContext(FieldConfig $field, ErrorList $errorList)
     {
         // no-op
     }

--- a/src/Input/StringQueryInput.php
+++ b/src/Input/StringQueryInput.php
@@ -18,7 +18,7 @@ use Rollerworks\Component\Search\Exception\InputProcessorException;
 use Rollerworks\Component\Search\Exception\InvalidSearchConditionException;
 use Rollerworks\Component\Search\Exception\UnexpectedTypeException;
 use Rollerworks\Component\Search\Exception\UnknownFieldException;
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\FieldConfig;
 use Rollerworks\Component\Search\FieldSet;
 use Rollerworks\Component\Search\Input\StringQuery\Lexer;
 use Rollerworks\Component\Search\Input\StringQuery\QueryException;
@@ -166,7 +166,7 @@ class StringQueryInput extends AbstractInput
     public function __construct(Validator $validator = null, callable $labelResolver = null)
     {
         $this->lexer = new Lexer();
-        $this->labelResolver = $labelResolver ?? function (FieldConfigInterface $field) {
+        $this->labelResolver = $labelResolver ?? function (FieldConfig $field) {
             return $field->getOption('label', $field->getName());
         };
 
@@ -414,13 +414,13 @@ class StringQueryInput extends AbstractInput
      * FieldValues ::= [ "!" ] String {"," [ "!" ] String |
      *     [ "!" ] Range | Comparison | PatternMatch}* [ ";" ].
      *
-     * @param FieldConfigInterface $field
-     * @param ValuesBag            $valuesBag
-     * @param string               $path
+     * @param FieldConfig $field
+     * @param ValuesBag   $valuesBag
+     * @param string      $path
      *
      * @return ValuesBag
      */
-    private function fieldValues(FieldConfigInterface $field, ValuesBag $valuesBag, string $path)
+    private function fieldValues(FieldConfig $field, ValuesBag $valuesBag, string $path)
     {
         $hasValues = false;
         $this->valuesFactory->initContext($field, $valuesBag, $path);

--- a/src/Input/Validator.php
+++ b/src/Input/Validator.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Rollerworks\Component\Search\Input;
 
 use Rollerworks\Component\Search\ErrorList;
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\FieldConfig;
 
 /**
  * The Validator validates input values according to a set of
@@ -29,12 +29,12 @@ interface Validator
      *
      * Whenever calling validate(), this context needs to be used.
      *
-     * @param FieldConfigInterface $field
-     * @param ErrorList            $errorList
+     * @param FieldConfig $field
+     * @param ErrorList   $errorList
      *
      * @return void
      */
-    public function initializeContext(FieldConfigInterface $field, ErrorList $errorList);
+    public function initializeContext(FieldConfig $field, ErrorList $errorList);
 
     /**
      * Validates and returns whether the value is valid.

--- a/src/Input/XmlInput.php
+++ b/src/Input/XmlInput.php
@@ -18,7 +18,7 @@ use Rollerworks\Component\Search\ErrorList;
 use Rollerworks\Component\Search\Exception\InputProcessorException;
 use Rollerworks\Component\Search\Exception\InvalidSearchConditionException;
 use Rollerworks\Component\Search\Exception\UnexpectedTypeException;
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\FieldConfig;
 use Rollerworks\Component\Search\SearchCondition;
 use Rollerworks\Component\Search\Util\XmlUtil;
 use Rollerworks\Component\Search\Value\Compare;
@@ -141,7 +141,7 @@ class XmlInput extends AbstractInput
         }
     }
 
-    private function valuesToBag(FieldConfigInterface $field, \SimpleXMLElement $values, ValuesBag $valuesBag, string $path)
+    private function valuesToBag(FieldConfig $field, \SimpleXMLElement $values, ValuesBag $valuesBag, string $path)
     {
         $this->valuesFactory->initContext($field, $valuesBag, $path.'/');
 

--- a/src/InputProcessor.php
+++ b/src/InputProcessor.php
@@ -16,11 +16,11 @@ namespace Rollerworks\Component\Search;
 use Rollerworks\Component\Search\Input\ProcessorConfig;
 
 /**
- * The InputProcessorInterface must be implemented by all input-processor.
+ * The InputProcessor must be implemented by all input-processor.
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-interface InputProcessorInterface
+interface InputProcessor
 {
     /**
      * Process the input and returns the result.

--- a/src/LazyFieldSetRegistry.php
+++ b/src/LazyFieldSetRegistry.php
@@ -16,7 +16,7 @@ namespace Rollerworks\Component\Search;
 use Rollerworks\Component\Search\Exception\InvalidArgumentException;
 use Rollerworks\Component\Search\Exception\UnexpectedTypeException;
 
-final class LazyFieldSetRegistry implements FieldSetRegistryInterface
+final class LazyFieldSetRegistry implements FieldSetRegistry
 {
     private $configurators;
 
@@ -55,9 +55,9 @@ final class LazyFieldSetRegistry implements FieldSetRegistryInterface
      *
      * @throws InvalidArgumentException if the configurator can not be retrieved
      *
-     * @return FieldSetConfiguratorInterface
+     * @return FieldSetConfigurator
      */
-    public function getConfigurator(string $name): FieldSetConfiguratorInterface
+    public function getConfigurator(string $name): FieldSetConfigurator
     {
         if (!isset($this->configurators[$name])) {
             $configurator = null;
@@ -68,7 +68,7 @@ final class LazyFieldSetRegistry implements FieldSetRegistryInterface
 
             if (!$configurator) {
                 // Support fully-qualified class names.
-                if (!class_exists($name) || !in_array(FieldSetConfiguratorInterface::class, class_implements($name), true)) {
+                if (!class_exists($name) || !in_array(FieldSetConfigurator::class, class_implements($name), true)) {
                     throw new InvalidArgumentException(sprintf('Could not load FieldSet configurator "%s"', $name));
                 }
 
@@ -98,6 +98,6 @@ final class LazyFieldSetRegistry implements FieldSetRegistryInterface
             return true;
         }
 
-        return class_exists($name) && in_array(FieldSetConfiguratorInterface::class, class_implements($name), true);
+        return class_exists($name) && in_array(FieldSetConfigurator::class, class_implements($name), true);
     }
 }

--- a/src/LazyFieldSetRegistry.php
+++ b/src/LazyFieldSetRegistry.php
@@ -16,7 +16,7 @@ namespace Rollerworks\Component\Search;
 use Rollerworks\Component\Search\Exception\InvalidArgumentException;
 use Rollerworks\Component\Search\Exception\UnexpectedTypeException;
 
-final class FieldSetRegistry implements FieldSetRegistryInterface
+final class LazyFieldSetRegistry implements FieldSetRegistryInterface
 {
     private $configurators;
 

--- a/src/PreloadedExtension.php
+++ b/src/PreloadedExtension.php
@@ -15,7 +15,7 @@ namespace Rollerworks\Component\Search;
 
 use Rollerworks\Component\Search\Exception\InvalidArgumentException;
 
-class PreloadedExtension implements SearchExtensionInterface
+class PreloadedExtension implements SearchExtension
 {
     /**
      * @var array
@@ -30,8 +30,8 @@ class PreloadedExtension implements SearchExtensionInterface
     /**
      * Constructor.
      *
-     * @param FieldTypeInterface[]          $types          The types that the extension should support
-     * @param FieldTypeExtensionInterface[] $typeExtensions The type extensions that the extension should support
+     * @param FieldType[]          $types          The types that the extension should support
+     * @param FieldTypeExtension[] $typeExtensions The type extensions that the extension should support
      */
     public function __construct(array $types, array $typeExtensions = [])
     {
@@ -42,7 +42,7 @@ class PreloadedExtension implements SearchExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public function getType(string $name): FieldTypeInterface
+    public function getType(string $name): FieldType
     {
         if (!isset($this->types[$name])) {
             throw new InvalidArgumentException(

--- a/src/ResolvedFieldType.php
+++ b/src/ResolvedFieldType.php
@@ -18,26 +18,26 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * A wrapper for a field type and its extensions.
  */
-interface ResolvedFieldTypeInterface
+interface ResolvedFieldType
 {
     /**
      * Returns the parent type.
      *
-     * @return ResolvedFieldTypeInterface|null The parent type or null
+     * @return ResolvedFieldType|null The parent type or null
      */
     public function getParent();
 
     /**
      * Returns the wrapped field type.
      *
-     * @return FieldTypeInterface The wrapped field type
+     * @return FieldType The wrapped field type
      */
-    public function getInnerType(): FieldTypeInterface;
+    public function getInnerType(): FieldType;
 
     /**
      * Returns the extensions of the wrapped field type.
      *
-     * @return FieldTypeExtensionInterface[]
+     * @return FieldTypeExtension[]
      */
     public function getTypeExtensions(): array;
 
@@ -47,9 +47,9 @@ interface ResolvedFieldTypeInterface
      * @param string $name
      * @param array  $options
      *
-     * @return FieldConfigInterface
+     * @return FieldConfig
      */
-    public function createField(string $name, array $options = []): FieldConfigInterface;
+    public function createField(string $name, array $options = []): FieldConfig;
 
     /**
      * This configures the {@link FieldConfigInterface}.
@@ -57,28 +57,28 @@ interface ResolvedFieldTypeInterface
      * This method is called for each type in the hierarchy starting from the
      * top most type. Type extensions can further modify the field.
      *
-     * @param FieldConfigInterface $config
-     * @param array                $options
+     * @param FieldConfig $config
+     * @param array       $options
      */
-    public function buildType(FieldConfigInterface $config, array $options);
+    public function buildType(FieldConfig $config, array $options);
 
     /**
      * Creates a new SearchFieldView for a field of this type.
      *
-     * @param FieldConfigInterface $config
+     * @param FieldConfig $config
      *
      * @return SearchFieldView
      */
-    public function createFieldView(FieldConfigInterface $config);
+    public function createFieldView(FieldConfig $config);
 
     /**
      * Configures a SearchFieldView for the type hierarchy.
      *
-     * @param SearchFieldView      $view
-     * @param FieldConfigInterface $config
-     * @param array                $options
+     * @param SearchFieldView $view
+     * @param FieldConfig     $config
+     * @param array           $options
      */
-    public function buildFieldView(SearchFieldView $view, FieldConfigInterface $config, array $options);
+    public function buildFieldView(SearchFieldView $view, FieldConfig $config, array $options);
 
     /**
      * Returns the configured options resolver used for this type.

--- a/src/ResolvedFieldTypeFactory.php
+++ b/src/ResolvedFieldTypeFactory.php
@@ -16,18 +16,18 @@ namespace Rollerworks\Component\Search;
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-interface ResolvedFieldTypeFactoryInterface
+interface ResolvedFieldTypeFactory
 {
     /**
      * Resolves a field type.
      *
-     * @param FieldTypeInterface         $type
-     * @param array                      $typeExtensions
-     * @param ResolvedFieldTypeInterface $parent
+     * @param FieldType         $type
+     * @param array             $typeExtensions
+     * @param ResolvedFieldType $parent
      *
      * @throws Exception\InvalidArgumentException if the types parent cannot be retrieved from any extension
      *
-     * @return ResolvedFieldTypeInterface
+     * @return ResolvedFieldType
      */
-    public function createResolvedType(FieldTypeInterface $type, array $typeExtensions, ResolvedFieldTypeInterface $parent = null): ResolvedFieldTypeInterface;
+    public function createResolvedType(FieldType $type, array $typeExtensions, ResolvedFieldType $parent = null): ResolvedFieldType;
 }

--- a/src/SearchConditionOptimizer.php
+++ b/src/SearchConditionOptimizer.php
@@ -20,15 +20,12 @@ namespace Rollerworks\Component\Search;
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-interface SearchConditionOptimizerInterface
+interface SearchConditionOptimizer
 {
     /**
      * Optimizes a {@link \Rollerworks\Component\Search\SearchCondition} instance.
      *
      * Optimizing may remove duplicated values, normalize overlapping values, etc.
-     *
-     * If the search condition has errors the optimizer is should
-     * ignore the condition and do nothing.
      *
      * @param SearchCondition $condition
      */

--- a/src/SearchConditionSerializer.php
+++ b/src/SearchConditionSerializer.php
@@ -27,7 +27,7 @@ class SearchConditionSerializer
 {
     private $searchFactory;
 
-    public function __construct(SearchFactoryInterface $searchFactory)
+    public function __construct(SearchFactory $searchFactory)
     {
         $this->searchFactory = $searchFactory;
     }

--- a/src/SearchExtension.php
+++ b/src/SearchExtension.php
@@ -16,7 +16,7 @@ namespace Rollerworks\Component\Search;
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-interface SearchExtensionInterface
+interface SearchExtension
 {
     /**
      * Returns a type by name.
@@ -25,9 +25,9 @@ interface SearchExtensionInterface
      *
      * @throws Exception\InvalidArgumentException if the given type is not supported by this extension
      *
-     * @return FieldTypeInterface
+     * @return FieldType
      */
-    public function getType(string $name): FieldTypeInterface;
+    public function getType(string $name): FieldType;
 
     /**
      * Returns whether the given type is supported.
@@ -43,7 +43,7 @@ interface SearchExtensionInterface
      *
      * @param string $name The name of the type
      *
-     * @return FieldTypeExtensionInterface[]
+     * @return FieldTypeExtension[]
      */
     public function getTypeExtensions(string $name): array;
 }

--- a/src/SearchFactory.php
+++ b/src/SearchFactory.php
@@ -16,14 +16,14 @@ namespace Rollerworks\Component\Search;
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-interface SearchFactoryInterface
+interface SearchFactory
 {
     /**
      * Create a new FieldSet instance with the configurator name
      * as FieldSet name.
      *
-     * @param string|FieldSetConfiguratorInterface $configurator Configurator for building the FieldSet,
-     *                                                           a string will be resolved to a configurator
+     * @param string|FieldSetConfigurator $configurator Configurator for building the FieldSet,
+     *                                                  a string will be resolved to a configurator
      *
      * @return FieldSet
      */
@@ -36,16 +36,16 @@ interface SearchFactoryInterface
      * @param string $type    Type of the field
      * @param array  $options Array of options for building the field
      *
-     * @return FieldConfigInterface
+     * @return FieldConfig
      */
-    public function createField(string $name, string $type, array $options = []): FieldConfigInterface;
+    public function createField(string $name, string $type, array $options = []): FieldConfig;
 
     /**
      * Create a new FieldSetBuilderInterface instance.
      *
-     * @return FieldSetBuilderInterface
+     * @return FieldSetBuilder
      */
-    public function createFieldSetBuilder(): FieldSetBuilderInterface;
+    public function createFieldSetBuilder(): FieldSetBuilder;
 
     /**
      * Get the SearchConditionSerializer.

--- a/src/SearchFactoryBuilder.php
+++ b/src/SearchFactoryBuilder.php
@@ -19,17 +19,17 @@ namespace Rollerworks\Component\Search;
 class SearchFactoryBuilder
 {
     /**
-     * @var ResolvedFieldTypeFactoryInterface
+     * @var ResolvedFieldTypeFactory
      */
     private $resolvedTypeFactory;
 
     /**
-     * @var SearchExtensionInterface[]
+     * @var SearchExtension[]
      */
     private $extensions = [];
 
     /**
-     * @var FieldTypeInterface[]
+     * @var FieldType[]
      */
     private $types = [];
 
@@ -39,23 +39,23 @@ class SearchFactoryBuilder
     private $typeExtensions = [];
 
     /**
-     * @var FieldSetRegistryInterface
+     * @var FieldSetRegistry
      */
     private $fieldSetRegistry;
 
     /**
-     * @var SearchConditionOptimizerInterface
+     * @var SearchConditionOptimizer
      */
     private $conditionOptimizer;
 
     /**
      * Sets the factory for creating ResolvedFieldTypeInterface instances.
      *
-     * @param ResolvedFieldTypeFactoryInterface $resolvedTypeFactory
+     * @param ResolvedFieldTypeFactory $resolvedTypeFactory
      *
      * @return $this The builder
      */
-    public function setResolvedTypeFactory(ResolvedFieldTypeFactoryInterface $resolvedTypeFactory)
+    public function setResolvedTypeFactory(ResolvedFieldTypeFactory $resolvedTypeFactory)
     {
         $this->resolvedTypeFactory = $resolvedTypeFactory;
 
@@ -65,11 +65,11 @@ class SearchFactoryBuilder
     /**
      * Sets the default SearchCondition optimizer.
      *
-     * @param SearchConditionOptimizerInterface $conditionOptimizer
+     * @param SearchConditionOptimizer $conditionOptimizer
      *
      * @return $this The builder
      */
-    public function setSearchConditionOptimizer(SearchConditionOptimizerInterface $conditionOptimizer)
+    public function setSearchConditionOptimizer(SearchConditionOptimizer $conditionOptimizer)
     {
         $this->conditionOptimizer = $conditionOptimizer;
 
@@ -79,11 +79,11 @@ class SearchFactoryBuilder
     /**
      * Adds an extension to be loaded by the factory.
      *
-     * @param SearchExtensionInterface $extension The extension
+     * @param SearchExtension $extension The extension
      *
      * @return $this The builder
      */
-    public function addExtension(SearchExtensionInterface $extension)
+    public function addExtension(SearchExtension $extension)
     {
         $this->extensions[] = $extension;
 
@@ -93,7 +93,7 @@ class SearchFactoryBuilder
     /**
      * Adds a list of extensions to be loaded by the factory.
      *
-     * @param SearchExtensionInterface[] $extensions The extensions
+     * @param SearchExtension[] $extensions The extensions
      *
      * @return $this The builder
      */
@@ -107,11 +107,11 @@ class SearchFactoryBuilder
     /**
      * Adds a field type to the factory.
      *
-     * @param FieldTypeInterface $type The field type
+     * @param FieldType $type The field type
      *
      * @return $this The builder
      */
-    public function addType(FieldTypeInterface $type)
+    public function addType(FieldType $type)
     {
         $this->types[get_class($type)] = $type;
 
@@ -121,7 +121,7 @@ class SearchFactoryBuilder
     /**
      * Adds a list of field types to the factory.
      *
-     * @param FieldTypeInterface[] $types The field types
+     * @param FieldType[] $types The field types
      *
      * @return $this The builder
      */
@@ -137,11 +137,11 @@ class SearchFactoryBuilder
     /**
      * Adds a field type extension to the factory.
      *
-     * @param FieldTypeExtensionInterface $typeExtension The field type extension
+     * @param FieldTypeExtension $typeExtension The field type extension
      *
      * @return $this The builder
      */
-    public function addTypeExtension(FieldTypeExtensionInterface $typeExtension)
+    public function addTypeExtension(FieldTypeExtension $typeExtension)
     {
         $this->typeExtensions[$typeExtension->getExtendedType()][] = $typeExtension;
 
@@ -151,7 +151,7 @@ class SearchFactoryBuilder
     /**
      * Adds a list of field type extension to the factory.
      *
-     * @param FieldTypeExtensionInterface[] $typeExtensions The field type extension
+     * @param FieldTypeExtension[] $typeExtensions The field type extension
      *
      * @return $this The builder
      */
@@ -167,9 +167,9 @@ class SearchFactoryBuilder
     /**
      * Builds and returns the factory.
      *
-     * @return SearchFactoryInterface The search factory
+     * @return SearchFactory The search factory
      */
-    public function getSearchFactory(): SearchFactoryInterface
+    public function getSearchFactory(): SearchFactory
     {
         $extensions = $this->extensions;
 

--- a/src/SearchFactoryBuilder.php
+++ b/src/SearchFactoryBuilder.php
@@ -177,9 +177,9 @@ class SearchFactoryBuilder
             $extensions[] = new PreloadedExtension($this->types, $this->typeExtensions);
         }
 
-        $resolvedTypeFactory = $this->resolvedTypeFactory ?? new ResolvedFieldTypeFactory();
-        $registry = new FieldRegistry($extensions, $resolvedTypeFactory);
+        $resolvedTypeFactory = $this->resolvedTypeFactory ?? new GenericResolvedFieldTypeFactory();
+        $registry = new GenericTypeRegistry($extensions, $resolvedTypeFactory);
 
-        return new SearchFactory($registry, $this->fieldSetRegistry ?? new FieldSetRegistry(), $this->conditionOptimizer);
+        return new GenericSearchFactory($registry, $this->fieldSetRegistry ?? new LazyFieldSetRegistry(), $this->conditionOptimizer);
     }
 }

--- a/src/SearchField.php
+++ b/src/SearchField.php
@@ -23,7 +23,7 @@ use Rollerworks\Component\Search\Value\RequiresComparatorValueHolder;
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class SearchField implements FieldConfigInterface
+class SearchField implements FieldConfig
 {
     /**
      * @var string
@@ -31,7 +31,7 @@ class SearchField implements FieldConfigInterface
     private $name;
 
     /**
-     * @var ResolvedFieldTypeInterface
+     * @var ResolvedFieldType
      */
     private $type;
 
@@ -51,7 +51,7 @@ class SearchField implements FieldConfigInterface
     private $supportedValueTypes = [];
 
     /**
-     * @var ValueComparisonInterface
+     * @var ValueComparator
      */
     private $valueComparison;
 
@@ -61,25 +61,25 @@ class SearchField implements FieldConfigInterface
     private $locked = false;
 
     /**
-     * @var DataTransformerInterface|null
+     * @var DataTransformer|null
      */
     private $viewTransformer;
 
     /**
-     * @var DataTransformerInterface|null
+     * @var DataTransformer|null
      */
     private $normTransformer;
 
     /**
      * Constructor.
      *
-     * @param string                     $name
-     * @param ResolvedFieldTypeInterface $type
-     * @param array                      $options
+     * @param string            $name
+     * @param ResolvedFieldType $type
+     * @param array             $options
      *
      * @throws \InvalidArgumentException When the name is invalid
      */
-    public function __construct(string $name, ResolvedFieldTypeInterface $type, array $options = [])
+    public function __construct(string $name, ResolvedFieldType $type, array $options = [])
     {
         if (!preg_match('/^[a-zA-Z][a-zA-Z0-9_\-]*$/D', $name)) {
             throw new InvalidArgumentException(
@@ -133,7 +133,7 @@ class SearchField implements FieldConfigInterface
     /**
      * {@inheritdoc}
      */
-    public function getType(): ResolvedFieldTypeInterface
+    public function getType(): ResolvedFieldType
     {
         return $this->type;
     }
@@ -145,7 +145,7 @@ class SearchField implements FieldConfigInterface
      *
      * @return self
      */
-    public function setValueComparison(ValueComparisonInterface $comparisonObj)
+    public function setValueComparison(ValueComparator $comparisonObj)
     {
         if ($this->locked) {
             throw new BadMethodCallException(
@@ -169,7 +169,7 @@ class SearchField implements FieldConfigInterface
     /**
      * {@inheritdoc}
      */
-    public function setViewTransformer(DataTransformerInterface $viewTransformer = null)
+    public function setViewTransformer(DataTransformer $viewTransformer = null)
     {
         if ($this->locked) {
             throw new BadMethodCallException(
@@ -193,7 +193,7 @@ class SearchField implements FieldConfigInterface
     /**
      * {@inheritdoc}
      */
-    public function setNormTransformer(DataTransformerInterface $viewTransformer = null)
+    public function setNormTransformer(DataTransformer $viewTransformer = null)
     {
         if ($this->locked) {
             throw new BadMethodCallException(

--- a/src/Test/FieldTransformationAssertion.php
+++ b/src/Test/FieldTransformationAssertion.php
@@ -16,7 +16,7 @@ namespace Rollerworks\Component\Search\Test;
 use PHPUnit_Framework_Assert;
 use PHPUnit_Framework_AssertionFailedError as AssertionFailedError;
 use Rollerworks\Component\Search\Exception\TransformationFailedException;
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\FieldConfig;
 
 final class FieldTransformationAssertion
 {
@@ -26,12 +26,12 @@ final class FieldTransformationAssertion
     private $transformed = false;
     private $model;
 
-    private function __construct(FieldConfigInterface $field)
+    private function __construct(FieldConfig $field)
     {
         $this->field = $field;
     }
 
-    public static function assertThat(FieldConfigInterface $field): self
+    public static function assertThat(FieldConfig $field): self
     {
         return new self($field);
     }

--- a/src/Test/SearchConditionExporterTestCase.php
+++ b/src/Test/SearchConditionExporterTestCase.php
@@ -17,7 +17,7 @@ use Rollerworks\Component\Search\ExporterInterface;
 use Rollerworks\Component\Search\Extension\Core\Type\DateType;
 use Rollerworks\Component\Search\Extension\Core\Type\IntegerType;
 use Rollerworks\Component\Search\Extension\Core\Type\TextType;
-use Rollerworks\Component\Search\FieldSetBuilder;
+use Rollerworks\Component\Search\GenericFieldSetBuilder;
 use Rollerworks\Component\Search\Input\ProcessorConfig;
 use Rollerworks\Component\Search\InputProcessorInterface;
 use Rollerworks\Component\Search\SearchCondition;
@@ -40,7 +40,7 @@ abstract class SearchConditionExporterTestCase extends SearchIntegrationTestCase
      */
     protected function getFieldSet(bool $build = true)
     {
-        $fieldSet = new FieldSetBuilder($this->getFactory());
+        $fieldSet = new GenericFieldSetBuilder($this->getFactory());
         $fieldSet->add('id', IntegerType::class);
         $fieldSet->add('name', TextType::class);
         $fieldSet->add('lastname', TextType::class);

--- a/src/Test/SearchConditionExporterTestCase.php
+++ b/src/Test/SearchConditionExporterTestCase.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Test;
 
-use Rollerworks\Component\Search\ExporterInterface;
+use Rollerworks\Component\Search\ConditionExporter;
 use Rollerworks\Component\Search\Extension\Core\Type\DateType;
 use Rollerworks\Component\Search\Extension\Core\Type\IntegerType;
 use Rollerworks\Component\Search\Extension\Core\Type\TextType;
 use Rollerworks\Component\Search\GenericFieldSetBuilder;
 use Rollerworks\Component\Search\Input\ProcessorConfig;
-use Rollerworks\Component\Search\InputProcessorInterface;
+use Rollerworks\Component\Search\InputProcessor;
 use Rollerworks\Component\Search\SearchCondition;
 use Rollerworks\Component\Search\Value\Compare;
 use Rollerworks\Component\Search\Value\ExcludedRange;
@@ -31,9 +31,9 @@ use Rollerworks\Component\Search\Value\ValuesGroup;
 // TODO Add some tests with empty fields and groups (and they should be able to process)
 abstract class SearchConditionExporterTestCase extends SearchIntegrationTestCase
 {
-    abstract protected function getExporter(): ExporterInterface;
+    abstract protected function getExporter(): ConditionExporter;
 
-    abstract protected function getInputProcessor(): InputProcessorInterface;
+    abstract protected function getInputProcessor(): InputProcessor;
 
     /**
      * {@inheritdoc}

--- a/src/Test/SearchConditionOptimizerTestCase.php
+++ b/src/Test/SearchConditionOptimizerTestCase.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Rollerworks\Component\Search\Test;
 
 use Rollerworks\Component\Search\FieldSet;
-use Rollerworks\Component\Search\SearchConditionOptimizerInterface;
+use Rollerworks\Component\Search\SearchConditionOptimizer;
 
 abstract class SearchConditionOptimizerTestCase extends SearchIntegrationTestCase
 {
@@ -24,7 +24,7 @@ abstract class SearchConditionOptimizerTestCase extends SearchIntegrationTestCas
     protected $fieldSet;
 
     /**
-     * @var SearchConditionOptimizerInterface
+     * @var SearchConditionOptimizer
      */
     protected $optimizer;
 

--- a/src/Test/SearchIntegrationTestCase.php
+++ b/src/Test/SearchIntegrationTestCase.php
@@ -17,12 +17,12 @@ use PHPUnit\Framework\TestCase;
 use Rollerworks\Component\Search\Exception\ExceptionInterface;
 use Rollerworks\Component\Search\Extension\Core\Type\IntegerType;
 use Rollerworks\Component\Search\Extension\Core\Type\TextType;
-use Rollerworks\Component\Search\FieldSetBuilder;
+use Rollerworks\Component\Search\GenericFieldSetBuilder;
+use Rollerworks\Component\Search\GenericSearchFactory;
 use Rollerworks\Component\Search\Input\ProcessorConfig;
 use Rollerworks\Component\Search\InputProcessorInterface;
 use Rollerworks\Component\Search\SearchCondition;
 use Rollerworks\Component\Search\Searches;
-use Rollerworks\Component\Search\SearchFactory;
 use Rollerworks\Component\Search\SearchFactoryBuilder;
 use Rollerworks\Component\Search\Tests\Input\InputProcessorTestCase;
 use Rollerworks\Component\Search\Value\Compare;
@@ -39,7 +39,7 @@ abstract class SearchIntegrationTestCase extends TestCase
     protected $factoryBuilder;
 
     /**
-     * @var SearchFactory
+     * @var GenericSearchFactory
      */
     private $searchFactory;
 
@@ -50,7 +50,7 @@ abstract class SearchIntegrationTestCase extends TestCase
         $this->factoryBuilder = Searches::createSearchFactoryBuilder();
     }
 
-    protected function getFactory(): SearchFactory
+    protected function getFactory(): GenericSearchFactory
     {
         if (null === $this->searchFactory) {
             $this->factoryBuilder->addExtensions($this->getExtensions());
@@ -81,11 +81,11 @@ abstract class SearchIntegrationTestCase extends TestCase
     /**
      * @param bool $build
      *
-     * @return \Rollerworks\Component\Search\FieldSet|FieldSetBuilder
+     * @return \Rollerworks\Component\Search\FieldSet|GenericFieldSetBuilder
      */
     protected function getFieldSet(bool $build = true)
     {
-        $fieldSet = new FieldSetBuilder($this->getFactory());
+        $fieldSet = new GenericFieldSetBuilder($this->getFactory());
         $fieldSet->set($this->getFactory()->createField('id', IntegerType::class));
         $fieldSet->add('name', TextType::class);
 

--- a/src/Test/SearchIntegrationTestCase.php
+++ b/src/Test/SearchIntegrationTestCase.php
@@ -14,13 +14,13 @@ declare(strict_types=1);
 namespace Rollerworks\Component\Search\Test;
 
 use PHPUnit\Framework\TestCase;
-use Rollerworks\Component\Search\Exception\ExceptionInterface;
+use Rollerworks\Component\Search\Exception\SearchException;
 use Rollerworks\Component\Search\Extension\Core\Type\IntegerType;
 use Rollerworks\Component\Search\Extension\Core\Type\TextType;
 use Rollerworks\Component\Search\GenericFieldSetBuilder;
 use Rollerworks\Component\Search\GenericSearchFactory;
 use Rollerworks\Component\Search\Input\ProcessorConfig;
-use Rollerworks\Component\Search\InputProcessorInterface;
+use Rollerworks\Component\Search\InputProcessor;
 use Rollerworks\Component\Search\SearchCondition;
 use Rollerworks\Component\Search\Searches;
 use Rollerworks\Component\Search\SearchFactoryBuilder;
@@ -119,7 +119,7 @@ abstract class SearchIntegrationTestCase extends TestCase
     protected function assertConditionEquals(
         $input,
         SearchCondition $condition,
-        InputProcessorInterface $processor,
+        InputProcessor $processor,
         ProcessorConfig $config
     ) {
         try {
@@ -142,7 +142,7 @@ abstract class SearchIntegrationTestCase extends TestCase
 
     protected static function detectSystemException(\Exception $exception)
     {
-        if (!$exception instanceof ExceptionInterface) {
+        if (!$exception instanceof SearchException) {
             throw $exception;
         }
     }

--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -16,7 +16,7 @@ namespace Rollerworks\Component\Search;
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-interface FieldRegistryInterface
+interface TypeRegistry
 {
     /**
      * Returns a field type by name.
@@ -27,9 +27,9 @@ interface FieldRegistryInterface
      *
      * @throws Exception\InvalidArgumentException if the type cannot be retrieved from any extension
      *
-     * @return ResolvedFieldTypeInterface
+     * @return ResolvedFieldType
      */
-    public function getType(string $name): ResolvedFieldTypeInterface;
+    public function getType(string $name): ResolvedFieldType;
 
     /**
      * Returns whether the given field type is supported.
@@ -43,7 +43,7 @@ interface FieldRegistryInterface
     /**
      * Returns the extensions loaded on the registry.
      *
-     * @return SearchExtensionInterface[]
+     * @return SearchExtension[]
      */
     public function getExtensions(): array;
 }

--- a/src/ValueComparator.php
+++ b/src/ValueComparator.php
@@ -14,13 +14,13 @@ declare(strict_types=1);
 namespace Rollerworks\Component\Search;
 
 /**
- * ValueComparisonInterface.
+ * ValueComparator.
  *
- * Each ValueComparison class must implement this class.
+ * Each ValueComparator class must implement this interface.
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-interface ValueComparisonInterface
+interface ValueComparator
 {
     /**
      * Returns whether the first value is higher then the second value.

--- a/src/ValueIncrementer.php
+++ b/src/ValueIncrementer.php
@@ -21,12 +21,12 @@ namespace Rollerworks\Component\Search;
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-interface ValueIncrementerInterface extends ValueComparisonInterface
+interface ValueIncrementer extends ValueComparator
 {
     /**
      * Returns the incremented value of the value.
      *
-     * The returned value must be returned in the "normalized" format,
+     * The returned value must be returned in the "model" format,
      * that is supported by the field type.
      *
      * @param mixed $value      The value to increment

--- a/tests/ConditionOptimizer/ChainOptimizerTest.php
+++ b/tests/ConditionOptimizer/ChainOptimizerTest.php
@@ -15,6 +15,7 @@ namespace Rollerworks\Component\Search\Tests\ConditionOptimizer;
 
 use Prophecy\Prophecy\ObjectProphecy;
 use Rollerworks\Component\Search\ConditionOptimizer\ChainOptimizer;
+use Rollerworks\Component\Search\SearchConditionOptimizer;
 use Rollerworks\Component\Search\Test\SearchConditionOptimizerTestCase;
 use Rollerworks\Component\Search\Value\ValuesGroup;
 
@@ -41,8 +42,8 @@ final class ChainOptimizerTest extends SearchConditionOptimizerTestCase
 
         $this->optimizer = new ChainOptimizer();
 
-        $this->optimizer1 = $this->prophesize('Rollerworks\Component\Search\SearchConditionOptimizerInterface');
-        $this->optimizer2 = $this->prophesize('Rollerworks\Component\Search\SearchConditionOptimizerInterface');
+        $this->optimizer1 = $this->prophesize(SearchConditionOptimizer::class);
+        $this->optimizer2 = $this->prophesize(SearchConditionOptimizer::class);
         $this->optimizer1->getPriority()->willReturn(0);
         $this->optimizer2->getPriority()->willReturn(5);
     }
@@ -50,7 +51,7 @@ final class ChainOptimizerTest extends SearchConditionOptimizerTestCase
     /**
      * @test
      */
-    public function it_allows_adding_formatters()
+    public function it_allows_adding_optimizers()
     {
         $this->optimizer->addOptimizer($this->optimizer1->reveal());
         $this->optimizer->addOptimizer($this->optimizer2->reveal());
@@ -59,7 +60,7 @@ final class ChainOptimizerTest extends SearchConditionOptimizerTestCase
     /**
      * @test
      */
-    public function it_execute_the_registered_formatters_priority_order()
+    public function it_execute_the_registered_optimizers_priority_order()
     {
         $searchCondition = $this->prophesize('Rollerworks\Component\Search\SearchCondition');
         $searchCondition->getValuesGroup()->willReturn(new ValuesGroup());

--- a/tests/Exporter/ArrayExporterTest.php
+++ b/tests/Exporter/ArrayExporterTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Tests\Exporter;
 
+use Rollerworks\Component\Search\ConditionExporter;
 use Rollerworks\Component\Search\Exporter\ArrayExporter;
-use Rollerworks\Component\Search\ExporterInterface;
 use Rollerworks\Component\Search\Input\ArrayInput;
-use Rollerworks\Component\Search\InputProcessorInterface;
+use Rollerworks\Component\Search\InputProcessor;
 use Rollerworks\Component\Search\Test\SearchConditionExporterTestCase;
 
 final class ArrayExporterTest extends SearchConditionExporterTestCase
@@ -202,12 +202,12 @@ final class ArrayExporterTest extends SearchConditionExporterTestCase
         return ['groups' => [[]]];
     }
 
-    protected function getExporter(): ExporterInterface
+    protected function getExporter(): ConditionExporter
     {
         return new ArrayExporter();
     }
 
-    protected function getInputProcessor(): InputProcessorInterface
+    protected function getInputProcessor(): InputProcessor
     {
         return new ArrayInput();
     }

--- a/tests/Exporter/JsonExporterTest.php
+++ b/tests/Exporter/JsonExporterTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Tests\Exporter;
 
+use Rollerworks\Component\Search\ConditionExporter;
 use Rollerworks\Component\Search\Exporter\JsonExporter;
-use Rollerworks\Component\Search\ExporterInterface;
 use Rollerworks\Component\Search\Input\JsonInput;
-use Rollerworks\Component\Search\InputProcessorInterface;
+use Rollerworks\Component\Search\InputProcessor;
 use Rollerworks\Component\Search\Test\SearchConditionExporterTestCase;
 
 final class JsonExporterTest extends SearchConditionExporterTestCase
@@ -218,12 +218,12 @@ final class JsonExporterTest extends SearchConditionExporterTestCase
         return json_encode(['groups' => [[]]]);
     }
 
-    protected function getExporter(): ExporterInterface
+    protected function getExporter(): ConditionExporter
     {
         return new JsonExporter();
     }
 
-    protected function getInputProcessor(): InputProcessorInterface
+    protected function getInputProcessor(): InputProcessor
     {
         return new JsonInput();
     }

--- a/tests/Exporter/StringQueryExporterTest.php
+++ b/tests/Exporter/StringQueryExporterTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Tests\Exporter;
 
+use Rollerworks\Component\Search\ConditionExporter;
 use Rollerworks\Component\Search\Exporter\StringQueryExporter;
-use Rollerworks\Component\Search\ExporterInterface;
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\FieldConfig;
 use Rollerworks\Component\Search\Input\ProcessorConfig;
 use Rollerworks\Component\Search\Input\StringQueryInput;
-use Rollerworks\Component\Search\InputProcessorInterface;
+use Rollerworks\Component\Search\InputProcessor;
 use Rollerworks\Component\Search\SearchCondition;
 use Rollerworks\Component\Search\Test\SearchConditionExporterTestCase;
 use Rollerworks\Component\Search\Value\ValuesBag;
@@ -31,7 +31,7 @@ final class StringQueryExporterTest extends SearchConditionExporterTestCase
      */
     public function it_exporters_with_field_label()
     {
-        $labelResolver = function (FieldConfigInterface $field) {
+        $labelResolver = function (FieldConfig $field) {
             $name = $field->getName();
 
             if ($name === 'name') {
@@ -109,12 +109,12 @@ final class StringQueryExporterTest extends SearchConditionExporterTestCase
         return '();';
     }
 
-    protected function getExporter(callable $labelResolver = null): ExporterInterface
+    protected function getExporter(callable $labelResolver = null): ConditionExporter
     {
         return new StringQueryExporter($labelResolver);
     }
 
-    protected function getInputProcessor(callable $labelResolver = null): InputProcessorInterface
+    protected function getInputProcessor(callable $labelResolver = null): InputProcessor
     {
         return new StringQueryInput(null, $labelResolver);
     }

--- a/tests/Exporter/XmlExporterTest.php
+++ b/tests/Exporter/XmlExporterTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Tests\Exporter;
 
+use Rollerworks\Component\Search\ConditionExporter;
 use Rollerworks\Component\Search\Exporter\XmlExporter;
-use Rollerworks\Component\Search\ExporterInterface;
 use Rollerworks\Component\Search\Input\XmlInput;
-use Rollerworks\Component\Search\InputProcessorInterface;
+use Rollerworks\Component\Search\InputProcessor;
 use Rollerworks\Component\Search\Test\SearchConditionExporterTestCase;
 
 final class XmlExporterTest extends SearchConditionExporterTestCase
@@ -305,12 +305,12 @@ final class XmlExporterTest extends SearchConditionExporterTestCase
         ;
     }
 
-    protected function getExporter(): ExporterInterface
+    protected function getExporter(): ConditionExporter
     {
         return new XmlExporter();
     }
 
-    protected function getInputProcessor(): InputProcessorInterface
+    protected function getInputProcessor(): InputProcessor
     {
         return new XmlInput();
     }

--- a/tests/Extension/Core/DataTransformer/BirthdayTransformerTest.php
+++ b/tests/Extension/Core/DataTransformer/BirthdayTransformerTest.php
@@ -15,7 +15,7 @@ namespace Rollerworks\Component\Search\Tests\Extension\Core\DataTransformer;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
-use Rollerworks\Component\Search\DataTransformerInterface;
+use Rollerworks\Component\Search\DataTransformer;
 use Rollerworks\Component\Search\Exception\TransformationFailedException;
 use Rollerworks\Component\Search\Extension\Core\DataTransformer\BirthdayTransformer;
 
@@ -24,7 +24,7 @@ class BirthdayTransformerTest extends TestCase
     /** @test */
     public function it_transforms_age_to_integer()
     {
-        $dateTransformer = $this->prophesize(DataTransformerInterface::class);
+        $dateTransformer = $this->prophesize(DataTransformer::class);
         $dateTransformer->reverseTransform(Argument::any())->shouldNotBeCalled();
         $dateTransformer->transform(Argument::any())->shouldNotBeCalled();
 
@@ -39,7 +39,7 @@ class BirthdayTransformerTest extends TestCase
     {
         $date = new \DateTime('2010-03-05 00:00:00 UTC');
 
-        $dateTransformer = $this->prophesize(DataTransformerInterface::class);
+        $dateTransformer = $this->prophesize(DataTransformer::class);
         $dateTransformer->reverseTransform('2010-03-05')->willReturn($date);
         $dateTransformer->transform($date)->willReturn('2010-03-05');
 
@@ -57,7 +57,7 @@ class BirthdayTransformerTest extends TestCase
     {
         $date = new \DateTime('2010-03-05 00:00:00 UTC');
 
-        $dateTransformer = $this->prophesize(DataTransformerInterface::class);
+        $dateTransformer = $this->prophesize(DataTransformer::class);
         $dateTransformer->reverseTransform('2010-03-05')->willReturn($date);
         $dateTransformer->transform($date)->willReturn('2010-03-05');
 
@@ -88,7 +88,7 @@ class BirthdayTransformerTest extends TestCase
     {
         $dateObj = new \DateTime('tomorrow');
 
-        $dateTransformer = $this->prophesize(DataTransformerInterface::class);
+        $dateTransformer = $this->prophesize(DataTransformer::class);
         $dateTransformer->reverseTransform($dateObj->format('Y-m-d'))->willReturn($dateObj);
 
         $transformer = new BirthdayTransformer($dateTransformer->reveal());
@@ -104,7 +104,7 @@ class BirthdayTransformerTest extends TestCase
     {
         $dateObj = new \DateTime('tomorrow');
 
-        $dateTransformer = $this->prophesize(DataTransformerInterface::class);
+        $dateTransformer = $this->prophesize(DataTransformer::class);
         $dateTransformer->reverseTransform($dateObj->format('Y-m-d'))->willReturn($dateObj);
         $dateTransformer->transform($dateObj)->willReturn($dateObj->format('Y-m-d'));
 

--- a/tests/Extension/Core/DataTransformer/LocalizedBirthdayTransformerTest.php
+++ b/tests/Extension/Core/DataTransformer/LocalizedBirthdayTransformerTest.php
@@ -15,7 +15,7 @@ namespace Rollerworks\Component\Search\Tests\Extension\Core\DataTransformer;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
-use Rollerworks\Component\Search\DataTransformerInterface;
+use Rollerworks\Component\Search\DataTransformer;
 use Rollerworks\Component\Search\Exception\TransformationFailedException;
 use Rollerworks\Component\Search\Extension\Core\DataTransformer\LocalizedBirthdayTransformer;
 use Symfony\Component\Intl\Util\IntlTestHelper;
@@ -32,7 +32,7 @@ class LocalizedBirthdayTransformerTest extends TestCase
     /** @test */
     public function it_transforms_age_to_integer()
     {
-        $dateTransformer = $this->prophesize(DataTransformerInterface::class);
+        $dateTransformer = $this->prophesize(DataTransformer::class);
         $dateTransformer->reverseTransform(Argument::any())->shouldNotBeCalled();
         $dateTransformer->transform(Argument::any())->shouldNotBeCalled();
 
@@ -50,7 +50,7 @@ class LocalizedBirthdayTransformerTest extends TestCase
 
         \Locale::setDefault('ar');
 
-        $dateTransformer = $this->prophesize(DataTransformerInterface::class);
+        $dateTransformer = $this->prophesize(DataTransformer::class);
         $dateTransformer->reverseTransform(Argument::any())->shouldNotBeCalled();
         $dateTransformer->transform(Argument::any())->shouldNotBeCalled();
 
@@ -65,7 +65,7 @@ class LocalizedBirthdayTransformerTest extends TestCase
     {
         $date = new \DateTime('2010-03-05 00:00:00 UTC');
 
-        $dateTransformer = $this->prophesize(DataTransformerInterface::class);
+        $dateTransformer = $this->prophesize(DataTransformer::class);
         $dateTransformer->reverseTransform('2010-03-05')->willReturn($date);
         $dateTransformer->transform($date)->willReturn('2010-03-05');
 
@@ -83,7 +83,7 @@ class LocalizedBirthdayTransformerTest extends TestCase
     {
         $date = new \DateTime('2010-03-05 00:00:00 UTC');
 
-        $dateTransformer = $this->prophesize(DataTransformerInterface::class);
+        $dateTransformer = $this->prophesize(DataTransformer::class);
         $dateTransformer->reverseTransform('2010-03-05')->willReturn($date);
         $dateTransformer->transform($date)->willReturn('2010-03-05');
 
@@ -114,7 +114,7 @@ class LocalizedBirthdayTransformerTest extends TestCase
     {
         $dateObj = new \DateTime('tomorrow');
 
-        $dateTransformer = $this->prophesize(DataTransformerInterface::class);
+        $dateTransformer = $this->prophesize(DataTransformer::class);
         $dateTransformer->reverseTransform($dateObj->format('Y-m-d'))->willReturn($dateObj);
 
         $transformer = new LocalizedBirthdayTransformer($dateTransformer->reveal());
@@ -130,7 +130,7 @@ class LocalizedBirthdayTransformerTest extends TestCase
     {
         $dateObj = new \DateTime('tomorrow');
 
-        $dateTransformer = $this->prophesize(DataTransformerInterface::class);
+        $dateTransformer = $this->prophesize(DataTransformer::class);
         $dateTransformer->reverseTransform($dateObj->format('Y-m-d'))->willReturn($dateObj);
         $dateTransformer->transform($dateObj)->willReturn($dateObj->format('Y-m-d'));
 

--- a/tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -79,7 +79,7 @@ class ChoiceTypeTest extends SearchIntegrationTestCase
         ]);
     }
 
-    public function testChoiceListOptionExpectsChoiceListInterface()
+    public function testChoiceListOptionExpectsChoiceList()
     {
         $this->expectException(InvalidOptionsException::class);
 

--- a/tests/FieldSetTest.php
+++ b/tests/FieldSetTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Rollerworks\Component\Search\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\FieldConfig;
 use Rollerworks\Component\Search\FieldSet;
 
 final class FieldSetTest extends TestCase
@@ -44,7 +44,7 @@ final class FieldSetTest extends TestCase
      */
     private function createFieldMock(string $name)
     {
-        $field = $this->createMock(FieldConfigInterface::class);
+        $field = $this->createMock(FieldConfig::class);
         $field->expects(self::any())->method('getName')->willReturn($name);
 
         return $field;

--- a/tests/GenericFieldSetBuilderTest.php
+++ b/tests/GenericFieldSetBuilderTest.php
@@ -15,10 +15,10 @@ namespace Rollerworks\Component\Search\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\FieldConfig;
 use Rollerworks\Component\Search\GenericFieldSetBuilder;
-use Rollerworks\Component\Search\ResolvedFieldTypeInterface;
-use Rollerworks\Component\Search\SearchFactoryInterface;
+use Rollerworks\Component\Search\ResolvedFieldType;
+use Rollerworks\Component\Search\SearchFactory;
 use Rollerworks\Component\Search\SearchField;
 use Rollerworks\Component\Search\Tests\Fixtures\BarType;
 use Rollerworks\Component\Search\Tests\Fixtures\FooType;
@@ -35,10 +35,10 @@ final class GenericFieldSetBuilderTest extends TestCase
         // Prophecy binds the callback to the ObjectProphecy.
         $test = $this;
 
-        $factory = $this->prophesize(SearchFactoryInterface::class);
+        $factory = $this->prophesize(SearchFactory::class);
         $factory->createField(Argument::cetera())->will(
             function ($args) use ($test) {
-                $type = $test->prophesize(ResolvedFieldTypeInterface::class);
+                $type = $test->prophesize(ResolvedFieldType::class);
                 $type->getInnerType()->willReturn(new $args[1]());
 
                 return new SearchField($args[0], $type->reveal(), $args[2]);
@@ -66,7 +66,7 @@ final class GenericFieldSetBuilderTest extends TestCase
 
     public function testSetPreConfiguredField()
     {
-        $field = $this->prophesize(FieldConfigInterface::class);
+        $field = $this->prophesize(FieldConfig::class);
         $field->getName()->willReturn('id');
 
         $field = $field->reveal();
@@ -102,13 +102,13 @@ final class GenericFieldSetBuilderTest extends TestCase
 
     private function assertBuilderFieldConfigurationEquals(string $name, string $type, array $options = [])
     {
-        self::assertInstanceOf(FieldConfigInterface::class, $field = $this->builder->get($name));
+        self::assertInstanceOf(FieldConfig::class, $field = $this->builder->get($name));
         self::assertEquals($name, $field->getName());
         self::assertInstanceOf($type, $field->getType()->getInnerType());
         self::assertEquals($options, $field->getOptions());
     }
 
-    private static function assertFieldConfigurationEquals(FieldConfigInterface $field, string $name, string $type, array $options = [])
+    private static function assertFieldConfigurationEquals(FieldConfig $field, string $name, string $type, array $options = [])
     {
         self::assertEquals($name, $field->getName());
         self::assertInstanceOf($type, $field->getType()->getInnerType());

--- a/tests/GenericFieldSetBuilderTest.php
+++ b/tests/GenericFieldSetBuilderTest.php
@@ -16,17 +16,17 @@ namespace Rollerworks\Component\Search\Tests;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Rollerworks\Component\Search\FieldConfigInterface;
-use Rollerworks\Component\Search\FieldSetBuilder;
+use Rollerworks\Component\Search\GenericFieldSetBuilder;
 use Rollerworks\Component\Search\ResolvedFieldTypeInterface;
-use Rollerworks\Component\Search\SearchFactory;
+use Rollerworks\Component\Search\SearchFactoryInterface;
 use Rollerworks\Component\Search\SearchField;
 use Rollerworks\Component\Search\Tests\Fixtures\BarType;
 use Rollerworks\Component\Search\Tests\Fixtures\FooType;
 
-final class FieldSetBuilderTest extends TestCase
+final class GenericFieldSetBuilderTest extends TestCase
 {
     /**
-     * @var FieldSetBuilder
+     * @var GenericFieldSetBuilder
      */
     private $builder;
 
@@ -35,7 +35,7 @@ final class FieldSetBuilderTest extends TestCase
         // Prophecy binds the callback to the ObjectProphecy.
         $test = $this;
 
-        $factory = $this->prophesize(SearchFactory::class);
+        $factory = $this->prophesize(SearchFactoryInterface::class);
         $factory->createField(Argument::cetera())->will(
             function ($args) use ($test) {
                 $type = $test->prophesize(ResolvedFieldTypeInterface::class);
@@ -45,7 +45,7 @@ final class FieldSetBuilderTest extends TestCase
             }
         );
 
-        $this->builder = new FieldSetBuilder($factory->reveal());
+        $this->builder = new GenericFieldSetBuilder($factory->reveal());
     }
 
     public function testAddFields()

--- a/tests/GenericSearchFactoryTest.php
+++ b/tests/GenericSearchFactoryTest.php
@@ -18,10 +18,10 @@ use Rollerworks\Component\Search\Extension\Core\Type\TextType;
 use Rollerworks\Component\Search\FieldConfigInterface;
 use Rollerworks\Component\Search\FieldRegistryInterface;
 use Rollerworks\Component\Search\FieldSetRegistryInterface;
+use Rollerworks\Component\Search\GenericSearchFactory;
 use Rollerworks\Component\Search\ResolvedFieldTypeInterface;
-use Rollerworks\Component\Search\SearchFactory;
 
-final class SearchFactoryTest extends TestCase
+final class GenericSearchFactoryTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
@@ -34,7 +34,7 @@ final class SearchFactoryTest extends TestCase
     private $fieldSetRegistry;
 
     /**
-     * @var SearchFactory
+     * @var GenericSearchFactory
      */
     private $factory;
 
@@ -49,7 +49,7 @@ final class SearchFactoryTest extends TestCase
         $this->registry = $this->createMock(FieldRegistryInterface::class);
         $this->fieldConfig = $this->createMock(FieldConfigInterface::class);
 
-        $this->factory = new SearchFactory($this->registry, $this->fieldSetRegistry);
+        $this->factory = new GenericSearchFactory($this->registry, $this->fieldSetRegistry);
     }
 
     /**

--- a/tests/GenericSearchFactoryTest.php
+++ b/tests/GenericSearchFactoryTest.php
@@ -15,11 +15,11 @@ namespace Rollerworks\Component\Search\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Rollerworks\Component\Search\Extension\Core\Type\TextType;
-use Rollerworks\Component\Search\FieldConfigInterface;
-use Rollerworks\Component\Search\FieldRegistryInterface;
-use Rollerworks\Component\Search\FieldSetRegistryInterface;
+use Rollerworks\Component\Search\FieldConfig;
+use Rollerworks\Component\Search\FieldSetRegistry;
 use Rollerworks\Component\Search\GenericSearchFactory;
-use Rollerworks\Component\Search\ResolvedFieldTypeInterface;
+use Rollerworks\Component\Search\ResolvedFieldType;
+use Rollerworks\Component\Search\TypeRegistry;
 
 final class GenericSearchFactoryTest extends TestCase
 {
@@ -45,9 +45,9 @@ final class GenericSearchFactoryTest extends TestCase
 
     protected function setUp()
     {
-        $this->fieldSetRegistry = $this->createMock(FieldSetRegistryInterface::class);
-        $this->registry = $this->createMock(FieldRegistryInterface::class);
-        $this->fieldConfig = $this->createMock(FieldConfigInterface::class);
+        $this->fieldSetRegistry = $this->createMock(FieldSetRegistry::class);
+        $this->registry = $this->createMock(TypeRegistry::class);
+        $this->fieldConfig = $this->createMock(FieldConfig::class);
 
         $this->factory = new GenericSearchFactory($this->registry, $this->fieldSetRegistry);
     }
@@ -84,6 +84,6 @@ final class GenericSearchFactoryTest extends TestCase
 
     private function getMockResolvedType()
     {
-        return $this->getMockBuilder(ResolvedFieldTypeInterface::class)->getMock();
+        return $this->getMockBuilder(ResolvedFieldType::class)->getMock();
     }
 }

--- a/tests/Input/ArrayInputTest.php
+++ b/tests/Input/ArrayInputTest.php
@@ -15,7 +15,7 @@ namespace Rollerworks\Component\Search\Tests\Input;
 
 use Rollerworks\Component\Search\ConditionErrorMessage;
 use Rollerworks\Component\Search\Input\ArrayInput;
-use Rollerworks\Component\Search\InputProcessorInterface;
+use Rollerworks\Component\Search\InputProcessor;
 use Rollerworks\Component\Search\Value\Compare;
 use Rollerworks\Component\Search\Value\PatternMatch;
 use Rollerworks\Component\Search\Value\Range;
@@ -31,7 +31,7 @@ final class ArrayInputTest extends InputProcessorTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getProcessor(): InputProcessorInterface
+    protected function getProcessor(): InputProcessor
     {
         return new ArrayInput();
     }

--- a/tests/Input/FieldValuesFactoryTest.php
+++ b/tests/Input/FieldValuesFactoryTest.php
@@ -15,13 +15,13 @@ namespace Rollerworks\Component\Search\Tests\Input;
 
 use Prophecy\Argument;
 use Rollerworks\Component\Search\ConditionErrorMessage;
-use Rollerworks\Component\Search\DataTransformerInterface;
+use Rollerworks\Component\Search\DataTransformer;
 use Rollerworks\Component\Search\ErrorList;
 use Rollerworks\Component\Search\Exception\UnsupportedValueTypeException;
 use Rollerworks\Component\Search\Exception\ValuesOverflowException;
 use Rollerworks\Component\Search\Extension\Core\Type\IntegerType;
 use Rollerworks\Component\Search\Extension\Core\Type\TextType;
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\FieldConfig;
 use Rollerworks\Component\Search\Input\FieldValuesFactory;
 use Rollerworks\Component\Search\Input\NullValidator;
 use Rollerworks\Component\Search\Input\Validator;
@@ -32,7 +32,7 @@ use Rollerworks\Component\Search\Value\ExcludedRange;
 use Rollerworks\Component\Search\Value\PatternMatch;
 use Rollerworks\Component\Search\Value\Range;
 use Rollerworks\Component\Search\Value\ValuesBag;
-use Rollerworks\Component\Search\ValueComparisonInterface;
+use Rollerworks\Component\Search\ValueComparator;
 
 final class FieldValuesFactoryTest extends SearchIntegrationTestCase
 {
@@ -508,7 +508,7 @@ final class FieldValuesFactoryTest extends SearchIntegrationTestCase
         return $this->getFactory()->createField('field-name', $type ?? TextType::class, $options);
     }
 
-    private function initContext(FieldValuesFactory $factory, FieldConfigInterface $field = null): ValuesBag
+    private function initContext(FieldValuesFactory $factory, FieldConfig $field = null): ValuesBag
     {
         $factory->initContext($field ?? $this->createField(), $valuesBag = new ValuesBag(), 'root/');
 
@@ -549,7 +549,7 @@ final class FieldValuesFactoryTest extends SearchIntegrationTestCase
         $field->setValueTypeSupport(Range::class, true);
         $field->setValueTypeSupport(Compare::class, true);
         $field->setViewTransformer(
-            new class() implements DataTransformerInterface {
+            new class() implements DataTransformer {
                 public function transform($value)
                 {
                     return null;
@@ -562,7 +562,7 @@ final class FieldValuesFactoryTest extends SearchIntegrationTestCase
             }
         );
         $field->setValueComparison(
-            new class() implements ValueComparisonInterface {
+            new class() implements ValueComparator {
                 public function isHigher($higher, $lower, array $options): bool
                 {
                     return $higher > $lower;

--- a/tests/Input/InputProcessorTestCase.php
+++ b/tests/Input/InputProcessorTestCase.php
@@ -25,7 +25,7 @@ use Rollerworks\Component\Search\Extension\Core\Type\IntegerType;
 use Rollerworks\Component\Search\Extension\Core\Type\TextType;
 use Rollerworks\Component\Search\GenericFieldSetBuilder;
 use Rollerworks\Component\Search\Input\ProcessorConfig;
-use Rollerworks\Component\Search\InputProcessorInterface;
+use Rollerworks\Component\Search\InputProcessor;
 use Rollerworks\Component\Search\SearchCondition;
 use Rollerworks\Component\Search\Test\SearchIntegrationTestCase;
 use Rollerworks\Component\Search\Value\Compare;
@@ -37,7 +37,7 @@ use Rollerworks\Component\Search\Value\ValuesGroup;
 
 abstract class InputProcessorTestCase extends SearchIntegrationTestCase
 {
-    abstract protected function getProcessor(): InputProcessorInterface;
+    abstract protected function getProcessor(): InputProcessor;
 
     /**
      * {@inheritdoc}

--- a/tests/Input/InputProcessorTestCase.php
+++ b/tests/Input/InputProcessorTestCase.php
@@ -23,7 +23,7 @@ use Rollerworks\Component\Search\Exception\ValuesOverflowException;
 use Rollerworks\Component\Search\Extension\Core\Type\DateType;
 use Rollerworks\Component\Search\Extension\Core\Type\IntegerType;
 use Rollerworks\Component\Search\Extension\Core\Type\TextType;
-use Rollerworks\Component\Search\FieldSetBuilder;
+use Rollerworks\Component\Search\GenericFieldSetBuilder;
 use Rollerworks\Component\Search\Input\ProcessorConfig;
 use Rollerworks\Component\Search\InputProcessorInterface;
 use Rollerworks\Component\Search\SearchCondition;
@@ -44,7 +44,7 @@ abstract class InputProcessorTestCase extends SearchIntegrationTestCase
      */
     protected function getFieldSet(bool $build = true)
     {
-        $fieldSet = new FieldSetBuilder($this->getFactory());
+        $fieldSet = new GenericFieldSetBuilder($this->getFactory());
         $fieldSet->add('id', IntegerType::class);
         $fieldSet->add('name', TextType::class);
         $fieldSet->add('lastname', TextType::class);

--- a/tests/Input/JsonInputTest.php
+++ b/tests/Input/JsonInputTest.php
@@ -16,7 +16,7 @@ namespace Rollerworks\Component\Search\Tests\Input;
 use Rollerworks\Component\Search\ConditionErrorMessage;
 use Rollerworks\Component\Search\Input\JsonInput;
 use Rollerworks\Component\Search\Input\ProcessorConfig;
-use Rollerworks\Component\Search\InputProcessorInterface;
+use Rollerworks\Component\Search\InputProcessor;
 use Rollerworks\Component\Search\Value\Compare;
 use Rollerworks\Component\Search\Value\PatternMatch;
 use Rollerworks\Component\Search\Value\Range;
@@ -24,7 +24,7 @@ use Rollerworks\Component\Search\Value\ValuesGroup;
 
 final class JsonInputTest extends InputProcessorTestCase
 {
-    protected function getProcessor(): InputProcessorInterface
+    protected function getProcessor(): InputProcessor
     {
         return new JsonInput();
     }

--- a/tests/Input/StringQueryInputTest.php
+++ b/tests/Input/StringQueryInputTest.php
@@ -15,11 +15,11 @@ namespace Rollerworks\Component\Search\Tests\Input;
 
 use Rollerworks\Component\Search\ConditionErrorMessage;
 use Rollerworks\Component\Search\Extension\Core\Type\TextType;
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\FieldConfig;
 use Rollerworks\Component\Search\Input\ProcessorConfig;
 use Rollerworks\Component\Search\Input\StringQuery\QueryException;
 use Rollerworks\Component\Search\Input\StringQueryInput;
-use Rollerworks\Component\Search\InputProcessorInterface;
+use Rollerworks\Component\Search\InputProcessor;
 use Rollerworks\Component\Search\SearchCondition;
 use Rollerworks\Component\Search\Value\Compare;
 use Rollerworks\Component\Search\Value\PatternMatch;
@@ -29,7 +29,7 @@ use Rollerworks\Component\Search\Value\ValuesGroup;
 
 final class StringQueryInputTest extends InputProcessorTestCase
 {
-    protected function getProcessor(callable $labelResolver = null): InputProcessorInterface
+    protected function getProcessor(callable $labelResolver = null): InputProcessor
     {
         return new StringQueryInput(null, $labelResolver);
     }
@@ -42,7 +42,7 @@ final class StringQueryInputTest extends InputProcessorTestCase
      */
     public function it_processes_aliased_fields($input)
     {
-        $labelResolver = function (FieldConfigInterface $field) {
+        $labelResolver = function (FieldConfig $field) {
             $name = $field->getName();
 
             if ($name === 'name') {

--- a/tests/Input/XmlInputTest.php
+++ b/tests/Input/XmlInputTest.php
@@ -18,7 +18,7 @@ use Rollerworks\Component\Search\Exception\InvalidSearchConditionException;
 use Rollerworks\Component\Search\Extension\Core\Type\TextType;
 use Rollerworks\Component\Search\Input\ProcessorConfig;
 use Rollerworks\Component\Search\Input\XmlInput;
-use Rollerworks\Component\Search\InputProcessorInterface;
+use Rollerworks\Component\Search\InputProcessor;
 use Rollerworks\Component\Search\Value\Compare;
 use Rollerworks\Component\Search\Value\PatternMatch;
 use Rollerworks\Component\Search\Value\Range;
@@ -26,7 +26,7 @@ use Rollerworks\Component\Search\Value\ValuesGroup;
 
 final class XmlInputTest extends InputProcessorTestCase
 {
-    protected function getProcessor(): InputProcessorInterface
+    protected function getProcessor(): InputProcessor
     {
         return new XmlInput();
     }

--- a/tests/LazyFieldSetRegistryTest.php
+++ b/tests/LazyFieldSetRegistryTest.php
@@ -16,9 +16,9 @@ namespace Rollerworks\Component\Search\Tests;
 use PHPUnit\Framework\TestCase;
 use Rollerworks\Component\Search\Exception\InvalidArgumentException;
 use Rollerworks\Component\Search\FieldSetConfiguratorInterface;
-use Rollerworks\Component\Search\FieldSetRegistry;
+use Rollerworks\Component\Search\LazyFieldSetRegistry;
 
-final class FieldSetRegistryTest extends TestCase
+final class LazyFieldSetRegistryTest extends TestCase
 {
     /** @test */
     public function it_loads_configurator_lazily()
@@ -26,7 +26,7 @@ final class FieldSetRegistryTest extends TestCase
         $configurator = $this->createMock(FieldSetConfiguratorInterface::class);
         $configurator2 = $this->createMock(FieldSetConfiguratorInterface::class);
 
-        $registry = new FieldSetRegistry(
+        $registry = new LazyFieldSetRegistry(
             [
                 'set' => function () use ($configurator) {
                     return $configurator;
@@ -57,7 +57,7 @@ final class FieldSetRegistryTest extends TestCase
         $configurator = $this->createMock(FieldSetConfiguratorInterface::class);
         $configurator2 = $this->createMock(FieldSetConfiguratorInterface::class);
 
-        $registry = new FieldSetRegistry(
+        $registry = new LazyFieldSetRegistry(
             [
                 'set' => function () use ($configurator) {
                     return $configurator;
@@ -82,7 +82,7 @@ final class FieldSetRegistryTest extends TestCase
         $configurator2 = $this->createMock(FieldSetConfiguratorInterface::class);
         $name = get_class($configurator2);
 
-        $registry = new FieldSetRegistry(
+        $registry = new LazyFieldSetRegistry(
             [
                 'set' => function () use ($configurator) {
                     return $configurator;
@@ -109,7 +109,7 @@ final class FieldSetRegistryTest extends TestCase
         $configurator = $this->createMock(FieldSetConfiguratorInterface::class);
         $configurator2 = \stdClass::class;
 
-        $registry = new FieldSetRegistry(
+        $registry = new LazyFieldSetRegistry(
             [
                 'set' => function () use ($configurator) {
                     return $configurator;
@@ -135,7 +135,7 @@ final class FieldSetRegistryTest extends TestCase
         $configurator = $this->createMock(FieldSetConfiguratorInterface::class);
         $configurator2 = 'f4394832948_foobar_cow';
 
-        $registry = new FieldSetRegistry(
+        $registry = new LazyFieldSetRegistry(
             [
                 'set' => function () use ($configurator) {
                     return $configurator;

--- a/tests/LazyFieldSetRegistryTest.php
+++ b/tests/LazyFieldSetRegistryTest.php
@@ -15,7 +15,7 @@ namespace Rollerworks\Component\Search\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Rollerworks\Component\Search\Exception\InvalidArgumentException;
-use Rollerworks\Component\Search\FieldSetConfiguratorInterface;
+use Rollerworks\Component\Search\FieldSetConfigurator;
 use Rollerworks\Component\Search\LazyFieldSetRegistry;
 
 final class LazyFieldSetRegistryTest extends TestCase
@@ -23,8 +23,8 @@ final class LazyFieldSetRegistryTest extends TestCase
     /** @test */
     public function it_loads_configurator_lazily()
     {
-        $configurator = $this->createMock(FieldSetConfiguratorInterface::class);
-        $configurator2 = $this->createMock(FieldSetConfiguratorInterface::class);
+        $configurator = $this->createMock(FieldSetConfigurator::class);
+        $configurator2 = $this->createMock(FieldSetConfigurator::class);
 
         $registry = new LazyFieldSetRegistry(
             [
@@ -54,8 +54,8 @@ final class LazyFieldSetRegistryTest extends TestCase
     /** @test */
     public function it_loads_configurator_by_fqcn()
     {
-        $configurator = $this->createMock(FieldSetConfiguratorInterface::class);
-        $configurator2 = $this->createMock(FieldSetConfiguratorInterface::class);
+        $configurator = $this->createMock(FieldSetConfigurator::class);
+        $configurator2 = $this->createMock(FieldSetConfigurator::class);
 
         $registry = new LazyFieldSetRegistry(
             [
@@ -78,8 +78,8 @@ final class LazyFieldSetRegistryTest extends TestCase
     /** @test */
     public function it_checks_registered_before_className()
     {
-        $configurator = $this->createMock(FieldSetConfiguratorInterface::class);
-        $configurator2 = $this->createMock(FieldSetConfiguratorInterface::class);
+        $configurator = $this->createMock(FieldSetConfigurator::class);
+        $configurator2 = $this->createMock(FieldSetConfigurator::class);
         $name = get_class($configurator2);
 
         $registry = new LazyFieldSetRegistry(
@@ -106,7 +106,7 @@ final class LazyFieldSetRegistryTest extends TestCase
     /** @test */
     public function it_errors_when_configurator_is_not_registered_and_class_is_a_configurator()
     {
-        $configurator = $this->createMock(FieldSetConfiguratorInterface::class);
+        $configurator = $this->createMock(FieldSetConfigurator::class);
         $configurator2 = \stdClass::class;
 
         $registry = new LazyFieldSetRegistry(
@@ -132,7 +132,7 @@ final class LazyFieldSetRegistryTest extends TestCase
     /** @test */
     public function it_errors_when_configurator_is_not_registered_class_does_not_exist()
     {
-        $configurator = $this->createMock(FieldSetConfiguratorInterface::class);
+        $configurator = $this->createMock(FieldSetConfigurator::class);
         $configurator2 = 'f4394832948_foobar_cow';
 
         $registry = new LazyFieldSetRegistry(

--- a/tests/ResolvedFieldTypeTest.php
+++ b/tests/ResolvedFieldTypeTest.php
@@ -19,7 +19,7 @@ use Rollerworks\Component\Search\AbstractFieldTypeExtension;
 use Rollerworks\Component\Search\FieldConfigInterface;
 use Rollerworks\Component\Search\FieldTypeExtensionInterface;
 use Rollerworks\Component\Search\FieldTypeInterface;
-use Rollerworks\Component\Search\ResolvedFieldType;
+use Rollerworks\Component\Search\GenericResolvedFieldType;
 use Rollerworks\Component\Search\SearchFieldView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -46,12 +46,12 @@ final class ResolvedFieldTypeTest extends TestCase
     private $extension2;
 
     /**
-     * @var ResolvedFieldType
+     * @var GenericResolvedFieldType
      */
     private $parentResolvedType;
 
     /**
-     * @var ResolvedFieldType
+     * @var GenericResolvedFieldType
      */
     private $resolvedType;
 
@@ -61,8 +61,8 @@ final class ResolvedFieldTypeTest extends TestCase
         $this->type = $this->getMockFieldType();
         $this->extension1 = $this->getMockFieldTypeExtension();
         $this->extension2 = $this->getMockFieldTypeExtension();
-        $this->parentResolvedType = new ResolvedFieldType($this->parentType);
-        $this->resolvedType = new ResolvedFieldType(
+        $this->parentResolvedType = new GenericResolvedFieldType($this->parentType);
+        $this->resolvedType = new GenericResolvedFieldType(
             $this->type,
             [$this->extension1, $this->extension2],
             $this->parentResolvedType
@@ -122,7 +122,7 @@ final class ResolvedFieldTypeTest extends TestCase
         $resolvedOptions = ['a' => 'a_custom', 'b' => 'b_default', 'c' => 'c_custom', 'd' => 'd_default'];
         $optionsResolver = $this->createOptionsResolverMock();
 
-        $this->resolvedType = $this->getMockBuilder(ResolvedFieldType::class)
+        $this->resolvedType = $this->getMockBuilder(GenericResolvedFieldType::class)
             ->setConstructorArgs([$this->type, [$this->extension1, $this->extension2], $this->parentResolvedType])
             ->setMethods(['getOptionsResolver'])
             ->getMock();

--- a/tests/ResolvedFieldTypeTest.php
+++ b/tests/ResolvedFieldTypeTest.php
@@ -16,9 +16,9 @@ namespace Rollerworks\Component\Search\Tests;
 use PHPUnit\Framework\TestCase;
 use Rollerworks\Component\Search\AbstractFieldType;
 use Rollerworks\Component\Search\AbstractFieldTypeExtension;
-use Rollerworks\Component\Search\FieldConfigInterface;
-use Rollerworks\Component\Search\FieldTypeExtensionInterface;
-use Rollerworks\Component\Search\FieldTypeInterface;
+use Rollerworks\Component\Search\FieldConfig;
+use Rollerworks\Component\Search\FieldType;
+use Rollerworks\Component\Search\FieldTypeExtension;
 use Rollerworks\Component\Search\GenericResolvedFieldType;
 use Rollerworks\Component\Search\SearchFieldView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -26,22 +26,22 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 final class ResolvedFieldTypeTest extends TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|FieldTypeInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|FieldType
      */
     private $parentType;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|FieldTypeInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|FieldType
      */
     private $type;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|FieldTypeExtensionInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|FieldTypeExtension
      */
     private $extension1;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|FieldTypeExtensionInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|FieldTypeExtension
      */
     private $extension2;
 
@@ -273,7 +273,7 @@ final class ResolvedFieldTypeTest extends TestCase
      */
     private function createFieldMock()
     {
-        return $this->getMockBuilder(FieldConfigInterface::class)->getMock();
+        return $this->getMockBuilder(FieldConfig::class)->getMock();
     }
 
     /**

--- a/tests/SearchConditionSerializerTest.php
+++ b/tests/SearchConditionSerializerTest.php
@@ -15,11 +15,11 @@ namespace Rollerworks\Component\Search\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Rollerworks\Component\Search\Exception\InvalidArgumentException;
-use Rollerworks\Component\Search\FieldConfigInterface;
+use Rollerworks\Component\Search\FieldConfig;
 use Rollerworks\Component\Search\FieldSet;
 use Rollerworks\Component\Search\SearchCondition;
 use Rollerworks\Component\Search\SearchConditionSerializer;
-use Rollerworks\Component\Search\SearchFactoryInterface;
+use Rollerworks\Component\Search\SearchFactory;
 use Rollerworks\Component\Search\Value\ValuesBag;
 use Rollerworks\Component\Search\Value\ValuesGroup;
 
@@ -35,12 +35,12 @@ final class SearchConditionSerializerTest extends TestCase
 
     protected function setUp()
     {
-        $field = $this->createMock(FieldConfigInterface::class);
+        $field = $this->createMock(FieldConfig::class);
         $field->expects(self::any())->method('getName')->willReturn('id');
 
         $this->fieldSet = new FieldSet(['id' => $field], 'foobar');
 
-        $factory = $this->prophesize(SearchFactoryInterface::class);
+        $factory = $this->prophesize(SearchFactory::class);
         $factory->createFieldSet('foobar')->willReturn($this->fieldSet);
 
         $this->serializer = new SearchConditionSerializer($factory->reveal());

--- a/tests/SearchFactoryBuilderTest.php
+++ b/tests/SearchFactoryBuilderTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Rollerworks\Component\Search\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Rollerworks\Component\Search\SearchFactory;
+use Rollerworks\Component\Search\GenericSearchFactory;
 use Rollerworks\Component\Search\SearchFactoryBuilder;
 use Rollerworks\Component\Search\Tests\Fixtures\FooType;
 
@@ -26,7 +26,7 @@ class SearchFactoryBuilderTest extends TestCase
 
     protected function setUp()
     {
-        $factory = new \ReflectionClass(SearchFactory::class);
+        $factory = new \ReflectionClass(GenericSearchFactory::class);
         $this->registry = $factory->getProperty('registry');
         $this->registry->setAccessible(true);
 

--- a/tests/SearchFieldTest.php
+++ b/tests/SearchFieldTest.php
@@ -14,20 +14,20 @@ declare(strict_types=1);
 namespace Rollerworks\Component\Search\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Rollerworks\Component\Search\DataTransformerInterface;
+use Rollerworks\Component\Search\DataTransformer;
 use Rollerworks\Component\Search\Exception\BadMethodCallException;
 use Rollerworks\Component\Search\Exception\InvalidConfigurationException;
-use Rollerworks\Component\Search\ResolvedFieldTypeInterface;
+use Rollerworks\Component\Search\ResolvedFieldType;
 use Rollerworks\Component\Search\SearchField;
 use Rollerworks\Component\Search\Value\Compare;
 use Rollerworks\Component\Search\Value\PatternMatch;
 use Rollerworks\Component\Search\Value\Range;
-use Rollerworks\Component\Search\ValueComparisonInterface;
+use Rollerworks\Component\Search\ValueComparator;
 
 final class SearchFieldTest extends TestCase
 {
     /**
-     * @var \Rollerworks\Component\Search\ResolvedFieldTypeInterface
+     * @var \Rollerworks\Component\Search\ResolvedFieldType
      */
     private $resolvedType;
 
@@ -38,7 +38,7 @@ final class SearchFieldTest extends TestCase
 
     protected function setUp()
     {
-        $this->resolvedType = $this->getMockBuilder(ResolvedFieldTypeInterface::class)->getMock();
+        $this->resolvedType = $this->getMockBuilder(ResolvedFieldType::class)->getMock();
         $this->field = new SearchField('foobar', $this->resolvedType, ['name' => 'value']);
     }
 
@@ -137,7 +137,7 @@ final class SearchFieldTest extends TestCase
      */
     public function it_allows_setting_a_comparison_class()
     {
-        $comparisonObj = $this->getMockBuilder(ValueComparisonInterface::class)->getMock();
+        $comparisonObj = $this->getMockBuilder(ValueComparator::class)->getMock();
 
         $this->field->setValueComparison($comparisonObj);
         self::assertEquals($comparisonObj, $this->field->getValueComparison());
@@ -224,6 +224,6 @@ final class SearchFieldTest extends TestCase
      */
     private function createTransformerMock()
     {
-        return $this->getMockBuilder(DataTransformerInterface::class)->getMock();
+        return $this->getMockBuilder(DataTransformer::class)->getMock();
     }
 }

--- a/tests/TypeRegistryTest.php
+++ b/tests/TypeRegistryTest.php
@@ -15,17 +15,17 @@ namespace Rollerworks\Component\Search\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
-use Rollerworks\Component\Search\FieldRegistry;
 use Rollerworks\Component\Search\FieldTypeExtensionInterface;
 use Rollerworks\Component\Search\FieldTypeInterface;
+use Rollerworks\Component\Search\GenericResolvedFieldTypeFactory;
+use Rollerworks\Component\Search\GenericTypeRegistry;
 use Rollerworks\Component\Search\PreloadedExtension;
-use Rollerworks\Component\Search\ResolvedFieldTypeFactory;
 use Rollerworks\Component\Search\ResolvedFieldTypeInterface;
 use Rollerworks\Component\Search\Tests\Fixtures\BarType;
 use Rollerworks\Component\Search\Tests\Fixtures\FooSubType;
 use Rollerworks\Component\Search\Tests\Fixtures\FooType;
 
-final class FieldRegistryTest extends TestCase
+final class TypeRegistryTest extends TestCase
 {
     /**
      * @test
@@ -36,12 +36,12 @@ final class FieldRegistryTest extends TestCase
         $extension2 = new PreloadedExtension([FooSubType::class => $fooSubType = new FooSubType()]);
         $barType = new BarType();
 
-        $resolvedFieldTypeFactory = $this->prophesize(ResolvedFieldTypeFactory::class);
+        $resolvedFieldTypeFactory = $this->prophesize(GenericResolvedFieldTypeFactory::class);
         $resolvedFieldTypeFactory->createResolvedType(Argument::type(FooType::class), [], null)->willReturn($resolvedFooType = $this->createResolvedTypeMock($fooType));
         $resolvedFieldTypeFactory->createResolvedType(Argument::type(FooSubType::class), [], $resolvedFooType)->willReturn($this->createResolvedTypeMock($fooSubType));
         $resolvedFieldTypeFactory->createResolvedType(Argument::type(BarType::class), [], null)->willReturn($this->createResolvedTypeMock($barType));
 
-        $registry = new FieldRegistry([$extension, $extension2], $resolvedFieldTypeFactory->reveal());
+        $registry = new GenericTypeRegistry([$extension, $extension2], $resolvedFieldTypeFactory->reveal());
 
         self::assertTrue($registry->hasType(FooType::class));
         self::assertTrue($registry->hasType(FooType::class)); // once the type is loaded it's cached internally
@@ -72,12 +72,12 @@ final class FieldRegistryTest extends TestCase
 
         $barType = new BarType();
 
-        $resolvedFieldTypeFactory = $this->prophesize(ResolvedFieldTypeFactory::class);
+        $resolvedFieldTypeFactory = $this->prophesize(GenericResolvedFieldTypeFactory::class);
         $resolvedFieldTypeFactory->createResolvedType(Argument::type(FooType::class), [], null)->willReturn($resolvedFooType = $this->createResolvedTypeMock($fooType));
         $resolvedFieldTypeFactory->createResolvedType(Argument::type(FooSubType::class), [$fooSubTypeExtension], $resolvedFooType)->willReturn($this->createResolvedTypeMock($fooSubType));
         $resolvedFieldTypeFactory->createResolvedType(Argument::type(BarType::class), [$barTypeExtension], null)->willReturn($this->createResolvedTypeMock($barType));
 
-        $registry = new FieldRegistry([$extension, $extension2], $resolvedFieldTypeFactory->reveal());
+        $registry = new GenericTypeRegistry([$extension, $extension2], $resolvedFieldTypeFactory->reveal());
 
         self::assertTrue($registry->hasType(FooType::class));
         self::assertTrue($registry->hasType(FooSubType::class));

--- a/tests/TypeRegistryTest.php
+++ b/tests/TypeRegistryTest.php
@@ -15,12 +15,12 @@ namespace Rollerworks\Component\Search\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
-use Rollerworks\Component\Search\FieldTypeExtensionInterface;
-use Rollerworks\Component\Search\FieldTypeInterface;
+use Rollerworks\Component\Search\FieldType;
+use Rollerworks\Component\Search\FieldTypeExtension;
 use Rollerworks\Component\Search\GenericResolvedFieldTypeFactory;
 use Rollerworks\Component\Search\GenericTypeRegistry;
 use Rollerworks\Component\Search\PreloadedExtension;
-use Rollerworks\Component\Search\ResolvedFieldTypeInterface;
+use Rollerworks\Component\Search\ResolvedFieldType;
 use Rollerworks\Component\Search\Tests\Fixtures\BarType;
 use Rollerworks\Component\Search\Tests\Fixtures\FooSubType;
 use Rollerworks\Component\Search\Tests\Fixtures\FooType;
@@ -49,9 +49,9 @@ final class TypeRegistryTest extends TestCase
         self::assertTrue($registry->hasType(BarType::class)); // auto loaded by FQCN
         self::assertFalse($registry->hasType('text'));
 
-        self::assertInstanceOf(ResolvedFieldTypeInterface::class, $registry->getType(FooType::class));
-        self::assertInstanceOf(ResolvedFieldTypeInterface::class, $registry->getType(FooSubType::class));
-        self::assertInstanceOf(ResolvedFieldTypeInterface::class, $registry->getType(BarType::class));
+        self::assertInstanceOf(ResolvedFieldType::class, $registry->getType(FooType::class));
+        self::assertInstanceOf(ResolvedFieldType::class, $registry->getType(FooSubType::class));
+        self::assertInstanceOf(ResolvedFieldType::class, $registry->getType(BarType::class));
     }
 
     /**
@@ -84,22 +84,22 @@ final class TypeRegistryTest extends TestCase
         self::assertTrue($registry->hasType(BarType::class)); // auto loaded by FQCN
         self::assertFalse($registry->hasType('text'));
 
-        self::assertInstanceOf(ResolvedFieldTypeInterface::class, $registry->getType(FooType::class));
-        self::assertInstanceOf(ResolvedFieldTypeInterface::class, $registry->getType(FooSubType::class));
-        self::assertInstanceOf(ResolvedFieldTypeInterface::class, $registry->getType(BarType::class));
+        self::assertInstanceOf(ResolvedFieldType::class, $registry->getType(FooType::class));
+        self::assertInstanceOf(ResolvedFieldType::class, $registry->getType(FooSubType::class));
+        self::assertInstanceOf(ResolvedFieldType::class, $registry->getType(BarType::class));
     }
 
-    private function createResolvedTypeMock(FieldTypeInterface $type): ResolvedFieldTypeInterface
+    private function createResolvedTypeMock(FieldType $type): ResolvedFieldType
     {
-        $resolvedType = $this->createMock(ResolvedFieldTypeInterface::class);
+        $resolvedType = $this->createMock(ResolvedFieldType::class);
         $resolvedType->expects($this->any())->method('getInnerType')->willReturn($type);
 
         return $resolvedType;
     }
 
-    private function createTypeExtensionMock(string $name): FieldTypeExtensionInterface
+    private function createTypeExtensionMock(string $name): FieldTypeExtension
     {
-        $fieldExtension = $this->createMock(FieldTypeExtensionInterface::class);
+        $fieldExtension = $this->createMock(FieldTypeExtension::class);
         $fieldExtension->expects($this->any())->method('getExtendedType')->willReturn($name);
 
         return $fieldExtension;


### PR DESCRIPTION
The (new) style guide of Rollerworks forbids that Interfaces are suffixed with “Interface” as this breaks ambiguous naming.

Say we had the SearchFactory class but like to introduce a SearchFactory (Interface), renaming the class is one thing. But now all the typehints and references need to be updated, which can cause some serieus BC breakage.

Second Interfaces suffixes are a form Hungarian notations, which is considered a bad practice for a really long time now. Only traits should be suffixed as they can never change there intention, not can they be type-hinted.