### PR TITLE
Add SearchCondition::assertFieldSetName

### DIFF
--- a/src/Exception/UnsupportedFieldSetException.php
+++ b/src/Exception/UnsupportedFieldSetException.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Exception;
+
+final class UnsupportedFieldSetException extends InvalidArgumentException
+{
+    public function __construct(array $expected, string $provided)
+    {
+        parent::__construct(
+            sprintf('FieldSet "%s" was not expected, expected one of "%s"', $provided, implode('", "', $expected))
+        );
+    }
+}

--- a/src/SearchCondition.php
+++ b/src/SearchCondition.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search;
 
+use Rollerworks\Component\Search\Exception\UnsupportedFieldSetException;
 use Rollerworks\Component\Search\Value\ValuesGroup;
 
 /**
@@ -37,5 +38,18 @@ class SearchCondition
     public function getValuesGroup(): ValuesGroup
     {
         return $this->values;
+    }
+
+    /**
+     * Checks that the FieldSet of this condition is supported
+     * by the contexts it's used in.
+     *
+     * @param \string[] ...$name One or more FieldSet names to check for
+     */
+    public function assertFieldSetName(string ...$name)
+    {
+        if (!in_array($providedName = $this->fieldSet->getSetName(), $name, true)) {
+            throw new UnsupportedFieldSetException($name, $providedName);
+        }
     }
 }

--- a/tests/SearchConditionTest.php
+++ b/tests/SearchConditionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Rollerworks\Component\Search\Exception\UnsupportedFieldSetException;
+use Rollerworks\Component\Search\FieldSet;
+use Rollerworks\Component\Search\SearchCondition;
+use Rollerworks\Component\Search\Value\ValuesGroup;
+
+class SearchConditionTest extends TestCase
+{
+    /** @test */
+    public function it_can_check_if_FieldSet_is_supported()
+    {
+        $fieldSet = $this->createMock(FieldSet::class);
+        $fieldSet->expects(self::any())->method('getSetName')->willReturn('test');
+
+        $condition = new SearchCondition($fieldSet, new ValuesGroup());
+        $condition->assertFieldSetName('test');
+        $condition->assertFieldSetName('test', 'foo');
+
+        // Dummy tests, no error means it works.
+        self::assertEquals(new ValuesGroup(), $condition->getValuesGroup());
+    }
+
+    /** @test */
+    public function it_gives_an_exception_when_checked_FieldSet_is_not_supported()
+    {
+        $fieldSet = $this->createMock(FieldSet::class);
+        $fieldSet->expects(self::any())->method('getSetName')->willReturn('test');
+
+        $condition = new SearchCondition($fieldSet, new ValuesGroup());
+
+        $this->expectException(UnsupportedFieldSetException::class);
+        $this->expectExceptionMessage((new UnsupportedFieldSetException(['bar', 'foo'], 'test'))->getMessage());
+
+        $condition->assertFieldSetName('bar', 'foo');
+    }
+}


### PR DESCRIPTION
The FieldSet holds a specific configuration of fields, which may not be supported everywhere.
To check if the FieldSet of a SearchCondition is supported in the context the `assertFieldSetName`
allows to check if the FieldSet is supported.