### PR TITLE
Introduce better Lazy loading of dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "symfony/property-access": "^3.2.1",
         "symfony/intl": "^3.2.1",
         "seld/jsonlint": "^1.5.0",
-        "moneyphp/money": "^3.0.0"
+        "moneyphp/money": "^3.0.0",
+        "psr/container": "^1.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7.5",

--- a/src/Loader/ClosureContainer.php
+++ b/src/Loader/ClosureContainer.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Loader;
+
+use Psr\Container\ContainerInterface;
+
+/**
+ * ClosureContainer helps with lazily loading dependencies.
+ *
+ * This class is provided for easy of use, it should not be used
+ * directly within your own code.
+ *
+ * @internal
+ */
+final class ClosureContainer implements ContainerInterface
+{
+    private $factories;
+    private $values = [];
+
+    /**
+     * @param \Closure[] $factories
+     */
+    public function __construct(array $factories)
+    {
+        $this->factories = $factories;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($id)
+    {
+        return isset($this->factories[$id]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get($id)
+    {
+        if (!isset($this->factories[$id])) {
+            throw new ServiceNotFoundException($id);
+        }
+
+        if (true !== $factory = $this->factories[$id]) {
+            $this->factories[$id] = true;
+            $this->values[$id] = $factory();
+        }
+
+        return $this->values[$id];
+    }
+}

--- a/src/Loader/ConditionExporterLoader.php
+++ b/src/Loader/ConditionExporterLoader.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Loader;
+
+use Psr\Container\ContainerInterface;
+use Rollerworks\Component\Search\ConditionExporter;
+use Rollerworks\Component\Search\Exception\InvalidArgumentException;
+use Rollerworks\Component\Search\Exporter;
+
+/**
+ * ConditionExporterLoader provides lazy loading of ConditionExporters.
+ *
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+final class ConditionExporterLoader
+{
+    private $container;
+    private $serviceIds = [];
+
+    /**
+     * @param ContainerInterface $container  A PSR-11 compatible Service locator/container
+     * @param array              $serviceIds Format alias to service-id mapping,
+     *                                       eg. 'json' => 'JsonExporter-ClassName'
+     */
+    public function __construct(ContainerInterface $container, array $serviceIds)
+    {
+        $this->container = $container;
+        $this->serviceIds = $serviceIds;
+    }
+
+    /**
+     * Create a new ConditionExporterLoader with the build-in ConditionExporters
+     * loadable.
+     *
+     * @return ConditionExporterLoader
+     */
+    public static function create(): ConditionExporterLoader
+    {
+        return new self(
+            new ClosureContainer(
+                [
+                    'rollerworks_search.condition_exporter.array' => function () {
+                        return new Exporter\ArrayExporter();
+                    },
+                    'rollerworks_search.condition_exporter.json' => function () {
+                        return new Exporter\JsonExporter();
+                    },
+                    'rollerworks_search.condition_exporter.xml' => function () {
+                        return new Exporter\XmlExporter();
+                    },
+                    'rollerworks_search.condition_exporter.string_query' => function () {
+                        return new Exporter\StringQueryExporter();
+                    },
+                ]
+            ),
+            [
+                'array' => 'rollerworks_search.condition_exporter.array',
+                'json' => 'rollerworks_search.condition_exporter.json',
+                'xml' => 'rollerworks_search.condition_exporter.xml',
+                'string_query' => 'rollerworks_search.condition_exporter.string_query',
+            ]
+        );
+    }
+
+    /**
+     * Lazily loads a ConditionExporter.
+     *
+     * @param string $format
+     *
+     * @throws \InvalidArgumentException when there is no exporter for the given format
+     *
+     * @return ConditionExporter
+     */
+    public function get(string $format): ConditionExporter
+    {
+        if (!isset($this->serviceIds[$format])) {
+            throw new InvalidArgumentException(
+                sprintf('Enable to load exporter, format "%s" has no registered exporter.', $format)
+            );
+        }
+
+        return $this->container->get($this->serviceIds[$format]);
+    }
+}

--- a/src/Loader/InputProcessorLoader.php
+++ b/src/Loader/InputProcessorLoader.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Loader;
+
+use Psr\Container\ContainerInterface;
+use Rollerworks\Component\Search\Exception\InvalidArgumentException;
+use Rollerworks\Component\Search\Input;
+use Rollerworks\Component\Search\InputProcessor;
+
+/**
+ * InputProcessorLoader provides lazy loading of Input processors.
+ *
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+final class InputProcessorLoader
+{
+    private $container;
+    private $serviceIds;
+
+    /**
+     * Constructor.
+     *
+     * @param ContainerInterface $container  A PSR-11 compatible Service locator/container
+     * @param string[]           $serviceIds Format alias to service-id mapping,
+     *                                       eg. 'json' => 'JsonInput-ClassName'
+     */
+    public function __construct(ContainerInterface $container, array $serviceIds)
+    {
+        $this->container = $container;
+        $this->serviceIds = $serviceIds;
+    }
+
+    /**
+     * Create a new InputProcessorLoader with the build-in InputProcessors
+     * loadable.
+     *
+     * @param Input\Validator|null $validator
+     *
+     * @return InputProcessorLoader
+     */
+    public static function create(Input\Validator $validator = null): InputProcessorLoader
+    {
+        return new self(
+            new ClosureContainer(
+                [
+                    'rollerworks_search.input.array' => function () use ($validator) {
+                        return new Input\ArrayInput($validator);
+                    },
+                    'rollerworks_search.input.json' => function () use ($validator) {
+                        return new Input\JsonInput($validator);
+                    },
+                    'rollerworks_search.input.xml' => function () use ($validator) {
+                        return new Input\XmlInput($validator);
+                    },
+                    'rollerworks_search.input.string_query' => function () use ($validator) {
+                        return new Input\StringQueryInput($validator);
+                    },
+                ]
+            ),
+            [
+                'array' => 'rollerworks_search.input.array',
+                'json' => 'rollerworks_search.input.json',
+                'xml' => 'rollerworks_search.input.xml',
+                'string_query' => 'rollerworks_search.input.string_query',
+            ]
+        );
+    }
+
+    /**
+     * Lazily loads an Input processor.
+     *
+     * @param string $name
+     *
+     * @throws \InvalidArgumentException when there is no input processor with the given name
+     *
+     * @return InputProcessor
+     */
+    public function get(string $name): InputProcessor
+    {
+        if (!isset($this->serviceIds[$name])) {
+            throw new InvalidArgumentException(
+                sprintf('Enable to load input-processor, "%s" is not registered as processor.', $name)
+            );
+        }
+
+        return $this->container->get($this->serviceIds[$name]);
+    }
+}

--- a/src/Loader/ServiceNotFoundException.php
+++ b/src/Loader/ServiceNotFoundException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Loader;
+
+use Psr\Container\NotFoundExceptionInterface;
+use Rollerworks\Component\Search\Exception\InvalidArgumentException;
+
+class ServiceNotFoundException extends InvalidArgumentException implements NotFoundExceptionInterface
+{
+    public function __construct(string $id)
+    {
+        parent::__construct(sprintf('You have requested a non-existent service "%s".', $id));
+    }
+}

--- a/src/SearchFactoryBuilder.php
+++ b/src/SearchFactoryBuilder.php
@@ -186,6 +186,6 @@ class SearchFactoryBuilder
         $resolvedTypeFactory = $this->resolvedTypeFactory ?? new GenericResolvedFieldTypeFactory();
         $registry = new GenericTypeRegistry($extensions, $resolvedTypeFactory);
 
-        return new GenericSearchFactory($registry, $this->fieldSetRegistry ?? new LazyFieldSetRegistry(), $this->conditionOptimizer);
+        return new GenericSearchFactory($registry, $this->fieldSetRegistry ?? LazyFieldSetRegistry::create(), $this->conditionOptimizer);
     }
 }

--- a/tests/LazyFieldSetRegistryTest.php
+++ b/tests/LazyFieldSetRegistryTest.php
@@ -26,7 +26,7 @@ final class LazyFieldSetRegistryTest extends TestCase
         $configurator = $this->createMock(FieldSetConfigurator::class);
         $configurator2 = $this->createMock(FieldSetConfigurator::class);
 
-        $registry = new LazyFieldSetRegistry(
+        $registry = LazyFieldSetRegistry::create(
             [
                 'set' => function () use ($configurator) {
                     return $configurator;
@@ -57,7 +57,7 @@ final class LazyFieldSetRegistryTest extends TestCase
         $configurator = $this->createMock(FieldSetConfigurator::class);
         $configurator2 = $this->createMock(FieldSetConfigurator::class);
 
-        $registry = new LazyFieldSetRegistry(
+        $registry = LazyFieldSetRegistry::create(
             [
                 'set' => function () use ($configurator) {
                     return $configurator;
@@ -82,7 +82,7 @@ final class LazyFieldSetRegistryTest extends TestCase
         $configurator2 = $this->createMock(FieldSetConfigurator::class);
         $name = get_class($configurator2);
 
-        $registry = new LazyFieldSetRegistry(
+        $registry = LazyFieldSetRegistry::create(
             [
                 'set' => function () use ($configurator) {
                     return $configurator;
@@ -109,7 +109,7 @@ final class LazyFieldSetRegistryTest extends TestCase
         $configurator = $this->createMock(FieldSetConfigurator::class);
         $configurator2 = \stdClass::class;
 
-        $registry = new LazyFieldSetRegistry(
+        $registry = LazyFieldSetRegistry::create(
             [
                 'set' => function () use ($configurator) {
                     return $configurator;
@@ -124,7 +124,7 @@ final class LazyFieldSetRegistryTest extends TestCase
         self::assertSame($configurator, $registry->getConfigurator('set'));
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Could not load FieldSet configurator "stdClass"');
+        $this->expectExceptionMessage('Configurator class "stdClass" is expected to be an instance of ');
 
         $registry->getConfigurator($configurator2);
     }
@@ -135,7 +135,7 @@ final class LazyFieldSetRegistryTest extends TestCase
         $configurator = $this->createMock(FieldSetConfigurator::class);
         $configurator2 = 'f4394832948_foobar_cow';
 
-        $registry = new LazyFieldSetRegistry(
+        $registry = LazyFieldSetRegistry::create(
             [
                 'set' => function () use ($configurator) {
                     return $configurator;

--- a/tests/Loader/ConditionExporterLoaderTest.php
+++ b/tests/Loader/ConditionExporterLoaderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Tests\Loader;
+
+use PHPUnit\Framework\TestCase;
+use Rollerworks\Component\Search\Exception\InvalidArgumentException;
+use Rollerworks\Component\Search\Exporter;
+use Rollerworks\Component\Search\Loader\ConditionExporterLoader;
+
+class ConditionExporterLoaderTest extends TestCase
+{
+    /** @test */
+    public function it_lazily_loads_a_condition_exporter()
+    {
+        $loader = ConditionExporterLoader::create();
+        $processor = $loader->get('json');
+
+        self::assertSame($processor, $loader->get('json'));
+    }
+
+    /**
+     * @dataProvider provideProcessors
+     * @test
+     */
+    public function it_can_load_bundled_processor(string $alias, string $className)
+    {
+        $loader = ConditionExporterLoader::create();
+
+        self::assertInstanceOf($className, $loader->get($alias));
+    }
+
+    public function provideProcessors(): array
+    {
+        return [
+            ['json', Exporter\JsonExporter::class],
+            ['xml', Exporter\XmlExporter::class],
+            ['array', Exporter\ArrayExporter::class],
+            ['string_query', Exporter\StringQueryExporter::class],
+        ];
+    }
+
+    /** @test */
+    public function it_fails_for_unsupported_processor()
+    {
+        $loader = ConditionExporterLoader::create();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Enable to load exporter, format "form" has no registered exporter.');
+
+        $loader->get('form');
+    }
+}

--- a/tests/Loader/InputProcessorLoaderTest.php
+++ b/tests/Loader/InputProcessorLoaderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Tests\Loader;
+
+use PHPUnit\Framework\TestCase;
+use Rollerworks\Component\Search\Exception\InvalidArgumentException;
+use Rollerworks\Component\Search\Input;
+use Rollerworks\Component\Search\Loader\InputProcessorLoader;
+
+class InputProcessorLoaderTest extends TestCase
+{
+    /** @test */
+    public function it_lazily_loads_an_input_processor()
+    {
+        $loader = InputProcessorLoader::create();
+        $processor = $loader->get('json');
+
+        self::assertSame($processor, $loader->get('json'));
+    }
+
+    /**
+     * @dataProvider provideProcessors
+     * @test
+     */
+    public function it_can_load_bundled_processor(string $alias, string $className)
+    {
+        $loader = InputProcessorLoader::create();
+
+        self::assertInstanceOf($className, $loader->get($alias));
+    }
+
+    public function provideProcessors(): array
+    {
+        return [
+            ['json', Input\JsonInput::class],
+            ['xml', Input\XmlInput::class],
+            ['array', Input\ArrayInput::class],
+            ['string_query', Input\StringQueryInput::class],
+        ];
+    }
+
+    /** @test */
+    public function it_fails_for_unsupported_processor()
+    {
+        $loader = InputProcessorLoader::create();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Enable to load input-processor, "form" is not registered as processor.');
+
+        $loader->get('form');
+    }
+}


### PR DESCRIPTION
Use the PSR-11 ContainerInterface for lazily loading dependencies (InputProcessors, ConditionExporters, FieldSet configurators), and easing framework integration.

The `LazyFieldSetRegistry` no longer accepts factories in constructor, use `LazyFieldSetRegistry::create()` instead. 