### PR TITLE
Rename ValueComparison to ValueComparator

### DIFF
--- a/src/ConditionOptimizer/ValueSortCompare.php
+++ b/src/ConditionOptimizer/ValueSortCompare.php
@@ -24,21 +24,21 @@ use Rollerworks\Component\Search\ValueComparator;
  */
 final class ValueSortCompare
 {
-    private $comparison;
+    private $comparator;
     private $options;
 
-    public function __construct(ValueComparator $comparison, array $options)
+    public function __construct(ValueComparator $comparator, array $options)
     {
-        $this->comparison = $comparison;
+        $this->comparator = $comparator;
         $this->options = $options;
     }
 
     public function __invoke($a, $b): int
     {
-        if ($this->comparison->isEqual($a, $b, $this->options)) {
+        if ($this->comparator->isEqual($a, $b, $this->options)) {
             return 0;
         }
 
-        return $this->comparison->isLower($a, $b, $this->options) ? -1 : 1;
+        return $this->comparator->isLower($a, $b, $this->options) ? -1 : 1;
     }
 }

--- a/src/ConditionOptimizer/ValuesToRange.php
+++ b/src/ConditionOptimizer/ValuesToRange.php
@@ -46,7 +46,7 @@ class ValuesToRange implements SearchConditionOptimizer
 
         foreach ($fieldSet->all() as $name => $field) {
             if ($field->supportValueType(Range::class)) {
-                $this->comparators[$name] = new ValueSortCompare($field->getValueComparison(), $field->getOptions());
+                $this->comparators[$name] = new ValueSortCompare($field->getValueComparator(), $field->getOptions());
 
                 $optimize = true;
                 break;
@@ -85,18 +85,18 @@ class ValuesToRange implements SearchConditionOptimizer
         }
     }
 
-    private function optimizeValuesInValuesBag(FieldConfig $config, ValueSortCompare $comparisonFunc, ValuesBag $valuesBag)
+    private function optimizeValuesInValuesBag(FieldConfig $config, ValueSortCompare $comparatorFunc, ValuesBag $valuesBag)
     {
         if ($valuesBag->hasSimpleValues()) {
             $values = $valuesBag->getSimpleValues();
-            uasort($values, $comparisonFunc);
+            uasort($values, $comparatorFunc);
 
             $this->listToRanges($values, $valuesBag, $config);
         }
 
         if ($valuesBag->hasExcludedSimpleValues()) {
             $excludes = $valuesBag->getExcludedSimpleValues();
-            uasort($excludes, $comparisonFunc);
+            uasort($excludes, $comparatorFunc);
 
             $this->listToRanges($excludes, $valuesBag, $config, true);
         }
@@ -105,8 +105,8 @@ class ValuesToRange implements SearchConditionOptimizer
     private function listToRanges(array $values, ValuesBag $valuesBag, FieldConfig $config, bool $exclude = false)
     {
         $class = $exclude ? ExcludedRange::class : Range::class;
-        /** @var ValueIncrementer $comparison */
-        $comparison = $config->getValueComparison();
+        /** @var ValueIncrementer $comparator */
+        $comparator = $config->getValueComparator();
         $options = $config->getOptions();
 
         $prevIndex = null;
@@ -133,9 +133,9 @@ class ValuesToRange implements SearchConditionOptimizer
                 continue;
             }
 
-            $increasedValue = $comparison->getIncrementedValue($prevValue, $options);
+            $increasedValue = $comparator->getIncrementedValue($prevValue, $options);
 
-            if ($comparison->isEqual($value, $increasedValue, $options)) {
+            if ($comparator->isEqual($value, $increasedValue, $options)) {
                 if (null === $rangeLower) {
                     $rangeLower = $prevValue;
                 }

--- a/src/Extension/Core/CoreExtension.php
+++ b/src/Extension/Core/CoreExtension.php
@@ -27,19 +27,19 @@ class CoreExtension extends AbstractExtension
      */
     protected function loadTypes(): array
     {
-        $dateTimeComparison = new ValueComparison\DateTimeValueComparison();
-        $numberComparison = new ValueComparison\NumberValueComparison();
+        $dateTimeComparator = new ValueComparator\DateTimeValueValueComparator();
+        $numberComparator = new ValueComparator\NumberValueComparator();
 
         return [
-            new Type\SearchFieldType(new ValueComparison\SimpleValueComparison()),
-            new Type\DateType(new ValueComparison\DateValueComparison()),
-            new Type\DateTimeType($dateTimeComparison),
-            new Type\TimeType($dateTimeComparison),
-            new Type\TimestampType($dateTimeComparison),
-            new Type\BirthdayType(new ValueComparison\BirthdayValueComparison()),
-            new Type\IntegerType($numberComparison),
-            new Type\MoneyType(new ValueComparison\MoneyValueComparison()),
-            new Type\NumberType($numberComparison),
+            new Type\SearchFieldType(new ValueComparator\SimpleValueComparator()),
+            new Type\DateType(new ValueComparator\DateValueComparator()),
+            new Type\DateTimeType($dateTimeComparator),
+            new Type\TimeType($dateTimeComparator),
+            new Type\TimestampType($dateTimeComparator),
+            new Type\BirthdayType(new ValueComparator\BirthdayValueComparator()),
+            new Type\IntegerType($numberComparator),
+            new Type\MoneyType(new ValueComparator\MoneyValueComparator()),
+            new Type\NumberType($numberComparator),
         ];
     }
 }

--- a/src/Extension/Core/Type/BaseDateTimeType.php
+++ b/src/Extension/Core/Type/BaseDateTimeType.php
@@ -28,7 +28,7 @@ abstract class BaseDateTimeType extends AbstractFieldType
     /**
      * @var ValueComparator
      */
-    protected $valueComparison;
+    protected $valueComparator;
 
     /**
      * @var array
@@ -43,11 +43,11 @@ abstract class BaseDateTimeType extends AbstractFieldType
     /**
      * Constructor.
      *
-     * @param ValueComparator $valueComparison
+     * @param ValueComparator $valueComparator
      */
-    public function __construct(ValueComparator $valueComparison)
+    public function __construct(ValueComparator $valueComparator)
     {
-        $this->valueComparison = $valueComparison;
+        $this->valueComparator = $valueComparator;
     }
 
     protected function validateFormat(string $name, $value)

--- a/src/Extension/Core/Type/BirthdayType.php
+++ b/src/Extension/Core/Type/BirthdayType.php
@@ -32,16 +32,16 @@ class BirthdayType extends AbstractFieldType
     /**
      * @var ValueComparator
      */
-    private $valueComparison;
+    private $valueComparator;
 
     /**
      * Constructor.
      *
-     * @param ValueComparator $valueComparison
+     * @param ValueComparator $valueComparator
      */
-    public function __construct(ValueComparator $valueComparison)
+    public function __construct(ValueComparator $valueComparator)
     {
-        $this->valueComparison = $valueComparison;
+        $this->valueComparator = $valueComparator;
     }
 
     /**
@@ -49,7 +49,7 @@ class BirthdayType extends AbstractFieldType
      */
     public function buildType(FieldConfig $config, array $options)
     {
-        $config->setValueComparison($this->valueComparison);
+        $config->setValueComparator($this->valueComparator);
         $config->setValueTypeSupport(Range::class, true);
         $config->setValueTypeSupport(Compare::class, true);
 

--- a/src/Extension/Core/Type/DateTimeType.php
+++ b/src/Extension/Core/Type/DateTimeType.php
@@ -59,7 +59,7 @@ class DateTimeType extends BaseDateTimeType
      */
     public function buildType(FieldConfig $config, array $options)
     {
-        $config->setValueComparison($this->valueComparison);
+        $config->setValueComparator($this->valueComparator);
         $config->setValueTypeSupport(Range::class, true);
         $config->setValueTypeSupport(Compare::class, true);
 

--- a/src/Extension/Core/Type/DateType.php
+++ b/src/Extension/Core/Type/DateType.php
@@ -35,7 +35,7 @@ class DateType extends BaseDateTimeType
      */
     public function buildType(FieldConfig $config, array $options)
     {
-        $config->setValueComparison($this->valueComparison);
+        $config->setValueComparator($this->valueComparator);
         $config->setValueTypeSupport(Range::class, true);
         $config->setValueTypeSupport(Compare::class, true);
 

--- a/src/Extension/Core/Type/IntegerType.php
+++ b/src/Extension/Core/Type/IntegerType.php
@@ -31,16 +31,16 @@ class IntegerType extends AbstractFieldType
     /**
      * @var ValueComparator
      */
-    protected $valueComparison;
+    protected $valueComparator;
 
     /**
      * Constructor.
      *
-     * @param ValueComparator $valueComparison
+     * @param ValueComparator $valueComparator
      */
-    public function __construct(ValueComparator $valueComparison)
+    public function __construct(ValueComparator $valueComparator)
     {
-        $this->valueComparison = $valueComparison;
+        $this->valueComparator = $valueComparator;
     }
 
     /**
@@ -48,7 +48,7 @@ class IntegerType extends AbstractFieldType
      */
     public function buildType(FieldConfig $config, array $options)
     {
-        $config->setValueComparison($this->valueComparison);
+        $config->setValueComparator($this->valueComparator);
         $config->setValueTypeSupport(Range::class, true);
         $config->setValueTypeSupport(Compare::class, true);
 

--- a/src/Extension/Core/Type/MoneyType.php
+++ b/src/Extension/Core/Type/MoneyType.php
@@ -31,16 +31,16 @@ class MoneyType extends AbstractFieldType
     /**
      * @var ValueComparator
      */
-    protected $valueComparison;
+    protected $valueComparator;
 
     /**
      * Constructor.
      *
-     * @param ValueComparator $valueComparison
+     * @param ValueComparator $valueComparator
      */
-    public function __construct(ValueComparator $valueComparison)
+    public function __construct(ValueComparator $valueComparator)
     {
-        $this->valueComparison = $valueComparison;
+        $this->valueComparator = $valueComparator;
     }
 
     /**
@@ -48,7 +48,7 @@ class MoneyType extends AbstractFieldType
      */
     public function buildType(FieldConfig $config, array $options)
     {
-        $config->setValueComparison($this->valueComparison);
+        $config->setValueComparator($this->valueComparator);
         $config->setValueTypeSupport(Range::class, true);
         $config->setValueTypeSupport(Compare::class, true);
 

--- a/src/Extension/Core/Type/NumberType.php
+++ b/src/Extension/Core/Type/NumberType.php
@@ -31,16 +31,16 @@ class NumberType extends AbstractFieldType
     /**
      * @var ValueComparator
      */
-    protected $valueComparison;
+    protected $valueComparator;
 
     /**
      * Constructor.
      *
-     * @param ValueComparator $valueComparison
+     * @param ValueComparator $valueComparator
      */
-    public function __construct(ValueComparator $valueComparison)
+    public function __construct(ValueComparator $valueComparator)
     {
-        $this->valueComparison = $valueComparison;
+        $this->valueComparator = $valueComparator;
     }
 
     /**
@@ -48,7 +48,7 @@ class NumberType extends AbstractFieldType
      */
     public function buildType(FieldConfig $config, array $options)
     {
-        $config->setValueComparison($this->valueComparison);
+        $config->setValueComparator($this->valueComparator);
         $config->setValueTypeSupport(Range::class, true);
         $config->setValueTypeSupport(Compare::class, true);
 

--- a/src/Extension/Core/Type/SearchFieldType.php
+++ b/src/Extension/Core/Type/SearchFieldType.php
@@ -26,16 +26,16 @@ class SearchFieldType extends AbstractFieldType
     /**
      * @var ValueComparator
      */
-    private $valueComparison;
+    private $valueComparator;
 
     /**
      * Constructor.
      *
-     * @param ValueComparator $valueComparison
+     * @param ValueComparator $valueComparator
      */
-    public function __construct(ValueComparator $valueComparison)
+    public function __construct(ValueComparator $valueComparator)
     {
-        $this->valueComparison = $valueComparison;
+        $this->valueComparator = $valueComparator;
     }
 
     /**
@@ -51,7 +51,7 @@ class SearchFieldType extends AbstractFieldType
      */
     public function buildType(FieldConfig $config, array $options)
     {
-        $config->setValueComparison($this->valueComparison);
+        $config->setValueComparator($this->valueComparator);
     }
 
     /**

--- a/src/Extension/Core/Type/TimeType.php
+++ b/src/Extension/Core/Type/TimeType.php
@@ -31,16 +31,16 @@ class TimeType extends AbstractFieldType
     /**
      * @var ValueComparator
      */
-    private $valueComparison;
+    private $valueComparator;
 
     /**
      * Constructor.
      *
-     * @param ValueComparator $valueComparison
+     * @param ValueComparator $valueComparator
      */
-    public function __construct(ValueComparator $valueComparison)
+    public function __construct(ValueComparator $valueComparator)
     {
-        $this->valueComparison = $valueComparison;
+        $this->valueComparator = $valueComparator;
     }
 
     /**
@@ -64,7 +64,7 @@ class TimeType extends AbstractFieldType
 
         $config->setValueTypeSupport(Range::class, true);
         $config->setValueTypeSupport(Compare::class, true);
-        $config->setValueComparison($this->valueComparison);
+        $config->setValueComparator($this->valueComparator);
 
         $config->setViewTransformer(
             new DateTimeToStringTransformer(

--- a/src/Extension/Core/Type/TimestampType.php
+++ b/src/Extension/Core/Type/TimestampType.php
@@ -30,16 +30,16 @@ class TimestampType extends AbstractFieldType
     /**
      * @var ValueComparator
      */
-    protected $valueComparison;
+    protected $valueComparator;
 
     /**
      * Constructor.
      *
-     * @param ValueComparator $valueComparison
+     * @param ValueComparator $valueComparator
      */
-    public function __construct(ValueComparator $valueComparison)
+    public function __construct(ValueComparator $valueComparator)
     {
-        $this->valueComparison = $valueComparison;
+        $this->valueComparator = $valueComparator;
     }
 
     /**
@@ -47,7 +47,7 @@ class TimestampType extends AbstractFieldType
      */
     public function buildType(FieldConfig $config, array $options)
     {
-        $config->setValueComparison($this->valueComparison);
+        $config->setValueComparator($this->valueComparator);
         $config->setValueTypeSupport(Range::class, true);
         $config->setValueTypeSupport(Compare::class, true);
 

--- a/src/Extension/Core/ValueComparator/BirthdayValueComparator.php
+++ b/src/Extension/Core/ValueComparator/BirthdayValueComparator.php
@@ -11,14 +11,14 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Component\Search\Extension\Core\ValueComparison;
+namespace Rollerworks\Component\Search\Extension\Core\ValueComparator;
 
 use Rollerworks\Component\Search\ValueIncrementer;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class BirthdayValueComparison implements ValueIncrementer
+class BirthdayValueComparator implements ValueIncrementer
 {
     /**
      * Returns whether the first value is higher then the second value.

--- a/src/Extension/Core/ValueComparator/DateTimeValueValueComparator.php
+++ b/src/Extension/Core/ValueComparator/DateTimeValueValueComparator.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Component\Search\Extension\Core\ValueComparison;
+namespace Rollerworks\Component\Search\Extension\Core\ValueComparator;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class DateTimeValueComparison extends DateValueComparison
+class DateTimeValueValueComparator extends DateValueComparator
 {
     /**
      * Returns the incremented value of the input.

--- a/src/Extension/Core/ValueComparator/DateValueComparator.php
+++ b/src/Extension/Core/ValueComparator/DateValueComparator.php
@@ -11,14 +11,14 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Component\Search\Extension\Core\ValueComparison;
+namespace Rollerworks\Component\Search\Extension\Core\ValueComparator;
 
 use Rollerworks\Component\Search\ValueIncrementer;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class DateValueComparison implements ValueIncrementer
+class DateValueComparator implements ValueIncrementer
 {
     /**
      * Returns whether the first value is higher then the second value.

--- a/src/Extension/Core/ValueComparator/MoneyValueComparator.php
+++ b/src/Extension/Core/ValueComparator/MoneyValueComparator.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Component\Search\Extension\Core\ValueComparison;
+namespace Rollerworks\Component\Search\Extension\Core\ValueComparator;
 
 use Money\Money;
 use Rollerworks\Component\Search\Extension\Core\Model\MoneyValue;
@@ -20,7 +20,7 @@ use Rollerworks\Component\Search\ValueIncrementer;
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class MoneyValueComparison implements ValueIncrementer
+class MoneyValueComparator implements ValueIncrementer
 {
     /**
      * Returns whether the first value is higher then the second value.

--- a/src/Extension/Core/ValueComparator/NumberValueComparator.php
+++ b/src/Extension/Core/ValueComparator/NumberValueComparator.php
@@ -11,14 +11,14 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Component\Search\Extension\Core\ValueComparison;
+namespace Rollerworks\Component\Search\Extension\Core\ValueComparator;
 
 use Rollerworks\Component\Search\ValueIncrementer;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class NumberValueComparison implements ValueIncrementer
+class NumberValueComparator implements ValueIncrementer
 {
     /**
      * Returns whether the first value is higher then the second value.

--- a/src/Extension/Core/ValueComparator/SimpleValueComparator.php
+++ b/src/Extension/Core/ValueComparator/SimpleValueComparator.php
@@ -11,16 +11,16 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Component\Search\Extension\Core\ValueComparison;
+namespace Rollerworks\Component\Search\Extension\Core\ValueComparator;
 
 use Rollerworks\Component\Search\ValueComparator;
 
 /**
- * Default ValueComparison implementation, only able to compare equality.
+ * Default ValueComparator implementation, only able to compare equality.
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class SimpleValueComparison implements ValueComparator
+class SimpleValueComparator implements ValueComparator
 {
     /**
      * {@inheritdoc}

--- a/src/Field/FieldConfig.php
+++ b/src/Field/FieldConfig.php
@@ -62,19 +62,19 @@ interface FieldConfig
     public function setValueTypeSupport(string $type, bool $enabled);
 
     /**
-     * Set the {@link ValueComparisonInterface} instance for optimizing
+     * Set the {@link ValueComparator} instance for optimizing
      * and validation.
      *
-     * @param ValueComparator $comparisonObj
+     * @param ValueComparator $comparator
      */
-    public function setValueComparison(ValueComparator $comparisonObj);
+    public function setValueComparator(ValueComparator $comparator);
 
     /**
-     * Returns the configured {@link ValueComparisonInterface} instance.
+     * Returns the configured {@link ValueComparator} instance.
      *
      * @return ValueComparator|null
      */
-    public function getValueComparison();
+    public function getValueComparator(): ?ValueComparator;
 
     /**
      * Sets a view transformer for the field.

--- a/src/Field/SearchField.php
+++ b/src/Field/SearchField.php
@@ -56,7 +56,7 @@ class SearchField implements FieldConfig
     /**
      * @var ValueComparator
      */
-    private $valueComparison;
+    private $valueComparator;
 
     /**
      * @var bool
@@ -148,7 +148,7 @@ class SearchField implements FieldConfig
      *
      * @return self
      */
-    public function setValueComparison(ValueComparator $comparisonObj)
+    public function setValueComparator(ValueComparator $comparator)
     {
         if ($this->locked) {
             throw new BadMethodCallException(
@@ -156,7 +156,7 @@ class SearchField implements FieldConfig
             );
         }
 
-        $this->valueComparison = $comparisonObj;
+        $this->valueComparator = $comparator;
 
         return $this;
     }
@@ -164,9 +164,9 @@ class SearchField implements FieldConfig
     /**
      * {@inheritdoc}
      */
-    public function getValueComparison()
+    public function getValueComparator(): ?ValueComparator
     {
-        return $this->valueComparison;
+        return $this->valueComparator;
     }
 
     /**
@@ -231,7 +231,7 @@ class SearchField implements FieldConfig
             return;
         }
 
-        if (null === $this->valueComparison) {
+        if (null === $this->valueComparator) {
             foreach ($this->supportedValueTypes as $type => $supported) {
                 if ($supported && isset(class_implements($type)[RequiresComparatorValueHolder::class])) {
                     throw new InvalidConfigurationException(

--- a/src/Input/FieldValuesFactory.php
+++ b/src/Input/FieldValuesFactory.php
@@ -65,7 +65,7 @@ class FieldValuesFactory
     /**
      * @var ValueComparator
      */
-    private $valueComparison;
+    private $valueComparator;
 
     /**
      * @var string
@@ -86,10 +86,9 @@ class FieldValuesFactory
         $this->count = $valuesBag->count();
         $this->path = $path;
 
-        $this->valueComparison = $field->getValueComparison();
+        $this->valueComparator = $field->getValueComparator();
         $this->viewTransformer = $field->getViewTransformer();
         $this->normTransformer = $field->getNormTransformer() ?? $this->viewTransformer;
-        $this->valueComparison = $field->getValueComparison();
 
         $this->validator->initializeContext($field, $this->errorList);
     }
@@ -331,7 +330,7 @@ class FieldValuesFactory
 
     private function validateRangeBounds(Range $range, array $path, $lower, $upper): bool
     {
-        if (!$this->valueComparison->isLower($range->getLower(), $range->getUpper(), $this->config->getOptions())) {
+        if (!$this->valueComparator->isLower($range->getLower(), $range->getUpper(), $this->config->getOptions())) {
             $message = 'Lower range-value {{ lower }} should be lower then upper range-value {{ upper }}.';
             $params = [
                 '{{ lower }}' => strpos((string) $lower, ' ') ? "'".$lower."'" : $lower,

--- a/tests/Extension/Core/ValueComparison/DateValueComparisonTest.php
+++ b/tests/Extension/Core/ValueComparison/DateValueComparisonTest.php
@@ -14,16 +14,16 @@ declare(strict_types=1);
 namespace Rollerworks\Component\Search\Tests\Extension\Core\ValueComparison;
 
 use PHPUnit\Framework\TestCase;
-use Rollerworks\Component\Search\Extension\Core\ValueComparison\DateValueComparison;
+use Rollerworks\Component\Search\Extension\Core\ValueComparator\DateValueComparator;
 
 class DateValueComparisonTest extends TestCase
 {
-    /** @var DateValueComparison */
+    /** @var DateValueComparator */
     private $comparison;
 
     protected function setUp()
     {
-        $this->comparison = new DateValueComparison();
+        $this->comparison = new DateValueComparator();
     }
 
     /** @test */

--- a/tests/Extension/Core/ValueComparison/MoneyValueComparisonTest.php
+++ b/tests/Extension/Core/ValueComparison/MoneyValueComparisonTest.php
@@ -17,16 +17,16 @@ use Money\Currency;
 use Money\Money;
 use PHPUnit\Framework\TestCase;
 use Rollerworks\Component\Search\Extension\Core\Model\MoneyValue;
-use Rollerworks\Component\Search\Extension\Core\ValueComparison\MoneyValueComparison;
+use Rollerworks\Component\Search\Extension\Core\ValueComparator\MoneyValueComparator;
 
 final class MoneyValueComparisonTest extends TestCase
 {
-    /** @var MoneyValueComparison */
+    /** @var MoneyValueComparator */
     private $comparison;
 
     protected function setUp()
     {
-        $this->comparison = new MoneyValueComparison();
+        $this->comparison = new MoneyValueComparator();
     }
 
     /** @test */

--- a/tests/Input/FieldValuesFactoryTest.php
+++ b/tests/Input/FieldValuesFactoryTest.php
@@ -561,7 +561,7 @@ final class FieldValuesFactoryTest extends SearchIntegrationTestCase
                 }
             }
         );
-        $field->setValueComparison(
+        $field->setValueComparator(
             new class() implements ValueComparator {
                 public function isHigher($higher, $lower, array $options): bool
                 {

--- a/tests/SearchFieldTest.php
+++ b/tests/SearchFieldTest.php
@@ -129,7 +129,7 @@ final class SearchFieldTest extends TestCase
      */
     public function it_has_no_comparison_class_by_default()
     {
-        self::assertEquals(null, $this->field->getValueComparison());
+        self::assertEquals(null, $this->field->getValueComparator());
     }
 
     /**
@@ -139,8 +139,8 @@ final class SearchFieldTest extends TestCase
     {
         $comparisonObj = $this->getMockBuilder(ValueComparator::class)->getMock();
 
-        $this->field->setValueComparison($comparisonObj);
-        self::assertEquals($comparisonObj, $this->field->getValueComparison());
+        $this->field->setValueComparator($comparisonObj);
+        self::assertEquals($comparisonObj, $this->field->getValueComparator());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The ValueComparisonInterface was already renamed to ValueComparator but related classes, methods and variable were not. This pr makes them consistent again.