### PR TITLE
Add LazyExtension for loading types lazily

### DIFF
--- a/src/Extension/LazyExtension.php
+++ b/src/Extension/LazyExtension.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Extension;
+
+use Psr\Container\ContainerInterface;
+use Rollerworks\Component\Search\Exception\InvalidArgumentException;
+use Rollerworks\Component\Search\Field\FieldType;
+use Rollerworks\Component\Search\Loader\ClosureContainer;
+use Rollerworks\Component\Search\SearchExtension;
+
+/**
+ * Provides a way to lazy load types from the Container.
+ *
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+final class LazyExtension implements SearchExtension
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $typeContainer;
+
+    /**
+     * @var array[]
+     */
+    private $typeExtensionServices = [];
+
+    /**
+     * Constructor.
+     *
+     * @param ContainerInterface $typeContainer
+     * @param iterable[]         $typeExtensions
+     */
+    public function __construct(ContainerInterface $typeContainer, iterable $typeExtensions)
+    {
+        $this->typeContainer = $typeContainer;
+        $this->typeExtensionServices = $typeExtensions;
+    }
+
+    /**
+     * Creates a new LazyExtension with easy factories for lazy loading.
+     *
+     * @param iterable   $types          FQCN => \Closure factory
+     * @param iterable[] $typeExtensions
+     *
+     * @return LazyExtension
+     */
+    public static function create(iterable $types, iterable $typeExtensions = []): LazyExtension
+    {
+        return new self(new ClosureContainer($types), $typeExtensions);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType(string $name): FieldType
+    {
+        if (!$this->typeContainer->has($name)) {
+            throw new InvalidArgumentException(
+                sprintf('The field type "%s" is not registered with the service container.', $name)
+            );
+        }
+
+        return $this->typeContainer->get($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasType(string $name): bool
+    {
+        return $this->typeContainer->has($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTypeExtensions(string $name): array
+    {
+        $extensions = [];
+
+        if (isset($this->typeExtensionServices[$name])) {
+            foreach ($this->typeExtensionServices[$name] as $extensionId => $extension) {
+                $extensions[] = $extension;
+
+                // validate result of getExtendedType() to ensure it is consistent with the service definition
+                if ($extension->getExtendedType() !== $name) {
+                    throw new InvalidArgumentException(
+                        sprintf('The extended type specified for the service "%s" does not match the actual extended type. Expected "%s", given "%s".',
+                            $extensionId,
+                            $name,
+                            $extension->getExtendedType()
+                        )
+                    );
+                }
+            }
+        }
+
+        return $extensions;
+    }
+}

--- a/src/Loader/ClosureContainer.php
+++ b/src/Loader/ClosureContainer.php
@@ -29,9 +29,9 @@ final class ClosureContainer implements ContainerInterface
     private $values = [];
 
     /**
-     * @param \Closure[] $factories
+     * @param \Closure[]|iterable $factories
      */
-    public function __construct(array $factories)
+    public function __construct(iterable $factories)
     {
         $this->factories = $factories;
     }

--- a/tests/LazyExtensionTest.php
+++ b/tests/LazyExtensionTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Rollerworks\Component\Search\Exception\InvalidArgumentException;
+use Rollerworks\Component\Search\Extension\Core\Type\IntegerType;
+use Rollerworks\Component\Search\Extension\Core\Type\NumberType;
+use Rollerworks\Component\Search\Extension\Core\Type\TextType;
+use Rollerworks\Component\Search\Extension\LazyExtension;
+use Rollerworks\Component\Search\Field\FieldTypeExtension;
+
+final class LazyExtensionTest extends TestCase
+{
+    /** @test */
+    public function it_allows_creating_without_types()
+    {
+        $extension = LazyExtension::create([]);
+
+        self::assertFalse($extension->hasType('something'));
+        self::assertFalse($extension->hasType(TextType::class));
+        self::assertEmpty($extension->getTypeExtensions(TextType::class));
+    }
+
+    /** @test */
+    public function it_loads_registered_type()
+    {
+        $extension = LazyExtension::create(
+            [
+                TextType::class => function () {
+                    return new TextType();
+                },
+            ]
+        );
+
+        self::assertTrue($extension->hasType(TextType::class));
+        self::assertInstanceOf(TextType::class, $extension->getType(TextType::class));
+        self::assertInstanceOf(TextType::class, $extension->getType(TextType::class));
+    }
+
+    /** @test */
+    public function it_fails_when_requested_type_is_not_registered()
+    {
+        $extension = LazyExtension::create([]);
+
+        self::assertFalse($extension->hasType(TextType::class));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The field type "'.TextType::class.'" is not registered with the service container.');
+
+        $extension->getType(TextType::class);
+    }
+
+    /** @test */
+    public function it_loads_type_extensions()
+    {
+        $typeExtension1 = $this->createTypeExtension(TextType::class);
+        $typeExtension2 = $this->createTypeExtension(TextType::class);
+        $typeExtension3 = $this->createTypeExtension(IntegerType::class);
+
+        $extension = LazyExtension::create(
+            [
+                TextType::class => function () {
+                    return new TextType();
+                },
+            ],
+            [
+                TextType::class => [$typeExtension1, $typeExtension2],
+                IntegerType::class => [$typeExtension3],
+            ]
+        );
+
+        self::assertTrue($extension->hasType(TextType::class));
+        self::assertInstanceOf(TextType::class, $extension->getType(TextType::class));
+        self::assertInstanceOf(TextType::class, $extension->getType(TextType::class));
+
+        self::assertSame([$typeExtension1, $typeExtension2], $extension->getTypeExtensions(TextType::class));
+        self::assertSame([$typeExtension3], $extension->getTypeExtensions(IntegerType::class));
+        self::assertEmpty($extension->getTypeExtensions(NumberType::class));
+    }
+
+    /** @test */
+    public function it_checks_type_extension_parent_equality()
+    {
+        $typeExtension1 = $this->createTypeExtension(TextType::class);
+
+        $extension = LazyExtension::create(
+            [
+                TextType::class => function () {
+                    return new TextType();
+                },
+            ],
+            [
+                IntegerType::class => ['extension_1' => $typeExtension1],
+            ]
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            sprintf(
+                'The extended type specified for the service "%s" does not match the actual extended type. Expected "%s", given "%s".',
+                'extension_1',
+                IntegerType::class,
+                TextType::class
+            )
+        );
+
+        $extension->getTypeExtensions(IntegerType::class);
+    }
+
+    public function createTypeExtension(string $type)
+    {
+        $typeExtension = $this->createMock(FieldTypeExtension::class);
+        $typeExtension
+            ->expects(self::any())
+            ->method('getExtendedType')
+            ->willReturn($type);
+
+        return $typeExtension;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Allow lazy loading types using a PSR-11 compatible container or Closures.