### PR TITLE
[Input] Remove Json linting to reduce deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "symfony/options-resolver": "^3.2.1",
         "symfony/property-access": "^3.2.1",
         "symfony/intl": "^3.2.1",
-        "seld/jsonlint": "^1.5.0",
         "moneyphp/money": "^3.0.0",
         "psr/container": "^1.0.0"
     },

--- a/tests/Input/JsonInputTest.php
+++ b/tests/Input/JsonInputTest.php
@@ -37,7 +37,7 @@ final class JsonInputTest extends InputProcessorTestCase
         $config = new ProcessorConfig($this->getFieldSet());
         $error = ConditionErrorMessage::rawMessage(
             '{]',
-            "Input does not contain valid JSON: \nParse error on line 1:\n{]\n^\nExpected one of: 'STRING', '}'"
+            "Input does not contain valid JSON: \nState mismatch (invalid or malformed JSON)"
         );
 
         $this->assertConditionContainsErrorsWithoutCause('{]', $config, [$error]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | (pending)

Remove the linting of Json input and use regular error checking instead. The Json linter is written in PHP which is slower then native C, secondly this level of error reporting doesn't provide any benefit as this input format is not something a user would generate by hand (unlike configuration files).