### PR TITLE
[CoreExtension] Make phpmoney lib optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,19 @@
         "symfony/options-resolver": "^3.2.1",
         "symfony/property-access": "^3.2.1",
         "symfony/intl": "^3.2.1",
-        "moneyphp/money": "^3.0.0",
         "psr/container": "^1.0.0"
     },
     "require-dev": {
+        "moneyphp/money": "^3.0.0",
         "phpunit/phpunit": "^5.7.5",
         "symfony/phpunit-bridge": "^3.2.1",
         "symfony/var-dumper": "^3.2.1"
+    },
+    "suggest": {
+        "moneyphp/money": "To use the MoneyType"
+    },
+    "conflict": {
+        "moneyphp/money": "<3.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Extension/Core/Type/MoneyType.php
+++ b/src/Extension/Core/Type/MoneyType.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Extension\Core\Type;
 
+use Money\Parser\IntlMoneyParser;
 use Rollerworks\Component\Search\Extension\Core\DataTransformer\MoneyToLocalizedStringTransformer;
 use Rollerworks\Component\Search\Extension\Core\DataTransformer\MoneyToStringTransformer;
 use Rollerworks\Component\Search\Field\AbstractFieldType;
@@ -28,10 +29,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class MoneyType extends AbstractFieldType
 {
-    /**
-     * @var ValueComparator
-     */
     protected $valueComparator;
+    private static $checked = false;
 
     /**
      * Constructor.
@@ -48,6 +47,14 @@ class MoneyType extends AbstractFieldType
      */
     public function buildType(FieldConfig $config, array $options)
     {
+        if (!self::$checked) {
+            self::$checked = true;
+
+            if (!class_exists(IntlMoneyParser::class)) {
+                throw new \RuntimeException('Unable to use MoneyType without the "moneyphp/money" library.');
+            }
+        }
+
         $config->setValueComparator($this->valueComparator);
         $config->setValueTypeSupport(Range::class, true);
         $config->setValueTypeSupport(Compare::class, true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | (pending)

The MoneyType uses the phpmoney library but not every installation uses the MoneyType, this makes the phpmoney library optional.