### PR TITLE
Add more return types and fix missing typehints

### DIFF
--- a/src/ConditionErrorMessage.php
+++ b/src/ConditionErrorMessage.php
@@ -113,10 +113,14 @@ final class ConditionErrorMessage
     /**
      * @param array $translatedParameters An array of parameter names that need
      *                                    to be translated prior to there usage
+     *
+     * @return $this
      */
-    public function setTranslatedParameters(array $translatedParameters)
+    public function setTranslatedParameters(array $translatedParameters): self
     {
         $this->translatedParameters = $translatedParameters;
+
+        return $this;
     }
 
     public function __toString(): string

--- a/src/ConditionOptimizer/ChainOptimizer.php
+++ b/src/ConditionOptimizer/ChainOptimizer.php
@@ -49,7 +49,7 @@ final class ChainOptimizer implements SearchConditionOptimizer
      *
      * @throws \InvalidArgumentException
      *
-     * @return self
+     * @return $this
      */
     public function addOptimizer(SearchConditionOptimizer $optimizer)
     {
@@ -72,7 +72,7 @@ final class ChainOptimizer implements SearchConditionOptimizer
     /**
      * {@inheritdoc}
      */
-    public function process(SearchCondition $condition)
+    public function process(SearchCondition $condition): void
     {
         krsort($this->optimizers, SORT_NUMERIC);
 

--- a/src/ConditionOptimizer/DuplicateRemover.php
+++ b/src/ConditionOptimizer/DuplicateRemover.php
@@ -40,7 +40,7 @@ use Rollerworks\Component\Search\ValueComparator;
  */
 final class DuplicateRemover implements SearchConditionOptimizer
 {
-    public function process(SearchCondition $condition)
+    public function process(SearchCondition $condition): void
     {
         $this->removeDuplicatesInGroup($condition->getValuesGroup(), $condition->getFieldSet());
     }
@@ -50,7 +50,7 @@ final class DuplicateRemover implements SearchConditionOptimizer
         return 5;
     }
 
-    private function removeDuplicatesInGroup(ValuesGroup $valuesGroup, FieldSet $fieldSet)
+    private function removeDuplicatesInGroup(ValuesGroup $valuesGroup, FieldSet $fieldSet): void
     {
         foreach ($valuesGroup->getFields() as $fieldName => $values) {
             $this->removeDuplicatesInValuesBag($fieldSet->get($fieldName), $values);
@@ -62,7 +62,7 @@ final class DuplicateRemover implements SearchConditionOptimizer
         }
     }
 
-    private function removeDuplicatesInValuesBag(FieldConfig $config, ValuesBag $valuesBag)
+    private function removeDuplicatesInValuesBag(FieldConfig $config, ValuesBag $valuesBag): void
     {
         $comparator = $config->getValueComparator();
         $options = $config->getOptions();
@@ -82,8 +82,8 @@ final class DuplicateRemover implements SearchConditionOptimizer
         ValuesBag $valuesBag,
         ValueComparator $comparator,
         array $options,
-        $exclude = false
-    ) {
+        bool $exclude = false
+    ): void {
         foreach ($values as $i => $value) {
             foreach ($values as $c => $value2) {
                 if ($i === $c || !$comparator->isEqual($value, $value2, $options)) {

--- a/src/ConditionOptimizer/RangeOptimizer.php
+++ b/src/ConditionOptimizer/RangeOptimizer.php
@@ -30,7 +30,7 @@ use Rollerworks\Component\Search\ValueComparator;
  */
 final class RangeOptimizer implements SearchConditionOptimizer
 {
-    public function process(SearchCondition $condition)
+    public function process(SearchCondition $condition): void
     {
         $fieldSet = $condition->getFieldSet();
         $supportsRanges = false;
@@ -56,7 +56,7 @@ final class RangeOptimizer implements SearchConditionOptimizer
         return -5;
     }
 
-    private function normalizeRangesInGroup(ValuesGroup $valuesGroup, FieldSet $fieldSet)
+    private function normalizeRangesInGroup(ValuesGroup $valuesGroup, FieldSet $fieldSet): void
     {
         foreach ($valuesGroup->getFields() as $fieldName => $values) {
             $config = $fieldSet->get($fieldName);
@@ -71,7 +71,7 @@ final class RangeOptimizer implements SearchConditionOptimizer
         }
     }
 
-    private function normalizeRangesInValuesBag(FieldConfig $config, ValuesBag $valuesBag)
+    private function normalizeRangesInValuesBag(FieldConfig $config, ValuesBag $valuesBag): void
     {
         $comparator = $config->getValueComparator();
         $options = $config->getOptions();
@@ -151,7 +151,7 @@ final class RangeOptimizer implements SearchConditionOptimizer
         ValueComparator $comparator,
         array $options,
         bool $exclude = false
-    ) {
+    ): void {
         foreach ($ranges as $i => $range) {
             foreach ($singleValues as $c => $value) {
                 if ($this->isValInRange($value, $range, $comparator, $options)) {
@@ -180,7 +180,7 @@ final class RangeOptimizer implements SearchConditionOptimizer
         ValuesBag $valuesBag,
         ValueComparator $comparator,
         array $options
-    ) {
+    ): void {
         foreach ($ranges as $i => $range) {
             // If the range is already removed just ignore it.
             if (!isset($ranges[$i])) {
@@ -219,7 +219,7 @@ final class RangeOptimizer implements SearchConditionOptimizer
         ValueComparator $comparator,
         array $options,
         bool $exclude = false
-    ) {
+    ): void {
         $class = $exclude ? ExcludedRange::class : Range::class;
 
         foreach ($ranges as $i => $range) {
@@ -300,12 +300,12 @@ final class RangeOptimizer implements SearchConditionOptimizer
 
     private function isBoundEqual(
         ValueComparator $comparator,
-        $options,
+        array $options,
         $value1,
         $value2,
-        $value1Inclusive,
-        $value2Inclusive
-    ) {
+        bool $value1Inclusive,
+        bool $value2Inclusive
+    ): bool {
         if (!$comparator->isEqual($value1, $value2, $options)) {
             return false;
         }

--- a/src/ConditionOptimizer/ValuesToRange.php
+++ b/src/ConditionOptimizer/ValuesToRange.php
@@ -32,7 +32,7 @@ final class ValuesToRange implements SearchConditionOptimizer
 {
     private $comparators = [];
 
-    public function process(SearchCondition $condition)
+    public function process(SearchCondition $condition): void
     {
         $fieldSet = $condition->getFieldSet();
         $valuesGroup = $condition->getValuesGroup();

--- a/src/Exporter/JsonExporter.php
+++ b/src/Exporter/JsonExporter.php
@@ -42,7 +42,7 @@ final class JsonExporter implements ConditionExporter
      *
      * @return string
      */
-    public function exportCondition(SearchCondition $condition)
+    public function exportCondition(SearchCondition $condition): string
     {
         return json_encode($this->exporter->exportCondition($condition));
     }

--- a/src/Exporter/XmlExporter.php
+++ b/src/Exporter/XmlExporter.php
@@ -71,7 +71,7 @@ final class XmlExporter extends AbstractExporter
         // no-op
     }
 
-    private function exportGroupNode(\DOMNode $parent, ValuesGroup $valuesGroup, FieldSet $fieldSet)
+    private function exportGroupNode(\DOMNode $parent, ValuesGroup $valuesGroup, FieldSet $fieldSet): void
     {
         $fields = $valuesGroup->getFields();
 
@@ -108,7 +108,7 @@ final class XmlExporter extends AbstractExporter
         }
     }
 
-    private function exportValuesToNode(ValuesBag $valuesBag, \DOMNode $parent, FieldConfig $field)
+    private function exportValuesToNode(ValuesBag $valuesBag, \DOMNode $parent, FieldConfig $field): void
     {
         if ($valuesBag->hasSimpleValues()) {
             $valuesNode = $this->document->createElement('simple-values');
@@ -198,7 +198,7 @@ final class XmlExporter extends AbstractExporter
         }
     }
 
-    private function exportRangeValueToNode(\DOMNode $parent, Range $range, FieldConfig $field)
+    private function exportRangeValueToNode(\DOMNode $parent, Range $range, FieldConfig $field): void
     {
         $rangeNode = $this->document->createElement('range');
 

--- a/src/Extension/Core/ChoiceList/ArrayChoiceList.php
+++ b/src/Extension/Core/ChoiceList/ArrayChoiceList.php
@@ -204,7 +204,7 @@ class ArrayChoiceList implements ChoiceList
      *                                   corresponding values
      * @param array    $structuredValues The values indexed by the original keys
      */
-    private function flatten(array $choices, callable $value, &$choicesByValues, &$keysByValues, &$structuredValues)
+    private function flatten(array $choices, callable $value, &$choicesByValues, &$keysByValues, &$structuredValues): void
     {
         if (null === $choicesByValues) {
             $choicesByValues = [];

--- a/src/Extension/Core/ChoiceList/Factory/CachingFactoryDecorator.php
+++ b/src/Extension/Core/ChoiceList/Factory/CachingFactoryDecorator.php
@@ -154,7 +154,7 @@ final class CachingFactoryDecorator implements ChoiceListFactory
      * @param array $array  The array to flatten
      * @param array $output The flattened output
      */
-    private static function flatten(array $array, &$output)
+    private static function flatten(array $array, &$output): void
     {
         if (null === $output) {
             $output = [];

--- a/src/Extension/Core/ChoiceList/Factory/DefaultChoiceListFactory.php
+++ b/src/Extension/Core/ChoiceList/Factory/DefaultChoiceListFactory.php
@@ -115,7 +115,7 @@ final class DefaultChoiceListFactory implements ChoiceListFactory
         return new ChoiceListView($otherViews, $preferredViews);
     }
 
-    private static function addChoiceView($choice, $value, $label, $keys, &$index, $attr, $isPreferred, &$preferredViews, &$otherViews)
+    private static function addChoiceView($choice, $value, $label, $keys, &$index, $attr, $isPreferred, &$preferredViews, &$otherViews): void
     {
         // $value may be an integer or a string, since it's stored in the array
         // keys. We want to guarantee it's a string though.
@@ -150,7 +150,7 @@ final class DefaultChoiceListFactory implements ChoiceListFactory
         }
     }
 
-    private static function addChoiceViewsGroupedBy($groupBy, $label, $choices, $keys, &$index, $attr, $isPreferred, &$preferredViews, &$otherViews)
+    private static function addChoiceViewsGroupedBy($groupBy, $label, $choices, $keys, &$index, $attr, $isPreferred, &$preferredViews, &$otherViews): void
     {
         foreach ($groupBy as $key => $value) {
             if (null === $value) {
@@ -200,7 +200,7 @@ final class DefaultChoiceListFactory implements ChoiceListFactory
         }
     }
 
-    private static function addChoiceViewGroupedBy($groupBy, $choice, $value, $label, $keys, &$index, $attr, $isPreferred, &$preferredViews, &$otherViews)
+    private static function addChoiceViewGroupedBy($groupBy, $choice, $value, $label, $keys, &$index, $attr, $isPreferred, &$preferredViews, &$otherViews): void
     {
         $groupLabel = call_user_func($groupBy, $choice, $keys[$value], $value);
 

--- a/src/Extension/Core/ChoiceList/View/ChoiceListView.php
+++ b/src/Extension/Core/ChoiceList/View/ChoiceListView.php
@@ -66,7 +66,7 @@ class ChoiceListView
         $this->preferredChoices = $preferredChoices;
     }
 
-    public function initChoicesByLabel()
+    public function initChoicesByLabel(): void
     {
         $this->choicesByLabel = [];
 

--- a/src/Extension/Core/DataTransformer/BirthdayTransformer.php
+++ b/src/Extension/Core/DataTransformer/BirthdayTransformer.php
@@ -98,7 +98,7 @@ final class BirthdayTransformer implements DataTransformer
         return $value;
     }
 
-    private function validateDate(\DateTimeInterface $value)
+    private function validateDate(\DateTimeInterface $value): void
     {
         static $currentDate;
 

--- a/src/Extension/Core/Type/BaseDateTimeType.php
+++ b/src/Extension/Core/Type/BaseDateTimeType.php
@@ -31,7 +31,7 @@ abstract class BaseDateTimeType extends AbstractFieldType
         \IntlDateFormatter::SHORT,
     ];
 
-    protected function validateFormat(string $name, $value)
+    protected function validateFormat(string $name, $value): void
     {
         if (!in_array($value, self::$acceptedFormats, true)) {
             throw new InvalidConfigurationException(
@@ -41,7 +41,7 @@ abstract class BaseDateTimeType extends AbstractFieldType
         }
     }
 
-    protected function validateDateFormat(string $name, string $format)
+    protected function validateDateFormat(string $name, string $format): void
     {
         if (null !== $format &&
             (false === strpos($format, 'y') || false === strpos($format, 'M') || false === strpos($format, 'd'))

--- a/src/Extension/Core/Type/BirthdayType.php
+++ b/src/Extension/Core/Type/BirthdayType.php
@@ -39,7 +39,7 @@ final class BirthdayType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildType(FieldConfig $config, array $options)
+    public function buildType(FieldConfig $config, array $options): void
     {
         $config->setValueComparator($this->valueComparator);
         $config->setValueTypeSupport(Range::class, true);
@@ -65,7 +65,7 @@ final class BirthdayType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildView(SearchFieldView $view, FieldConfig $config, array $options)
+    public function buildView(SearchFieldView $view, FieldConfig $config, array $options): void
     {
         $view->vars['allow_age'] = $options['allow_age'];
         $view->vars['allow_future_date'] = $options['allow_future_date'];
@@ -74,7 +74,7 @@ final class BirthdayType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'allow_age' => true,
@@ -95,7 +95,7 @@ final class BirthdayType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return DateType::class;
     }

--- a/src/Extension/Core/Type/ChoiceType.php
+++ b/src/Extension/Core/Type/ChoiceType.php
@@ -48,7 +48,7 @@ final class ChoiceType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildType(FieldConfig $config, array $options)
+    public function buildType(FieldConfig $config, array $options): void
     {
         $choiceList = $this->createChoiceList($options);
         $config->setAttribute('choice_list', $choiceList);
@@ -85,7 +85,7 @@ final class ChoiceType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildView(SearchFieldView $view, FieldConfig $config, array $options)
+    public function buildView(SearchFieldView $view, FieldConfig $config, array $options): void
     {
         /** @var ChoiceListView $choiceListView */
         $choiceListView = $config->getAttribute('choice_list_view');
@@ -101,7 +101,7 @@ final class ChoiceType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $choiceTranslationDomainNormalizer = function (Options $options, $choiceTranslationDomain) {
             if (true === $choiceTranslationDomain) {

--- a/src/Extension/Core/Type/CountryType.php
+++ b/src/Extension/Core/Type/CountryType.php
@@ -31,7 +31,7 @@ final class CountryType extends AbstractFieldType implements ChoiceLoader
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'choice_loader' => $this,
@@ -42,7 +42,7 @@ final class CountryType extends AbstractFieldType implements ChoiceLoader
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return ChoiceType::class;
     }

--- a/src/Extension/Core/Type/CurrencyType.php
+++ b/src/Extension/Core/Type/CurrencyType.php
@@ -31,7 +31,7 @@ final class CurrencyType extends AbstractFieldType implements ChoiceLoader
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'choice_loader' => $this,
@@ -43,7 +43,7 @@ final class CurrencyType extends AbstractFieldType implements ChoiceLoader
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return ChoiceType::class;
     }

--- a/src/Extension/Core/Type/DateTimeType.php
+++ b/src/Extension/Core/Type/DateTimeType.php
@@ -65,7 +65,7 @@ final class DateTimeType extends BaseDateTimeType
     /**
      * {@inheritdoc}
      */
-    public function buildType(FieldConfig $config, array $options)
+    public function buildType(FieldConfig $config, array $options): void
     {
         $config->setValueComparator($this->valueComparator);
         $config->setValueTypeSupport(Range::class, true);
@@ -107,7 +107,7 @@ final class DateTimeType extends BaseDateTimeType
     /**
      * {@inheritdoc}
      */
-    public function buildView(SearchFieldView $view, FieldConfig $config, array $options)
+    public function buildView(SearchFieldView $view, FieldConfig $config, array $options): void
     {
         $pattern = $options['pattern'];
 
@@ -128,7 +128,7 @@ final class DateTimeType extends BaseDateTimeType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(
             [

--- a/src/Extension/Core/Type/DateType.php
+++ b/src/Extension/Core/Type/DateType.php
@@ -41,7 +41,7 @@ final class DateType extends BaseDateTimeType
     /**
      * {@inheritdoc}
      */
-    public function buildType(FieldConfig $config, array $options)
+    public function buildType(FieldConfig $config, array $options): void
     {
         $config->setValueComparator($this->valueComparator);
         $config->setValueTypeSupport(Range::class, true);
@@ -79,7 +79,7 @@ final class DateType extends BaseDateTimeType
     /**
      * {@inheritdoc}
      */
-    public function buildView(SearchFieldView $view, FieldConfig $config, array $options)
+    public function buildView(SearchFieldView $view, FieldConfig $config, array $options): void
     {
         $pattern = $options['pattern'];
 
@@ -101,7 +101,7 @@ final class DateType extends BaseDateTimeType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(
             [

--- a/src/Extension/Core/Type/IntegerType.php
+++ b/src/Extension/Core/Type/IntegerType.php
@@ -38,7 +38,7 @@ final class IntegerType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildType(FieldConfig $config, array $options)
+    public function buildType(FieldConfig $config, array $options): void
     {
         $config->setValueComparator($this->valueComparator);
         $config->setValueTypeSupport(Range::class, true);
@@ -53,7 +53,7 @@ final class IntegerType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildView(SearchFieldView $view, FieldConfig $config, array $options)
+    public function buildView(SearchFieldView $view, FieldConfig $config, array $options): void
     {
         $view->vars['grouping'] = $options['grouping'];
     }
@@ -61,7 +61,7 @@ final class IntegerType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(
             [

--- a/src/Extension/Core/Type/LanguageType.php
+++ b/src/Extension/Core/Type/LanguageType.php
@@ -31,7 +31,7 @@ final class LanguageType extends AbstractFieldType implements ChoiceLoader
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'choice_loader' => $this,
@@ -42,7 +42,7 @@ final class LanguageType extends AbstractFieldType implements ChoiceLoader
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return ChoiceType::class;
     }

--- a/src/Extension/Core/Type/LocaleType.php
+++ b/src/Extension/Core/Type/LocaleType.php
@@ -31,7 +31,7 @@ final class LocaleType extends AbstractFieldType implements ChoiceLoader
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'choice_loader' => $this,
@@ -43,7 +43,7 @@ final class LocaleType extends AbstractFieldType implements ChoiceLoader
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return ChoiceType::class;
     }

--- a/src/Extension/Core/Type/MoneyType.php
+++ b/src/Extension/Core/Type/MoneyType.php
@@ -43,7 +43,7 @@ final class MoneyType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildType(FieldConfig $config, array $options)
+    public function buildType(FieldConfig $config, array $options): void
     {
         $config->setValueComparator($this->valueComparator);
         $config->setValueTypeSupport(Range::class, true);
@@ -64,7 +64,7 @@ final class MoneyType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildView(SearchFieldView $view, FieldConfig $config, array $options)
+    public function buildView(SearchFieldView $view, FieldConfig $config, array $options): void
     {
         $view->vars['grouping'] = $options['grouping'];
         $view->vars['default_currency'] = $options['default_currency'];
@@ -74,7 +74,7 @@ final class MoneyType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(
             [

--- a/src/Extension/Core/Type/NumberType.php
+++ b/src/Extension/Core/Type/NumberType.php
@@ -38,7 +38,7 @@ final class NumberType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildType(FieldConfig $config, array $options)
+    public function buildType(FieldConfig $config, array $options): void
     {
         $config->setValueComparator($this->valueComparator);
         $config->setValueTypeSupport(Range::class, true);
@@ -63,7 +63,7 @@ final class NumberType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildView(SearchFieldView $view, FieldConfig $config, array $options)
+    public function buildView(SearchFieldView $view, FieldConfig $config, array $options): void
     {
         $view->vars['precision'] = $options['precision'];
         $view->vars['grouping'] = $options['grouping'];
@@ -72,7 +72,7 @@ final class NumberType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(
             [

--- a/src/Extension/Core/Type/SearchFieldType.php
+++ b/src/Extension/Core/Type/SearchFieldType.php
@@ -33,15 +33,15 @@ final class SearchFieldType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
-        // no-op
+        return null;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function buildType(FieldConfig $config, array $options)
+    public function buildType(FieldConfig $config, array $options): void
     {
         $config->setValueComparator($this->valueComparator);
     }
@@ -49,7 +49,7 @@ final class SearchFieldType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(
             [

--- a/src/Extension/Core/Type/TextType.php
+++ b/src/Extension/Core/Type/TextType.php
@@ -25,7 +25,7 @@ final class TextType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildType(FieldConfig $config, array $options)
+    public function buildType(FieldConfig $config, array $options): void
     {
         $config->setValueTypeSupport(PatternMatch::class, true);
     }

--- a/src/Extension/Core/Type/TimeType.php
+++ b/src/Extension/Core/Type/TimeType.php
@@ -38,7 +38,7 @@ final class TimeType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildType(FieldConfig $config, array $options)
+    public function buildType(FieldConfig $config, array $options): void
     {
         $format = 'H';
 
@@ -78,7 +78,7 @@ final class TimeType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildView(SearchFieldView $view, FieldConfig $config, array $options)
+    public function buildView(SearchFieldView $view, FieldConfig $config, array $options): void
     {
         $pattern = 'H';
 
@@ -98,7 +98,7 @@ final class TimeType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(
             [

--- a/src/Extension/Core/Type/TimestampType.php
+++ b/src/Extension/Core/Type/TimestampType.php
@@ -37,7 +37,7 @@ final class TimestampType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildType(FieldConfig $config, array $options)
+    public function buildType(FieldConfig $config, array $options): void
     {
         $config->setValueComparator($this->valueComparator);
         $config->setValueTypeSupport(Range::class, true);
@@ -54,7 +54,7 @@ final class TimestampType extends AbstractFieldType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'model_timezone' => null,

--- a/src/Extension/Core/Type/TimezoneType.php
+++ b/src/Extension/Core/Type/TimezoneType.php
@@ -30,7 +30,7 @@ final class TimezoneType extends AbstractFieldType implements ChoiceLoader
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'choice_loader' => $this,
@@ -41,7 +41,7 @@ final class TimezoneType extends AbstractFieldType implements ChoiceLoader
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return ChoiceType::class;
     }

--- a/src/Field/AbstractFieldType.php
+++ b/src/Field/AbstractFieldType.php
@@ -31,28 +31,28 @@ abstract class AbstractFieldType implements FieldType
     /**
      * {@inheritdoc}
      */
-    public function buildType(FieldConfig $config, array $options)
+    public function buildType(FieldConfig $config, array $options): void
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function buildView(SearchFieldView $view, FieldConfig $config, array $options)
+    public function buildView(SearchFieldView $view, FieldConfig $config, array $options): void
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return SearchFieldType::class;
     }

--- a/src/Field/AbstractFieldTypeExtension.php
+++ b/src/Field/AbstractFieldTypeExtension.php
@@ -28,21 +28,21 @@ abstract class AbstractFieldTypeExtension implements FieldTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function buildType(FieldConfig $builder, array $options)
+    public function buildType(FieldConfig $builder, array $options): void
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function buildView(FieldConfig $config, SearchFieldView $view)
+    public function buildView(FieldConfig $config, SearchFieldView $view): void
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
     }
 }

--- a/src/Field/FieldConfig.php
+++ b/src/Field/FieldConfig.php
@@ -94,7 +94,7 @@ interface FieldConfig
      *
      * @return DataTransformer|null
      */
-    public function getViewTransformer();
+    public function getViewTransformer(): ?DataTransformer;
 
     /**
      * Sets a normalize transformer for the field.
@@ -114,7 +114,7 @@ interface FieldConfig
      *
      * @return DataTransformer|null
      */
-    public function getNormTransformer();
+    public function getNormTransformer(): ?DataTransformer;
 
     /**
      * Returns whether the field's data is locked.

--- a/src/Field/FieldType.php
+++ b/src/Field/FieldType.php
@@ -25,14 +25,14 @@ interface FieldType
      *
      * @return string|null The name of the parent type if any, null otherwise
      */
-    public function getParent();
+    public function getParent(): ?string;
 
     /**
      * Sets the default options for this type.
      *
      * @param OptionsResolver $resolver The resolver for the options
      */
-    public function configureOptions(OptionsResolver $resolver);
+    public function configureOptions(OptionsResolver $resolver): void;
 
     /**
      * This configures the {@link FieldConfigInterface}.
@@ -43,7 +43,7 @@ interface FieldType
      * @param FieldConfig $config
      * @param array       $options
      */
-    public function buildType(FieldConfig $config, array $options);
+    public function buildType(FieldConfig $config, array $options): void;
 
     /**
      * Configures the SearchFieldView instance.
@@ -57,7 +57,7 @@ interface FieldType
      * @param FieldConfig     $config
      * @param array           $options
      */
-    public function buildView(SearchFieldView $view, FieldConfig $config, array $options);
+    public function buildView(SearchFieldView $view, FieldConfig $config, array $options): void;
 
     /**
      * Returns the prefix of the template block name for this type.

--- a/src/Field/FieldTypeExtension.php
+++ b/src/Field/FieldTypeExtension.php
@@ -31,7 +31,7 @@ interface FieldTypeExtension
      * @param FieldConfig $builder
      * @param array       $options
      */
-    public function buildType(FieldConfig $builder, array $options);
+    public function buildType(FieldConfig $builder, array $options): void;
 
     /**
      * Builds the SearchFieldView.
@@ -42,14 +42,14 @@ interface FieldTypeExtension
      * @param FieldConfig     $config
      * @param SearchFieldView $view
      */
-    public function buildView(FieldConfig $config, SearchFieldView $view);
+    public function buildView(FieldConfig $config, SearchFieldView $view): void;
 
     /**
      * Overrides the default options from the extended type.
      *
      * @param OptionsResolver $resolver
      */
-    public function configureOptions(OptionsResolver $resolver);
+    public function configureOptions(OptionsResolver $resolver): void;
 
     /**
      * Returns the name of the type being extended.

--- a/src/Field/GenericResolvedFieldType.php
+++ b/src/Field/GenericResolvedFieldType.php
@@ -70,7 +70,7 @@ class GenericResolvedFieldType implements ResolvedFieldType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?ResolvedFieldType
     {
         return $this->parent;
     }
@@ -104,7 +104,7 @@ class GenericResolvedFieldType implements ResolvedFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildType(FieldConfig $config, array $options)
+    public function buildType(FieldConfig $config, array $options): void
     {
         if (null !== $this->parent) {
             $this->parent->buildType($config, $options);
@@ -120,7 +120,7 @@ class GenericResolvedFieldType implements ResolvedFieldType
     /**
      * {@inheritdoc}
      */
-    public function createFieldView(FieldConfig $config, FieldSetView $view)
+    public function createFieldView(FieldConfig $config, FieldSetView $view): SearchFieldView
     {
         $view = $this->newView($view);
         $view->vars = array_merge($view->vars, [
@@ -136,7 +136,7 @@ class GenericResolvedFieldType implements ResolvedFieldType
     /**
      * {@inheritdoc}
      */
-    public function buildFieldView(SearchFieldView $view, FieldConfig $config, array $options)
+    public function buildFieldView(SearchFieldView $view, FieldConfig $config, array $options): void
     {
         if (null !== $this->parent) {
             $this->parent->buildFieldView($view, $config, $options);

--- a/src/Field/ResolvedFieldType.php
+++ b/src/Field/ResolvedFieldType.php
@@ -24,9 +24,9 @@ interface ResolvedFieldType
     /**
      * Returns the parent type.
      *
-     * @return ResolvedFieldType|null The parent type or null
+     * @return ResolvedFieldType|null
      */
-    public function getParent();
+    public function getParent(): ?ResolvedFieldType;
 
     /**
      * Returns the wrapped field type.
@@ -61,7 +61,7 @@ interface ResolvedFieldType
      * @param FieldConfig $config
      * @param array       $options
      */
-    public function buildType(FieldConfig $config, array $options);
+    public function buildType(FieldConfig $config, array $options): void;
 
     /**
      * Creates a new SearchFieldView for a field of this type.
@@ -71,7 +71,7 @@ interface ResolvedFieldType
      *
      * @return SearchFieldView
      */
-    public function createFieldView(FieldConfig $config, FieldSetView $view);
+    public function createFieldView(FieldConfig $config, FieldSetView $view): SearchFieldView;
 
     /**
      * Configures a SearchFieldView for the type hierarchy.
@@ -80,7 +80,7 @@ interface ResolvedFieldType
      * @param FieldConfig     $config
      * @param array           $options
      */
-    public function buildFieldView(SearchFieldView $view, FieldConfig $config, array $options);
+    public function buildFieldView(SearchFieldView $view, FieldConfig $config, array $options): void;
 
     /**
      * Returns the prefix of the template block name for this type.

--- a/src/Field/SearchField.php
+++ b/src/Field/SearchField.php
@@ -188,7 +188,7 @@ class SearchField implements FieldConfig
     /**
      * {@inheritdoc}
      */
-    public function getViewTransformer()
+    public function getViewTransformer(): ?DataTransformer
     {
         return $this->viewTransformer;
     }
@@ -212,7 +212,7 @@ class SearchField implements FieldConfig
     /**
      * {@inheritdoc}
      */
-    public function getNormTransformer()
+    public function getNormTransformer(): ?DataTransformer
     {
         return $this->normTransformer;
     }
@@ -225,7 +225,7 @@ class SearchField implements FieldConfig
      * @throws InvalidConfigurationException when a supported value-type requires
      *                                       a value comparator but none is set
      */
-    public function finalizeConfig()
+    public function finalizeConfig(): void
     {
         if ($this->locked) {
             return;

--- a/src/FieldSet.php
+++ b/src/FieldSet.php
@@ -26,9 +26,9 @@ interface FieldSet
     /**
      * Returns the name of the set.
      *
-     * @return null|string
+     * @return string|null
      */
-    public function getSetName();
+    public function getSetName(): ?string;
 
     /**
      * Returns the {@link FieldConfigInterface} object of the search field.

--- a/src/FieldSetBuilder.php
+++ b/src/FieldSetBuilder.php
@@ -28,7 +28,7 @@ interface FieldSetBuilder
      * @param string $type    The FQCN of the type
      * @param array  $options Array of options for building the field
      *
-     * @return self
+     * @return $this The builder
      */
     public function add(string $name, string $type, array $options = []);
 
@@ -37,7 +37,7 @@ interface FieldSetBuilder
      *
      * @param FieldConfig $field
      *
-     * @return FieldSetBuilder
+     * @return $this The builder
      */
     public function set(FieldConfig $field);
 
@@ -48,7 +48,7 @@ interface FieldSetBuilder
      *
      * @throws BadMethodCallException When the FieldSet has been already turned into a FieldSet instance
      *
-     * @return self
+     * @return $this The builder
      */
     public function remove(string $name);
 
@@ -59,7 +59,7 @@ interface FieldSetBuilder
      *
      * @return bool
      */
-    public function has(string $name);
+    public function has(string $name): bool;
 
     /**
      * Get a previously registered field from the set.
@@ -68,7 +68,7 @@ interface FieldSetBuilder
      *
      * @return FieldConfig
      */
-    public function get(string $name);
+    public function get(string $name): FieldConfig;
 
     /**
      * Create the FieldSet using the fields set on the builder.

--- a/src/FieldSetConfigurator.php
+++ b/src/FieldSetConfigurator.php
@@ -30,8 +30,6 @@ interface FieldSetConfigurator
      * Configure the FieldSet builder.
      *
      * @param FieldSetBuilder $builder
-     *
-     * @return void
      */
-    public function buildFieldSet(FieldSetBuilder $builder);
+    public function buildFieldSet(FieldSetBuilder $builder): void;
 }

--- a/src/GenericFieldSet.php
+++ b/src/GenericFieldSet.php
@@ -34,7 +34,7 @@ final class GenericFieldSet implements FieldSetWithView
      * @param string|null   $name        FQCN of the FieldSet configurator
      * @param callable      $viewBuilder A callable to finalize the FieldSetView
      */
-    public function __construct(array $fields, string $name = null, callable $viewBuilder = null)
+    public function __construct(array $fields, ?string $name = null, callable $viewBuilder = null)
     {
         $this->fields = $fields;
         $this->name = $name;
@@ -44,7 +44,7 @@ final class GenericFieldSet implements FieldSetWithView
     /**
      * {@inheritdoc}
      */
-    public function getSetName()
+    public function getSetName(): ?string
     {
         return $this->name;
     }

--- a/src/GenericFieldSetBuilder.php
+++ b/src/GenericFieldSetBuilder.php
@@ -79,7 +79,7 @@ final class GenericFieldSetBuilder implements FieldSetBuilder
     /**
      * {@inheritdoc}
      */
-    public function has(string $name)
+    public function has(string $name): bool
     {
         if (isset($this->unresolvedFields[$name])) {
             return true;
@@ -95,7 +95,7 @@ final class GenericFieldSetBuilder implements FieldSetBuilder
     /**
      * {@inheritdoc}
      */
-    public function get(string $name)
+    public function get(string $name): FieldConfig
     {
         if (isset($this->unresolvedFields[$name])) {
             $this->fields[$name] = $this->searchFactory->createField(

--- a/src/GenericSearchFactory.php
+++ b/src/GenericSearchFactory.php
@@ -84,7 +84,7 @@ final class GenericSearchFactory implements SearchFactory
     /**
      * {@inheritdoc}
      */
-    public function optimizeCondition(SearchCondition $condition)
+    public function optimizeCondition(SearchCondition $condition): void
     {
         $this->optimizer->process($condition);
     }

--- a/src/Input/FieldValuesFactory.php
+++ b/src/Input/FieldValuesFactory.php
@@ -79,7 +79,7 @@ class FieldValuesFactory
         $this->validator = $validator;
     }
 
-    public function initContext(FieldConfig $field, ValuesBag $valuesBag, string $path)
+    public function initContext(FieldConfig $field, ValuesBag $valuesBag, string $path): void
     {
         $this->config = $field;
         $this->valuesBag = $valuesBag;
@@ -93,7 +93,7 @@ class FieldValuesFactory
         $this->validator->initializeContext($field, $this->errorList);
     }
 
-    public function addSimpleValue($value, string $path)
+    public function addSimpleValue($value, string $path): void
     {
         $path = $this->createValuePath($path);
 
@@ -106,7 +106,7 @@ class FieldValuesFactory
         }
     }
 
-    public function addExcludedSimpleValue($value, string $path)
+    public function addExcludedSimpleValue($value, string $path): void
     {
         $path = $this->createValuePath($path);
         $this->increaseValuesCount($path);
@@ -125,7 +125,7 @@ class FieldValuesFactory
      * @param bool  $upperInclusive
      * @param array $path           [path, lower-path-pattern, upper-path-pattern]
      */
-    public function addRange($lower, $upper, bool $lowerInclusive, bool $upperInclusive, array $path)
+    public function addRange($lower, $upper, bool $lowerInclusive, bool $upperInclusive, array $path): void
     {
         $path[0] = $this->createValuePath($path[0]);
 
@@ -151,7 +151,7 @@ class FieldValuesFactory
      * @param bool  $upperInclusive
      * @param array $path           [path, lower-path-pattern, upper-path-pattern]
      */
-    public function addExcludedRange($lower, $upper, $lowerInclusive, $upperInclusive, array $path)
+    public function addExcludedRange($lower, $upper, bool $lowerInclusive, bool $upperInclusive, array $path): void
     {
         $path[0] = $this->createValuePath($path[0]);
 
@@ -170,7 +170,7 @@ class FieldValuesFactory
         }
     }
 
-    public function addComparisonValue($operator, $value, array $path)
+    public function addComparisonValue($operator, $value, array $path): void
     {
         $basePath = $this->createValuePath($path[0]);
 
@@ -192,7 +192,7 @@ class FieldValuesFactory
         }
     }
 
-    public function addPatterMatch($type, $value, bool $caseInsensitive, array $path)
+    public function addPatterMatch($type, $value, bool $caseInsensitive, array $path): void
     {
         $basePath = $this->createValuePath($path[0]);
         $valid = true;
@@ -294,7 +294,7 @@ class FieldValuesFactory
         }
     }
 
-    protected function addError(ConditionErrorMessage $error)
+    protected function addError(ConditionErrorMessage $error): void
     {
         $this->errorList[] = $error;
     }
@@ -308,14 +308,14 @@ class FieldValuesFactory
         return $this->path.$path;
     }
 
-    private function increaseValuesCount(string $path)
+    private function increaseValuesCount(string $path): void
     {
         if (++$this->count > $this->maxCount) {
             throw new ValuesOverflowException($this->config->getName(), $this->maxCount, $path);
         }
     }
 
-    private function assertAcceptsType(string $type)
+    private function assertAcceptsType(string $type): void
     {
         if (isset($this->checkedValueType[$type])) {
             return;

--- a/src/Input/NullValidator.php
+++ b/src/Input/NullValidator.php
@@ -21,7 +21,7 @@ final class NullValidator implements Validator
     /**
      * {@inheritdoc}
      */
-    public function initializeContext(FieldConfig $field, ErrorList $errorList)
+    public function initializeContext(FieldConfig $field, ErrorList $errorList): void
     {
         // no-op
     }

--- a/src/Input/StringLexer.php
+++ b/src/Input/StringLexer.php
@@ -39,7 +39,7 @@ final class StringLexer
     private $cursorSnapshot;
     private $charSnapshot;
 
-    public function parse($data)
+    public function parse(string $data): void
     {
         $this->data = str_replace(["\r\n", "\r"], "\n", $data);
         $this->end = strlen($this->data);
@@ -50,7 +50,7 @@ final class StringLexer
         $this->skipEmptyLines();
     }
 
-    public function skipWhitespace()
+    public function skipWhitespace(): void
     {
         if (preg_match('/\h+/A', $this->data, $match, 0, $this->cursor)) {
             $this->char += mb_strlen($match[0]);
@@ -58,28 +58,28 @@ final class StringLexer
         }
     }
 
-    public function skipEmptyLines()
+    public function skipEmptyLines(): void
     {
         if (preg_match('/(?:\s*+)++/A', $this->data, $match, 0, $this->cursor)) {
             $this->moveCursor($match[0]);
         }
     }
 
-    public function moveCursor(string $text)
+    public function moveCursor(string $text): void
     {
         $this->lineno += mb_substr_count($text, "\n");
         $this->cursor += strlen($text);
         $this->char += mb_strlen($text);
     }
 
-    public function snapshot()
+    public function snapshot(): void
     {
         $this->linenoSnapshot = $this->lineno;
         $this->cursorSnapshot = $this->cursor;
         $this->charSnapshot = $this->char;
     }
 
-    public function restoreCursor()
+    public function restoreCursor(): void
     {
         if (null === $this->cursorSnapshot) {
             throw new \RuntimeException('Unable to restore cursor because no snapshot was stored.');
@@ -113,7 +113,7 @@ final class StringLexer
         return null;
     }
 
-    public function expects(string $data, $expected = null)
+    public function expects(string $data, $expected = null): ?string
     {
         $match = $this->regexOrSingleChar($data);
 
@@ -132,7 +132,7 @@ final class StringLexer
         return $this->cursor >= $this->end;
     }
 
-    public function createSyntaxException($expected)
+    public function createSyntaxException($expected): StringLexerException
     {
         $expected = (array) $expected;
 
@@ -146,7 +146,7 @@ final class StringLexer
         );
     }
 
-    public function createFormatException($string)
+    public function createFormatException($string): StringLexerException
     {
         return StringLexerException::formatError(
             $this->cursor,

--- a/src/Input/Validator.php
+++ b/src/Input/Validator.php
@@ -31,10 +31,8 @@ interface Validator
      *
      * @param FieldConfig $field
      * @param ErrorList   $errorList
-     *
-     * @return void
      */
-    public function initializeContext(FieldConfig $field, ErrorList $errorList);
+    public function initializeContext(FieldConfig $field, ErrorList $errorList): void;
 
     /**
      * Validates and returns whether the value is valid.

--- a/src/Loader/ClosureContainer.php
+++ b/src/Loader/ClosureContainer.php
@@ -39,7 +39,7 @@ final class ClosureContainer implements ContainerInterface
     /**
      * {@inheritdoc}
      */
-    public function has($id)
+    public function has($id): bool
     {
         return isset($this->factories[$id]);
     }

--- a/src/SearchConditionOptimizer.php
+++ b/src/SearchConditionOptimizer.php
@@ -29,7 +29,7 @@ interface SearchConditionOptimizer
      *
      * @param SearchCondition $condition
      */
-    public function process(SearchCondition $condition);
+    public function process(SearchCondition $condition): void;
 
     /**
      * Priority of the optimizer.

--- a/src/SearchFactory.php
+++ b/src/SearchFactory.php
@@ -61,5 +61,5 @@ interface SearchFactory
      *
      * @param SearchCondition $condition
      */
-    public function optimizeCondition(SearchCondition $condition);
+    public function optimizeCondition(SearchCondition $condition): void;
 }

--- a/src/Test/FieldTransformationAssertion.php
+++ b/src/Test/FieldTransformationAssertion.php
@@ -78,7 +78,7 @@ final class FieldTransformationAssertion
         return $this;
     }
 
-    public function failsToTransforms()
+    public function failsToTransforms(): void
     {
         if (null === $this->inputView) {
             throw new \LogicException('withInput() must be called first.');

--- a/src/Value/ValuesBag.php
+++ b/src/Value/ValuesBag.php
@@ -36,7 +36,7 @@ class ValuesBag implements \Countable, \Serializable
     /**
      * {@inheritdoc}
      */
-    public function serialize()
+    public function serialize(): string
     {
         return serialize(
             [
@@ -51,7 +51,7 @@ class ValuesBag implements \Countable, \Serializable
     /**
      * {@inheritdoc}
      */
-    public function unserialize($serialized)
+    public function unserialize($serialized): void
     {
         $data = unserialize($serialized);
 

--- a/src/Value/ValuesGroup.php
+++ b/src/Value/ValuesGroup.php
@@ -233,7 +233,7 @@ class ValuesGroup implements \Serializable
     /**
      * {@inheritdoc}
      */
-    public function serialize()
+    public function serialize(): string
     {
         return serialize(
             [
@@ -247,7 +247,7 @@ class ValuesGroup implements \Serializable
     /**
      * {@inheritdoc}
      */
-    public function unserialize($serialized)
+    public function unserialize($serialized): void
     {
         $data = unserialize($serialized);
 

--- a/tests/Fixtures/BarType.php
+++ b/tests/Fixtures/BarType.php
@@ -20,7 +20,8 @@ use Rollerworks\Component\Search\Field\AbstractFieldType;
  */
 final class BarType extends AbstractFieldType
 {
-    public function getParent()
+    public function getParent(): ?string
     {
+        return null;
     }
 }

--- a/tests/Fixtures/FooSubType.php
+++ b/tests/Fixtures/FooSubType.php
@@ -20,7 +20,7 @@ use Rollerworks\Component\Search\Field\AbstractFieldType;
  */
 final class FooSubType extends AbstractFieldType
 {
-    public function getParent()
+    public function getParent(): ?string
     {
         return FooType::class;
     }

--- a/tests/Fixtures/FooType.php
+++ b/tests/Fixtures/FooType.php
@@ -20,7 +20,8 @@ use Rollerworks\Component\Search\Field\AbstractFieldType;
  */
 final class FooType extends AbstractFieldType
 {
-    public function getParent()
+    public function getParent(): ?string
     {
+        return null;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This should be the last major BC break, all types, type extensions etc. now have return types (including void).