### PR TITLE
Remove support for Regex ValueMatch

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -1,3 +1,12 @@
+UPGRADE FROM 2.0-ALPHA2 to 2.0-ALPHA3
+=====================================
+
+* Support for using Regex in ValueMatch has been removed.
+  
+  * The constants `PatternMatch::PATTERN_REGEX` and `PatternMatch::PATTERN_NOT_REGEX`
+    have been removed.
+  * The method `PatternMatch::isRegex` has been removed.
+
 UPGRADE FROM 2.0-ALPHA1 to 2.0-ALPHA2
 =====================================
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,7 +14,7 @@ parameters:
         - '#Call to an undefined method DateTimeInterface\:\:setTimezone\(\)#'
         - '#Call to an undefined method Money\\Exception\:\:getMessage\(\)#'
         - '#Call to an undefined method Exception\:\:getErrors\(\)#'
-        - '#expects Rollerworks\\Component\\Search\\Field\\FieldTypeExtension\[\], mixed\[\]\[\] given#'
+        - '#expects Rollerworks\\Component\\Search\\Field\\FieldTypeExtension\[\], Rollerworks\\Component\\Search\\Field\\FieldTypeExtension\[\]\[\] given#'
         - '#\(mixed\[\]\[\]\) does not accept iterable\(iterable\(mixed\[\]\)\[\]\)#'
         - '#Undefined variable: \$(c|flatChoices)#'
 

--- a/src/Exporter/StringQueryExporter.php
+++ b/src/Exporter/StringQueryExporter.php
@@ -176,11 +176,6 @@ final class StringQueryExporter extends AbstractExporter
                 $operator .= '<';
                 break;
 
-            case PatternMatch::PATTERN_REGEX:
-            case PatternMatch::PATTERN_NOT_REGEX:
-                $operator .= '?';
-                break;
-
             case PatternMatch::PATTERN_EQUALS:
             case PatternMatch::PATTERN_NOT_EQUALS:
                 $operator .= '=';

--- a/src/Input/StringLexer.php
+++ b/src/Input/StringLexer.php
@@ -272,7 +272,7 @@ final class StringLexer
         $negative = false;
         $caseInsensitive = false;
 
-        if (!preg_match('/([^*<>?=]{0,2}\s*)([*<>?=])/A', $this->data, $match, 0, $this->cursor)) {
+        if (!preg_match('/([^*<>=]{0,2}\s*)([*<>=])/A', $this->data, $match, 0, $this->cursor)) {
             throw $this->createSyntaxException('PatternMatch');
         }
 
@@ -293,7 +293,6 @@ final class StringLexer
             '*' => 'CONTAINS',
             '>' => 'STARTS_WITH',
             '<' => 'ENDS_WITH',
-            '?' => 'REGEX',
             '=' => 'EQUALS',
         ];
 

--- a/src/Test/SearchConditionExporterTestCase.php
+++ b/src/Test/SearchConditionExporterTestCase.php
@@ -207,7 +207,6 @@ abstract class SearchConditionExporterTestCase extends SearchIntegrationTestCase
         $values->add(new PatternMatch('value', PatternMatch::PATTERN_CONTAINS));
         $values->add(new PatternMatch('value2', PatternMatch::PATTERN_STARTS_WITH, true));
         $values->add(new PatternMatch('value3', PatternMatch::PATTERN_ENDS_WITH));
-        $values->add(new PatternMatch('^foo|bar?', PatternMatch::PATTERN_REGEX));
         $values->add(new PatternMatch('value4', PatternMatch::PATTERN_NOT_CONTAINS));
         $values->add(new PatternMatch('value5', PatternMatch::PATTERN_NOT_CONTAINS, true));
         $values->add(new PatternMatch('value9', PatternMatch::PATTERN_EQUALS));

--- a/src/Value/PatternMatch.php
+++ b/src/Value/PatternMatch.php
@@ -23,11 +23,9 @@ final class PatternMatch implements ValueHolder
     public const PATTERN_CONTAINS = 'CONTAINS';
     public const PATTERN_STARTS_WITH = 'STARTS_WITH';
     public const PATTERN_ENDS_WITH = 'ENDS_WITH';
-    public const PATTERN_REGEX = 'REGEX';
     public const PATTERN_NOT_CONTAINS = 'NOT_CONTAINS';
     public const PATTERN_NOT_STARTS_WITH = 'NOT_STARTS_WITH';
     public const PATTERN_NOT_ENDS_WITH = 'NOT_ENDS_WITH';
-    public const PATTERN_NOT_REGEX = 'NOT_REGEX';
     public const PATTERN_EQUALS = 'EQUALS';
     public const PATTERN_NOT_EQUALS = 'NOT_EQUALS';
 
@@ -91,16 +89,8 @@ final class PatternMatch implements ValueHolder
                 self::PATTERN_NOT_STARTS_WITH,
                 self::PATTERN_NOT_CONTAINS,
                 self::PATTERN_NOT_ENDS_WITH,
-                self::PATTERN_NOT_REGEX,
                 self::PATTERN_NOT_EQUALS,
             ], true
         );
-    }
-
-    public function isRegex(): bool
-    {
-        return self::PATTERN_REGEX === $this->patternType
-            || self::PATTERN_NOT_REGEX === $this->patternType
-        ;
     }
 }

--- a/tests/Exporter/ArrayExporterTest.php
+++ b/tests/Exporter/ArrayExporterTest.php
@@ -113,7 +113,6 @@ final class ArrayExporterTest extends SearchConditionExporterTestCase
                         ['type' => 'CONTAINS', 'value' => 'value', 'case-insensitive' => false],
                         ['type' => 'STARTS_WITH', 'value' => 'value2', 'case-insensitive' => true],
                         ['type' => 'ENDS_WITH', 'value' => 'value3', 'case-insensitive' => false],
-                        ['type' => 'REGEX', 'value' => '^foo|bar?', 'case-insensitive' => false],
                         ['type' => 'NOT_CONTAINS', 'value' => 'value4', 'case-insensitive' => false],
                         ['type' => 'NOT_CONTAINS', 'value' => 'value5', 'case-insensitive' => true],
                         ['type' => 'EQUALS', 'value' => 'value9', 'case-insensitive' => false],

--- a/tests/Exporter/JsonExporterTest.php
+++ b/tests/Exporter/JsonExporterTest.php
@@ -122,7 +122,6 @@ final class JsonExporterTest extends SearchConditionExporterTestCase
                             ['type' => 'CONTAINS', 'value' => 'value', 'case-insensitive' => false],
                             ['type' => 'STARTS_WITH', 'value' => 'value2', 'case-insensitive' => true],
                             ['type' => 'ENDS_WITH', 'value' => 'value3', 'case-insensitive' => false],
-                            ['type' => 'REGEX', 'value' => '^foo|bar?', 'case-insensitive' => false],
                             ['type' => 'NOT_CONTAINS', 'value' => 'value4', 'case-insensitive' => false],
                             ['type' => 'NOT_CONTAINS', 'value' => 'value5', 'case-insensitive' => true],
                             ['type' => 'EQUALS', 'value' => 'value9', 'case-insensitive' => false],

--- a/tests/Exporter/StringQueryExporterTest.php
+++ b/tests/Exporter/StringQueryExporterTest.php
@@ -84,7 +84,7 @@ final class StringQueryExporterTest extends SearchConditionExporterTestCase
 
     public function provideMatcherValuesTest()
     {
-        return 'name: ~* value, ~i> value2, ~< value3, ~? "^foo|bar?", ~!* value4, ~i!* value5, ~= value9, ~!= value10, ~i= value11, ~i!= value12;';
+        return 'name: ~* value, ~i> value2, ~< value3, ~!* value4, ~i!* value5, ~= value9, ~!= value10, ~i= value11, ~i!= value12;';
     }
 
     public function provideGroupTest()

--- a/tests/Exporter/XmlExporterTest.php
+++ b/tests/Exporter/XmlExporterTest.php
@@ -162,7 +162,6 @@ final class XmlExporterTest extends SearchConditionExporterTestCase
                         <pattern-matcher type="contains" case-insensitive="false">value</pattern-matcher>
                         <pattern-matcher type="starts_with" case-insensitive="true">value2</pattern-matcher>
                         <pattern-matcher type="ends_with" case-insensitive="false">value3</pattern-matcher>
-                        <pattern-matcher type="regex" case-insensitive="false">^foo|bar?</pattern-matcher>
                         <pattern-matcher type="not_contains" case-insensitive="false">value4</pattern-matcher>
                         <pattern-matcher type="not_contains" case-insensitive="true">value5</pattern-matcher>
                         <pattern-matcher type="equals" case-insensitive="false">value9</pattern-matcher>

--- a/tests/Input/ArrayInputTest.php
+++ b/tests/Input/ArrayInputTest.php
@@ -144,7 +144,6 @@ final class ArrayInputTest extends InputProcessorTestCase
                                 ['value' => 'value', 'type' => 'CONTAINS'],
                                 ['value' => 'value2', 'type' => 'STARTS_WITH', 'case-insensitive' => true],
                                 ['value' => 'value3', 'type' => 'ENDS_WITH'],
-                                ['value' => '^foo|bar?', 'type' => 'REGEX'],
                                 ['value' => 'value4', 'type' => 'NOT_CONTAINS'],
                                 ['value' => 'value5', 'type' => 'NOT_CONTAINS', 'case-insensitive' => true],
                                 ['value' => 'value9', 'type' => 'EQUALS'],

--- a/tests/Input/InputProcessorTestCase.php
+++ b/tests/Input/InputProcessorTestCase.php
@@ -250,7 +250,6 @@ abstract class InputProcessorTestCase extends SearchIntegrationTestCase
         $values->add(new PatternMatch('value', PatternMatch::PATTERN_CONTAINS));
         $values->add(new PatternMatch('value2', PatternMatch::PATTERN_STARTS_WITH, true));
         $values->add(new PatternMatch('value3', PatternMatch::PATTERN_ENDS_WITH));
-        $values->add(new PatternMatch('^foo|bar?', PatternMatch::PATTERN_REGEX));
         $values->add(new PatternMatch('value4', PatternMatch::PATTERN_NOT_CONTAINS));
         $values->add(new PatternMatch('value5', PatternMatch::PATTERN_NOT_CONTAINS, true));
         $values->add(new PatternMatch('value9', PatternMatch::PATTERN_EQUALS));

--- a/tests/Input/JsonInputTest.php
+++ b/tests/Input/JsonInputTest.php
@@ -162,7 +162,6 @@ final class JsonInputTest extends InputProcessorTestCase
                                     ['value' => 'value', 'type' => 'CONTAINS'],
                                     ['value' => 'value2', 'type' => 'STARTS_WITH', 'case-insensitive' => true],
                                     ['value' => 'value3', 'type' => 'ENDS_WITH'],
-                                    ['value' => '^foo|bar?', 'type' => 'REGEX'],
                                     ['value' => 'value4', 'type' => 'NOT_CONTAINS'],
                                     ['value' => 'value5', 'type' => 'NOT_CONTAINS', 'case-insensitive' => true],
                                     ['value' => 'value9', 'type' => 'EQUALS'],

--- a/tests/Input/StringQueryInputTest.php
+++ b/tests/Input/StringQueryInputTest.php
@@ -238,7 +238,7 @@ final class StringQueryInputTest extends InputProcessorTestCase
     public function provideMatcherValues()
     {
         return [
-            ['name: ~*value, ~i>value2, ~<value3, ~?"^foo|bar?", ~!*value4, ~i!*value5, ~=value9, ~!=value10, ~i=value11, ~i!=value12;'],
+            ['name: ~*value, ~i>value2, ~<value3, ~!*value4, ~i!*value5, ~=value9, ~!=value10, ~i=value11, ~i!=value12;'],
         ];
     }
 

--- a/tests/Input/XmlInputTest.php
+++ b/tests/Input/XmlInputTest.php
@@ -292,7 +292,6 @@ final class XmlInputTest extends InputProcessorTestCase
                             <pattern-matcher type="contains" case-insensitive="false">value</pattern-matcher>
                             <pattern-matcher type="starts_with" case-insensitive="true">value2</pattern-matcher>
                             <pattern-matcher type="ends_with" case-insensitive="false">value3</pattern-matcher>
-                            <pattern-matcher type="regex" case-insensitive="false">^foo|bar?</pattern-matcher>
                             <pattern-matcher type="not_contains" case-insensitive="false">value4</pattern-matcher>
                             <pattern-matcher type="not_contains" case-insensitive="true">value5</pattern-matcher>
                             <pattern-matcher type="equals">value9</pattern-matcher>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | (pending)

Remove support for Regex ValueMatch:

- This is not supported in Elastic Search, and would cause an inconsistency with other processors.
- Allowing Regexes without any form of validation opens the system to "Regular expression Denial of Service" attacks.
- YAGNI, most operations can be solved using begin/ends/contains matches.