### PR TITLE
Allow to set a PreCondition for result limiting

### DIFF
--- a/src/SearchCondition.php
+++ b/src/SearchCondition.php
@@ -25,6 +25,7 @@ class SearchCondition
 {
     private $fieldSet;
     private $values;
+    private $preCondition;
 
     public function __construct(FieldSet $fieldSet, ValuesGroup $valuesGroup)
     {
@@ -40,6 +41,16 @@ class SearchCondition
     public function getValuesGroup(): ValuesGroup
     {
         return $this->values;
+    }
+
+    public function setPreCondition(SearchPreCondition $condition): void
+    {
+        $this->preCondition = $condition;
+    }
+
+    public function getPreCondition(): ?SearchPreCondition
+    {
+        return $this->preCondition;
     }
 
     /**

--- a/src/SearchPreCondition.php
+++ b/src/SearchPreCondition.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search;
+
+use Rollerworks\Component\Search\Value\ValuesGroup;
+
+/**
+ * SearchPreCondition contains a condition that must be fulfilled at all times.
+ *
+ * A Pre-condition is applied as `(SearchPreCondition) AND (SearchCondition)`.
+ *
+ * Caution: It's important for QueryGenerator to always apply
+ * the pre-condition even if the SearchCondition itself is empty!
+ *
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+final class SearchPreCondition
+{
+    private $values;
+
+    public function __construct(ValuesGroup $valuesGroup)
+    {
+        $this->values = $valuesGroup;
+    }
+
+    public function getValuesGroup(): ValuesGroup
+    {
+        return $this->values;
+    }
+}

--- a/tests/SearchConditionTest.php
+++ b/tests/SearchConditionTest.php
@@ -17,6 +17,8 @@ use PHPUnit\Framework\TestCase;
 use Rollerworks\Component\Search\Exception\UnsupportedFieldSetException;
 use Rollerworks\Component\Search\FieldSet;
 use Rollerworks\Component\Search\SearchCondition;
+use Rollerworks\Component\Search\SearchPreCondition;
+use Rollerworks\Component\Search\Value\ValuesBag;
 use Rollerworks\Component\Search\Value\ValuesGroup;
 
 /**
@@ -50,5 +52,19 @@ final class SearchConditionTest extends TestCase
         $this->expectExceptionMessage((new UnsupportedFieldSetException(['bar', 'foo'], 'test'))->getMessage());
 
         $condition->assertFieldSetName('bar', 'foo');
+    }
+
+    /** @test */
+    public function it_allows_setting_a_pre_condition()
+    {
+        $fieldSet = $this->createMock(FieldSet::class);
+        $fieldSet->expects(self::any())->method('getSetName')->willReturn('test');
+
+        $preCondition = new SearchPreCondition((new ValuesGroup())->addField('id', new ValuesBag()));
+
+        $condition = new SearchCondition($fieldSet, new ValuesGroup());
+        $condition->setPreCondition($preCondition);
+
+        self::assertEquals($preCondition, $condition->getPreCondition());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | (pending)

Related to https://github.com/rollerworks/search/issues/182

This reuses the SearchConditon model-format to compose a Condition that is only used for generating a pre-condition in the Query. This reuses the (root) SearchCondition's FieldSet as providing a separate FieldSet makes asserting a supported FieldSet more complicated. As an alternative some fields can be marked as internal/hidden to disallow usage by InputProcessors.