### PR TITLE
Integrate existing Elasticsearch support to Symfony, API Platform

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "doctrine/doctrine-bundle": "^1.7",
         "doctrine/doctrine-cache-bundle": "^1.3",
         "doctrine/orm": "^2.5",
+        "friendsofsymfony/elastica-bundle": "^4.0",
         "matthiasnoback/symfony-dependency-injection-test": "^2.0.0",
         "matthiasnoback/symfony-service-definition-validator": "^1.2.7",
         "moneyphp/money": "^3.0.0",

--- a/lib/ApiPlatform/Elasticsearch/Extension/SearchExtension.php
+++ b/lib/ApiPlatform/Elasticsearch/Extension/SearchExtension.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\ApiPlatform\Elasticsearch\Extension;
+
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\QueryCollectionExtensionInterface;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ORM\QueryBuilder;
+use Elastica\Client;
+use Elastica\Document;
+use Elastica\Query;
+use Elastica\Search;
+use Rollerworks\Component\Search\ApiPlatform\ArrayKeysValidator;
+use Rollerworks\Component\Search\Elasticsearch\ElasticsearchFactory;
+use Rollerworks\Component\Search\Exception\BadMethodCallException;
+use Rollerworks\Component\Search\SearchCondition;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Class SearchExtension.
+ */
+class SearchExtension implements QueryCollectionExtensionInterface
+{
+    private $requestStack;
+    private $registry;
+    private $elasticsearchFactory;
+    private $client;
+    private $identifierNames = [];
+
+    public function __construct(RequestStack $requestStack, ManagerRegistry $registry, ElasticsearchFactory $elasticsearchFactory, Client $client)
+    {
+        $this->requestStack = $requestStack;
+        $this->registry = $registry;
+        $this->elasticsearchFactory = $elasticsearchFactory;
+        $this->client = $client;
+    }
+
+    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null)
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        /** @var SearchCondition $condition */
+        if (!$request || null === $condition = $request->attributes->get('_api_search_condition')) {
+            return;
+        }
+
+        $context = $request->attributes->get('_api_search_context');
+        $configuration = $request->attributes->get('_api_search_config');
+        $configPath = "{$resourceClass}#attributes[rollerworks_search][contexts][{$context}][elasticsearch]";
+
+        if (empty($configuration['elasticsearch'])) {
+            return;
+        }
+
+        /** @var String[][] $configuration */
+        $configuration = (array) $configuration['elasticsearch'];
+        ArrayKeysValidator::assertOnlyKeys($configuration, ['mappings', 'identifiers_normalizer'], $configPath);
+
+        // this snippet looks weird, factory should create the proper instance on its own
+        $conditionGenerator = $this->elasticsearchFactory->createCachedConditionGenerator(
+            $this->elasticsearchFactory->createConditionGenerator($condition)
+        );
+
+        foreach ($configuration['mappings'] as $fieldName => $mapping) {
+            $conditionGenerator->registerField($fieldName, $mapping);
+        }
+
+        $normalizer = null;
+        if (array_key_exists('identifiers_normalizer', $configuration)) {
+            $normalizer = $configuration['identifiers_normalizer'];
+            if (!\is_callable($normalizer)) {
+                throw new BadMethodCallException('Parameter "identifiers_normalizer" must be a valid callable');
+            }
+        }
+
+        // TODO: temporary, how to do this better?
+        $query = new Query($conditionGenerator->getQuery());
+
+        // move limit/offset from QueryBuilder to Elasticsearch query
+        if (null !== $firstResult = $queryBuilder->getFirstResult()) {
+            $query->setFrom($firstResult);
+            $queryBuilder->setFirstResult(null);
+        }
+        if (null !== $maxResults = $queryBuilder->getMaxResults()) {
+            $query->setSize($maxResults);
+            $queryBuilder->setMaxResults(null);
+        }
+
+        $search = new Search($this->client);
+        $mappings = $conditionGenerator->getMappings();
+        foreach ($mappings as $mapping) {
+            $index = $this->client->getIndex($mapping->indexName);
+            $type = $index->getType($mapping->typeName);
+            $search
+                ->addIndex($index)
+                ->addType($type);
+        }
+        $response = $search->search($query);
+
+        // NOTE: written like this so we only check if we have a normalizer once
+        if (null !== $normalizer) {
+            $callable = function (Document $document) use ($normalizer) {
+                return \call_user_func($normalizer, $document->getId());
+            };
+        } else {
+            $callable = function (Document $document) {
+                return $document->getId();
+            };
+        }
+        $ids = array_map($callable, $response->getDocuments());
+
+        // straight from FOS Elastica Bundle
+        $rootAlias = $queryBuilder->getRootAliases()[0];
+        $identifier = $this->getIdentifierNames($resourceClass);
+
+        // TODO: hack, only works for non-composite PKs
+        $identifier = current($identifier);
+        $queryBuilder
+            ->andWhere(
+                $queryBuilder
+                    ->expr()
+                        ->in($rootAlias.'.'.$identifier, ':ids')
+            )
+            ->setParameter('ids', $ids);
+    }
+
+    private function getIdentifierNames(string $class): array
+    {
+        if (!array_key_exists($class, $this->identifierNames)) {
+            $manager = $this->registry->getManagerForClass($class);
+            $metadata = $manager->getClassMetadata($class);
+
+            $this->identifierNames[$class] = $metadata->getIdentifier();
+        }
+
+        return $this->identifierNames[$class];
+    }
+}

--- a/lib/ApiPlatform/Tests/Elasticsearch/Extension/SearchExtensionTest.php
+++ b/lib/ApiPlatform/Tests/Elasticsearch/Extension/SearchExtensionTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types = 1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\ApiPlatform\Tests\Elasticsearch\Extension;
+
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGenerator;
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ORM\Query\Expr;
+use Doctrine\ORM\QueryBuilder;
+use Elastica\Client;
+use Elastica\Response;
+use PHPUnit\Framework\TestCase;
+use Rollerworks\Component\Search\ApiPlatform\Elasticsearch\Extension\SearchExtension;
+use Rollerworks\Component\Search\ApiPlatform\Tests\Fixtures\Dummy;
+use Rollerworks\Component\Search\Elasticsearch\CachedConditionGenerator;
+use Rollerworks\Component\Search\Elasticsearch\ElasticsearchFactory;
+use Rollerworks\Component\Search\Elasticsearch\QueryConditionGenerator;
+use Rollerworks\Component\Search\FieldSet;
+use Rollerworks\Component\Search\SearchCondition;
+use Rollerworks\Component\Search\Value\ValuesGroup;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/** @internal */
+class SearchExtensionTest extends TestCase
+{
+    public function testApplyToCollectionWithValidCondition()
+    {
+        $query = ['query' => ['bool' => ['must' => 'foo']]];
+        $ids = [3, 1, 5];
+
+        $elasticaResponse = $this->createResponse($ids);
+        $searchCondition = $this->createCondition();
+
+        $queryFunctionProphecy = $this->prophesize(Expr\Func::class);
+        $queryFunction = $queryFunctionProphecy->reveal();
+
+        $queryExpressionProphecy = $this->prophesize(Expr::class);
+        $queryExpressionProphecy->in('o.id', ':ids')->willReturn($queryFunction);
+        $queryExpression = $queryExpressionProphecy->reveal();
+
+        $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
+        $queryBuilderProphecy->andWhere($queryFunction)->willReturn($queryBuilderProphecy);
+        $queryBuilderProphecy->expr()->willReturn($queryExpression);
+        $queryBuilderProphecy->setParameter('ids', $ids)->shouldBeCalled();
+        $queryBuilderProphecy->getFirstResult()->shouldBeCalled();
+        $queryBuilderProphecy->getMaxResults()->shouldBeCalled();
+        $queryBuilderProphecy->getRootAliases()->willReturn(['o']);
+        $queryBuilder = $queryBuilderProphecy->reveal();
+
+        $classMetadataProphecy = $this->prophesize(ClassMetadata::class);
+        $classMetadataProphecy->getIdentifier()->willReturn(['id']);
+        $classMetadata = $classMetadataProphecy->reveal();
+
+        $managerProphecy = $this->prophesize(ObjectManager::class);
+        $managerProphecy->getClassMetadata(Dummy::class)->willReturn($classMetadata);
+        $manager = $managerProphecy->reveal();
+
+        $managerRegistryProphecy = $this->prophesize(ManagerRegistry::class);
+        $managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn($manager);
+        $managerRegistry = $managerRegistryProphecy->reveal();
+
+        $elasticaClientProphecy = $this->prophesize(Client::class);
+        $elasticaClientProphecy->request('/_search', 'GET', $query, [])->willReturn($elasticaResponse);
+        $elasticaClient = $elasticaClientProphecy->reveal();
+
+        $conditionGeneratorProphecy = $this->prophesize(QueryConditionGenerator::class);
+        $conditionGenerator = $conditionGeneratorProphecy->reveal();
+
+        $cachedConditionGeneratorProphecy = $this->prophesize(CachedConditionGenerator::class);
+        $cachedConditionGeneratorProphecy->registerField('dummy-id', 'id')->shouldBeCalled();
+        $cachedConditionGeneratorProphecy->registerField('dummy-name', 'name')->shouldBeCalled();
+        $cachedConditionGeneratorProphecy->getQuery()->willReturn($query);
+        $cachedConditionGeneratorProphecy->getMappings()->shouldBeCalled();
+        $cachedConditionGenerator = $cachedConditionGeneratorProphecy->reveal();
+
+        $elasticsearchFactoryProphecy = $this->prophesize(ElasticsearchFactory::class);
+        $elasticsearchFactoryProphecy->createConditionGenerator($searchCondition)->willReturn($conditionGenerator);
+        $elasticsearchFactoryProphecy->createCachedConditionGenerator($conditionGenerator)->willReturn($cachedConditionGenerator);
+        $elasticsearchFactory = $elasticsearchFactoryProphecy->reveal();
+
+        $request = new Request([], [], [
+            '_api_search_condition' => $searchCondition,
+            '_api_search_context' => 'dummy',
+            '_api_search_config' => [
+                'elasticsearch' => [
+                    'mappings' => [
+                        'dummy-id' => 'id',
+                        'dummy-name' => 'name',
+                    ],
+                ],
+            ],
+        ]);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $orderExtensionTest = new SearchExtension($requestStack, $managerRegistry, $elasticsearchFactory, $elasticaClient);
+        $orderExtensionTest->applyToCollection($queryBuilder, new QueryNameGenerator(), Dummy::class, 'get');
+    }
+
+    private function createCondition(?string $setName = 'dummy_fieldset'): SearchCondition
+    {
+        $fieldSetProphecy = $this->prophesize(FieldSet::class);
+        $fieldSetProphecy->getSetName()->willReturn($setName);
+
+        return new SearchCondition($fieldSetProphecy->reveal(), new ValuesGroup());
+    }
+
+    private function createResponse($ids): Response
+    {
+        $response = [];
+        foreach ($ids as $id) {
+            $response['hits']['hits'][]['_id'] = $id;
+        }
+
+        return new Response($response);
+    }
+}

--- a/lib/Elasticsearch/QueryConditionGenerator.php
+++ b/lib/Elasticsearch/QueryConditionGenerator.php
@@ -21,7 +21,7 @@ use Rollerworks\Component\Search\Value\PatternMatch;
 use Rollerworks\Component\Search\Value\Range;
 use Rollerworks\Component\Search\Value\ValuesGroup;
 
-final class QueryConditionGenerator implements ConditionGenerator
+/* final */ class QueryConditionGenerator implements ConditionGenerator
 {
     private const PROPERTY_ID = '_id';
 

--- a/lib/Symfony/SearchBundle/DependencyInjection/Compiler/ElasticaBundlePass.php
+++ b/lib/Symfony/SearchBundle/DependencyInjection/Compiler/ElasticaBundlePass.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\SearchBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * If FOS Elastica Bundle is detected, use its client as our client.
+ *
+ * Class ElasticaBundlePass.
+ */
+class ElasticaBundlePass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has('fos_elastica.client')) {
+            return;
+        }
+
+        $container->setAlias('rollerworks_search.elasticsearch.client', 'fos_elastica.client');
+    }
+}

--- a/lib/Symfony/SearchBundle/DependencyInjection/Configuration.php
+++ b/lib/Symfony/SearchBundle/DependencyInjection/Configuration.php
@@ -16,6 +16,7 @@ namespace Rollerworks\Bundle\SearchBundle\DependencyInjection;
 use Rollerworks\Component\Search\ApiPlatform\EventListener\SearchConditionListener;
 use Rollerworks\Component\Search\Doctrine\Dbal\DoctrineDbalFactory;
 use Rollerworks\Component\Search\Doctrine\Orm\DoctrineOrmFactory;
+use Rollerworks\Component\Search\Elasticsearch\ElasticsearchFactory;
 use Rollerworks\Component\Search\Processor\Psr7SearchProcessor;
 use Symfony\Bridge\PsrHttpMessage\HttpFoundationFactoryInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
@@ -47,6 +48,7 @@ final class Configuration implements ConfigurationInterface
 
         $this->addDoctrineSection($rootNode);
         $this->addApiPlatformSection($rootNode);
+        $this->addElasticsearchSection($rootNode);
 
         return $treeBuilder;
     }
@@ -93,8 +95,21 @@ final class Configuration implements ConfigurationInterface
                          ->arrayNode('doctrine_orm')
                              ->{class_exists(DoctrineOrmFactory::class) ? 'canBeDisabled' : 'canBeEnabled'}()
                          ->end()
+                        ->arrayNode('elasticsearch')
+                            ->{class_exists(ElasticsearchFactory::class) ? 'canBeDisabled' : 'canBeEnabled'}()
+                        ->end()
                      ->end()
                  ->end()
              ->end();
+    }
+
+    private function addElasticsearchSection(ArrayNodeDefinition $rootNode)
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('elasticsearch')
+                    ->{class_exists(ElasticsearchFactory::class) ? 'canBeDisabled' : 'canBeEnabled'}()
+                ->end()
+            ->end();
     }
 }

--- a/lib/Symfony/SearchBundle/DependencyInjection/RollerworksSearchExtension.php
+++ b/lib/Symfony/SearchBundle/DependencyInjection/RollerworksSearchExtension.php
@@ -55,6 +55,10 @@ class RollerworksSearchExtension extends Extension implements PrependExtensionIn
             }
         }
 
+        if ($this->isConfigEnabled($container, $config['elasticsearch'])) {
+            $loader->load('elasticsearch.xml');
+        }
+
         if (interface_exists(ValidatorInterface::class)) {
             $loader->load('input_validator.xml');
         }
@@ -68,6 +72,12 @@ class RollerworksSearchExtension extends Extension implements PrependExtensionIn
 
             if ($this->isConfigEnabled($container, $config['api_platform']['doctrine_orm'])) {
                 $loader->load('api_platform_doctrine_orm.xml');
+            }
+            if ($this->isConfigEnabled($container, $config['api_platform']['elasticsearch'])) {
+                if (!$this->isConfigEnabled($container, $config['elasticsearch'])) {
+                    throw new LogicException('API Platform Elasticsearch support cannot be enabled as Elasticsearch is not enabled');
+                }
+                $loader->load('api_platform_elasticsearch.xml');
             }
         }
     }

--- a/lib/Symfony/SearchBundle/Resources/config/api_platform_elasticsearch.xml
+++ b/lib/Symfony/SearchBundle/Resources/config/api_platform_elasticsearch.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="rollerworks_search.api_platform.elasticsearch.query_extension.search" class="Rollerworks\Component\Search\ApiPlatform\Elasticsearch\Extension\SearchExtension" public="false">
+            <argument type="service" id="request_stack" />
+            <argument type="service" id="doctrine" />
+            <argument type="service" id="rollerworks_search.elasticsearch.factory" />
+            <argument type="service" id="rollerworks_search.elasticsearch.client" />
+
+            <tag name="api_platform.doctrine.orm.query_extension.collection" priority="32" />
+        </service>
+    </services>
+</container>

--- a/lib/Symfony/SearchBundle/Resources/config/elasticsearch.xml
+++ b/lib/Symfony/SearchBundle/Resources/config/elasticsearch.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="rollerworks_search.elasticsearch.factory" class="Rollerworks\Component\Search\Elasticsearch\ElasticsearchFactory" public="true">
+            <argument type="service" id="rollerworks_search.elasticsearch.cache" on-invalid="null" />
+        </service>
+
+        <service id="rollerworks_search.elasticsearch.client" synthetic="true" />
+
+        <!-- conversions -->
+        <service id="Rollerworks\Component\Search\Elasticsearch\Extension\Conversion\CurrencyConversion" public="false"/>
+        <service id="Rollerworks\Component\Search\Elasticsearch\Extension\Conversion\DateConversion" public="false"/>
+        <service id="Rollerworks\Component\Search\Elasticsearch\Extension\Conversion\DateTimeConversion" public="false"/>
+
+        <!-- extensions -->
+        <service id="Rollerworks\Component\Search\Elasticsearch\Extension\Type\FieldTypeExtension" public="false">
+            <tag name="rollerworks_search.type_extension" extended-type="Rollerworks\Component\Search\Extension\Core\Type\SearchFieldType" />
+        </service>
+
+        <service id="Rollerworks\Component\Search\Elasticsearch\Extension\Type\BirthdayTypeExtension" public="false">
+            <argument type="service" id="Rollerworks\Component\Search\Elasticsearch\Extension\Conversion\DateConversion" />
+            <tag name="rollerworks_search.type_extension" extended-type="Rollerworks\Component\Search\Extension\Core\Type\BirthdayType" />
+        </service>
+
+        <service id="Rollerworks\Component\Search\Elasticsearch\Extension\Type\DateTypeExtension" public="false">
+            <argument type="service" id="Rollerworks\Component\Search\Elasticsearch\Extension\Conversion\DateConversion" />
+            <tag name="rollerworks_search.type_extension" extended-type="Rollerworks\Component\Search\Extension\Core\Type\DateType" />
+        </service>
+
+        <service id="Rollerworks\Component\Search\Elasticsearch\Extension\Type\DateTimeTypeExtension" public="false">
+            <argument type="service" id="Rollerworks\Component\Search\Elasticsearch\Extension\Conversion\DateTimeConversion" />
+            <tag name="rollerworks_search.type_extension" extended-type="Rollerworks\Component\Search\Extension\Core\Type\DateTimeType" />
+        </service>
+
+        <service id="Rollerworks\Component\Search\Elasticsearch\Extension\Type\MoneyTypeExtension" public="false">
+            <argument type="service" id="Rollerworks\Component\Search\Elasticsearch\Extension\Conversion\CurrencyConversion" />
+            <tag name="rollerworks_search.type_extension" extended-type="Rollerworks\Component\Search\Extension\Core\Type\MoneyType" />
+        </service>
+    </services>
+</container>

--- a/lib/Symfony/SearchBundle/RollerworksSearchBundle.php
+++ b/lib/Symfony/SearchBundle/RollerworksSearchBundle.php
@@ -28,6 +28,7 @@ class RollerworksSearchBundle extends Bundle
         $container->addCompilerPass(new Compiler\ConditionOptimizerPass());
         $container->addCompilerPass(new Compiler\FieldSetRegistryPass());
         $container->addCompilerPass(new Compiler\DoctrineOrmPass());
+        $container->addCompilerPass(new Compiler\ElasticaBundlePass());
         $container->addCompilerPass(new Compiler\DoctrineOrmQueryBuilderPass(), PassConfig::TYPE_BEFORE_REMOVING);
     }
 }

--- a/lib/Symfony/SearchBundle/Tests/Functional/Application/AppKernel.php
+++ b/lib/Symfony/SearchBundle/Tests/Functional/Application/AppKernel.php
@@ -16,6 +16,7 @@ namespace Rollerworks\Bundle\SearchBundle\Tests\Functional\Application;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\ApiPlatformBundle;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle;
+use FOS\ElasticaBundle\FOSElasticaBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -60,6 +61,10 @@ class AppKernel extends Kernel
             $bundles[] = new DoctrineBundle();
         }
 
+        if (class_exists(FOSElasticaBundle::class)) {
+            $bundles[] = new FOSElasticaBundle();
+        }
+
         if ('api_platform.yml' === substr($this->config, -16)) {
             $bundles[] = new TwigBundle();
             $bundles[] = new ApiPlatformBundle();
@@ -88,16 +93,6 @@ class AppKernel extends Kernel
             $tmpDir = sys_get_temp_dir();
         }
 
-        return rtrim($tmpDir, '/\\').'/RSearch/'.substr(sha1($this->config), 0, 6);
-    }
-
-    public function serialize()
-    {
-        return serialize([$this->config, $this->isDebug()]);
-    }
-
-    public function unserialize($str)
-    {
-        call_user_func_array([$this, '__construct'], unserialize($str));
+        return rtrim($tmpDir, '/\\').'/rollerworks-search-'.sha1(__DIR__).'/'.substr(sha1($this->config), 0, 6);
     }
 }

--- a/lib/Symfony/SearchBundle/Tests/Functional/Application/config/api_platform.yml
+++ b/lib/Symfony/SearchBundle/Tests/Functional/Application/config/api_platform.yml
@@ -42,6 +42,12 @@ doctrine:
                 mappings:
                     AppBundle:  ~
 
+fos_elastica:
+    clients:
+        default: {host: localhost, port: 9200}
+    indexes:
+        app: ~
+
 api_platform:
     title:       API Platform's demo
     description: |

--- a/lib/Symfony/SearchBundle/Tests/Functional/Application/config/default.yml
+++ b/lib/Symfony/SearchBundle/Tests/Functional/Application/config/default.yml
@@ -3,3 +3,4 @@ imports:
 
 rollerworks_search:
     api_platform: false
+    elasticsearch: false

--- a/lib/Symfony/SearchBundle/Tests/Functional/Application/config/doctrine_dbal.yml
+++ b/lib/Symfony/SearchBundle/Tests/Functional/Application/config/doctrine_dbal.yml
@@ -9,3 +9,4 @@ doctrine:
 
 rollerworks_search:
     api_platform: false
+    elasticsearch: false

--- a/lib/Symfony/SearchBundle/Tests/Functional/Application/config/doctrine_orm.yml
+++ b/lib/Symfony/SearchBundle/Tests/Functional/Application/config/doctrine_orm.yml
@@ -36,3 +36,4 @@ doctrine:
 
 rollerworks_search:
     api_platform: false
+    elasticsearch: false

--- a/lib/Symfony/SearchBundle/Tests/Functional/Application/config/elasticsearch.yml
+++ b/lib/Symfony/SearchBundle/Tests/Functional/Application/config/elasticsearch.yml
@@ -1,0 +1,9 @@
+imports:
+    - { resource: 'framework.yml' }
+
+rollerworks_search:
+    api_platform: false
+    doctrine:
+        dbal: false
+        orm: false
+    elasticsearch: true

--- a/lib/Symfony/SearchBundle/Tests/Functional/ElasticsearchTest.php
+++ b/lib/Symfony/SearchBundle/Tests/Functional/ElasticsearchTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\SearchBundle\Tests\Functional;
+
+use Rollerworks\Component\Search\Elasticsearch\ElasticsearchFactory;
+
+final class ElasticsearchTest extends FunctionalTestCase
+{
+    public function testElasticsearchFactoryIsAccessible()
+    {
+        if (!class_exists(ElasticsearchFactory::class)) {
+            self::markTestSkipped('rollerworks/search-elasticsearch is not installed');
+        }
+
+        $client = self::newClient(['config' => 'elasticsearch.yml']);
+        $client->getKernel()->boot();
+
+        $container = $client->getContainer();
+
+        self::assertInstanceOf(ElasticsearchFactory::class, $container->get('rollerworks_search.elasticsearch.factory'));
+    }
+}


### PR DESCRIPTION
Porting https://github.com/rollerworks/search-api-platform/pull/8, https://github.com/rollerworks/RollerworksSearchBundle/pull/37 to new mono-repo.

Closes #179.