### PR TITLE
Prepare for monolith release

### DIFF
--- a/lib/ApiPlatform/composer.json
+++ b/lib/ApiPlatform/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "rollerworks/search-processor": "^0.2.1",
+        "rollerworks/search-processor": "^2.0",
         "rollerworks/search": "^2.0@dev,>=2.0.0-ALPHA4",
         "rollerworks/uri-encoder": "^1.1.0 || ^2.0",
         "api-platform/core": "^2.0.10",
@@ -39,7 +39,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-master": "2.0-dev"
         }
     },
     "minimum-stability": "dev",

--- a/lib/Elasticsearch/composer.json
+++ b/lib/Elasticsearch/composer.json
@@ -37,7 +37,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-master": "2.0-dev"
         }
     }
 }

--- a/lib/Processor/composer.json
+++ b/lib/Processor/composer.json
@@ -40,7 +40,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-master": "2.0-dev"
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Update branch-aliases to 2.0-dev.

All split packages will have the same version, and therefor need a correct and matching branch-alias.

**You will need to update your composer constraints to use the new 2.0 constraint. But in the future upgrading will be much easier 👍**