### PR TITLE
[Elasticsearch] Fix getMappings() for pattern matcher

### DIFF
--- a/lib/Elasticsearch/QueryConditionGenerator.php
+++ b/lib/Elasticsearch/QueryConditionGenerator.php
@@ -128,6 +128,10 @@ use Rollerworks\Component\Search\Value\ValuesGroup;
             if ($valuesBag->has(Compare::class)) {
                 $mappings[$fieldName] = $this->mappings[$fieldName];
             }
+
+            if ($valuesBag->has(PatternMatch::class)) {
+                $mappings[$fieldName] = $this->mappings[$fieldName];
+            }
         }
 
         return array_values($mappings);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Get mappings missing for pattern matchers.