### PR TITLE
[Elasticsearch] Fix getMappings() for pattern matcher and nested groups

### DIFF
--- a/lib/Elasticsearch/QueryConditionGenerator.php
+++ b/lib/Elasticsearch/QueryConditionGenerator.php
@@ -114,20 +114,11 @@ use Rollerworks\Component\Search\Value\ValuesGroup;
     public function getMappings(): array
     {
         $mappings = [];
-
         $group = $this->searchCondition->getValuesGroup();
-        foreach ($group->getFields() as $fieldName => $valuesBag) {
-            if ($valuesBag->hasSimpleValues()) {
-                $mappings[$fieldName] = $this->mappings[$fieldName];
-            }
+        $mappings = \array_merge($mappings, $this->getGroupMappings($group));
 
-            if ($valuesBag->has(Range::class)) {
-                $mappings[$fieldName] = $this->mappings[$fieldName];
-            }
-
-            if ($valuesBag->has(Compare::class)) {
-                $mappings[$fieldName] = $this->mappings[$fieldName];
-            }
+        foreach ($group->getGroups() as $subGroup) {
+            $mappings = \array_merge($mappings, $this->getGroupMappings($subGroup));
         }
 
         return array_values($mappings);
@@ -165,6 +156,29 @@ use Rollerworks\Component\Search\Value\ValuesGroup;
     public static function translateComparison(string $operator): string
     {
         return self::COMPARISON_OPERATOR_MAP[$operator];
+    }
+
+    private function getGroupMappings(ValuesGroup $group): array
+    {
+        $mappings = [];
+        foreach ($group->getFields() as $fieldName => $valuesBag) {
+            if ($valuesBag->hasSimpleValues()) {
+                $mappings[$fieldName] = $this->mappings[$fieldName];
+            }
+
+            if ($valuesBag->has(Range::class)) {
+                $mappings[$fieldName] = $this->mappings[$fieldName];
+            }
+
+            if ($valuesBag->has(Compare::class)) {
+                $mappings[$fieldName] = $this->mappings[$fieldName];
+            }
+
+            if ($valuesBag->has(PatternMatch::class)) {
+                $mappings[$fieldName] = $this->mappings[$fieldName];
+            }
+        }
+        return $mappings;
     }
 
     private function processGroup(ValuesGroup $group): array

--- a/lib/Elasticsearch/Tests/QueryConditionGeneratorTest.php
+++ b/lib/Elasticsearch/Tests/QueryConditionGeneratorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Tests\Elasticsearch;
 
+use Rollerworks\Component\Search\Elasticsearch\FieldMapping;
 use Rollerworks\Component\Search\Elasticsearch\QueryConditionGenerator;
 use Rollerworks\Component\Search\FieldSet;
 use Rollerworks\Component\Search\SearchConditionBuilder;
@@ -33,6 +34,7 @@ final class QueryConditionGeneratorTest extends SearchIntegrationTestCase
         $generator->registerField('name', 'name');
 
         self::assertNull($generator->getQuery());
+        self::assertMapping([], $generator->getMappings());
     }
 
     /** @test */
@@ -77,6 +79,8 @@ final class QueryConditionGeneratorTest extends SearchIntegrationTestCase
                 ],
             ],
         ], $generator->getQuery());
+
+        self::assertMapping(['id', 'name'], $generator->getMappings());
     }
 
     /** @test */
@@ -113,6 +117,8 @@ final class QueryConditionGeneratorTest extends SearchIntegrationTestCase
                 ],
             ],
         ], $generator->getQuery());
+
+        self::assertMapping(['id'], $generator->getMappings());
     }
 
     /** @test */
@@ -165,6 +171,8 @@ final class QueryConditionGeneratorTest extends SearchIntegrationTestCase
                 ],
             ],
         ], $generator->getQuery());
+
+        self::assertMapping(['id', 'name'], $generator->getMappings());
     }
 
     /** @test */
@@ -215,6 +223,8 @@ final class QueryConditionGeneratorTest extends SearchIntegrationTestCase
                 ],
             ],
         ], $generator->getQuery());
+
+        self::assertMapping(['id'], $generator->getMappings());
     }
 
     /** @test */
@@ -268,6 +278,8 @@ final class QueryConditionGeneratorTest extends SearchIntegrationTestCase
                 ],
             ],
         ], $generator->getQuery());
+
+        self::assertMapping(['id'], $generator->getMappings());
     }
 
     /** @test */
@@ -348,6 +360,8 @@ final class QueryConditionGeneratorTest extends SearchIntegrationTestCase
                 ],
             ],
         ], $generator->getQuery());
+
+        self::assertMapping(['name'], $generator->getMappings());
     }
 
     /** @test */
@@ -392,6 +406,8 @@ final class QueryConditionGeneratorTest extends SearchIntegrationTestCase
             ],
             $generator->getQuery()
         );
+
+        self::assertMapping(['name'], $generator->getMappings());
     }
 
     /**
@@ -403,5 +419,22 @@ final class QueryConditionGeneratorTest extends SearchIntegrationTestCase
         $fieldSet = $this->getFieldSet();
 
         return SearchConditionBuilder::create($fieldSet);
+    }
+
+    /**
+     * @param string[]       $expected
+     * @param FieldMapping[] $mappings
+     */
+    private static function assertMapping(array $expected, array $mappings)
+    {
+        $actual = [];
+        foreach ($mappings as $mapping) {
+            $actual[] = $mapping->fieldName;
+        }
+
+        sort($expected);
+        sort($actual);
+
+        self::assertEquals($expected, $actual);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Get mappings missing for pattern matchers.

Note: this is exactly the same as #197, but my app wasn't picking up my fork to install, thought the branch name was tripping Composer up. Turns out it was #199.