### PR TITLE
[Input] Introduce NormStringQuery for processing normalizev value in StringQuery

### DIFF
--- a/lib/ApiPlatform/EventListener/SearchConditionListener.php
+++ b/lib/ApiPlatform/EventListener/SearchConditionListener.php
@@ -87,7 +87,7 @@ final class SearchConditionListener
 
         $searchConfig = $this->resolveSearchConfiguration($searchConfig, $resourceClass, $request);
 
-        $config = new ProcessorConfig($this->searchFactory->createFieldSet($searchConfig['fieldset']), 'array');
+        $config = new ProcessorConfig($this->searchFactory->createFieldSet($searchConfig['fieldset']), 'norm_string_query');
         $this->configureProcessor($config, $searchConfig, $resourceClass);
         $payload = $this->searchProcessor->processRequest($request, $config);
 
@@ -95,7 +95,7 @@ final class SearchConditionListener
             $routeArguments = array_merge(
                 $request->query->all(),
                 $this->resolveRouteArguments($request), // Execute after query to prevent overwriting.
-                ['search' => $payload->exportedCondition] // Use array instead or string.
+                ['search' => $payload->exportedCondition]
             );
 
             $event->setResponse(new RedirectResponse(

--- a/lib/ApiPlatform/Tests/EventListener/SearchConditionListenerTest.php
+++ b/lib/ApiPlatform/Tests/EventListener/SearchConditionListenerTest.php
@@ -64,8 +64,8 @@ class SearchConditionListenerTest extends SearchIntegrationTestCase
 
         $searchPayload = new SearchPayload();
         $searchPayload->searchCondition = $condition = $this->createCondition();
-        $searchPayload->exportedFormat = 'array';
-        $searchPayload->exportedCondition = ['fields' => ['id' => ['single-values' => [1, 2]]]];
+        $searchPayload->exportedFormat = 'norm_string_query';
+        $searchPayload->exportedCondition = 'id: 1, 2;';
 
         $processorProphecy = $this->prophesize(SearchProcessor::class);
         $processorProphecy->processRequest($request, Argument::any())->willReturn($searchPayload);
@@ -121,8 +121,8 @@ class SearchConditionListenerTest extends SearchIntegrationTestCase
 
         $searchPayload = new SearchPayload();
         $searchPayload->searchCondition = $condition = $this->createCondition();
-        $searchPayload->exportedFormat = 'array';
-        $searchPayload->exportedCondition = ['fields' => ['id' => ['single-values' => [1, 2]]]];
+        $searchPayload->exportedFormat = 'norm_string_query';
+        $searchPayload->exportedCondition = 'id: 1, 2;';
 
         $processorProphecy = $this->prophesize(SearchProcessor::class);
         $processorProphecy->processRequest($request, Argument::any())->willReturn($searchPayload);
@@ -179,7 +179,7 @@ class SearchConditionListenerTest extends SearchIntegrationTestCase
 
         $searchPayload = new SearchPayload(true);
         $searchPayload->searchCondition = $condition = $this->createCondition();
-        $searchPayload->exportedFormat = 'array';
+        $searchPayload->exportedFormat = 'norm_string_query';
         $searchPayload->exportedCondition = ['fields' => ['id' => ['single-values' => [1]]]];
 
         $processorProphecy = $this->prophesize(SearchProcessor::class);
@@ -191,7 +191,7 @@ class SearchConditionListenerTest extends SearchIntegrationTestCase
             'api_books_collection',
             ['search' => ['fields' => ['id' => ['single-values' => [1]]]]],
             Argument::any()
-        )->willReturn('/books?search[fields][id][0]=1');
+        )->willReturn('/books?search=id: 1;');
 
         $urlGenerator = $urlGeneratorProphecy->reveal();
 
@@ -199,7 +199,7 @@ class SearchConditionListenerTest extends SearchIntegrationTestCase
         $listener = new SearchConditionListener($this->getFactory(), $searchProcessor, $urlGenerator, $resourceMetadataFactory, $eventDispatcher);
         $listener->onKernelRequest($event = new GetResponseEvent($httpKernel, $request, HttpKernelInterface::MASTER_REQUEST));
 
-        self::assertEquals(new RedirectResponse('/books?search[fields][id][0]=1'), $event->getResponse());
+        self::assertEquals(new RedirectResponse('/books?search=id: 1;'), $event->getResponse());
         self::assertEquals(
             [
                 '_api_resource_class' => Dummy::class,
@@ -250,8 +250,8 @@ class SearchConditionListenerTest extends SearchIntegrationTestCase
 
         $searchPayload = new SearchPayload(true);
         $searchPayload->searchCondition = $condition = $this->createCondition();
-        $searchPayload->exportedFormat = 'array';
-        $searchPayload->exportedCondition = ['fields' => ['id' => ['single-values' => [1]]]];
+        $searchPayload->exportedFormat = 'norm_string_query';
+        $searchPayload->exportedCondition = 'id: 1;';
 
         $processorProphecy = $this->prophesize(SearchProcessor::class);
         $processorProphecy->processRequest($request, Argument::any())->willReturn($searchPayload);
@@ -260,9 +260,9 @@ class SearchConditionListenerTest extends SearchIntegrationTestCase
         $urlGeneratorProphecy = $this->prophesize(UrlGeneratorInterface::class);
         $urlGeneratorProphecy->generate(
             'api_books_collection',
-            ['_format' => 'json', 'search' => ['fields' => ['id' => ['single-values' => [1]]]]],
+            ['_format' => 'json', 'search' => 'id: 1;'],
             Argument::any()
-        )->willReturn('/books.json?search[fields][id][0]=1');
+        )->willReturn('/books.json?search=id: 1;');
 
         $urlGenerator = $urlGeneratorProphecy->reveal();
 
@@ -270,7 +270,7 @@ class SearchConditionListenerTest extends SearchIntegrationTestCase
         $listener = new SearchConditionListener($this->getFactory(), $searchProcessor, $urlGenerator, $resourceMetadataFactory, $eventDispatcher);
         $listener->onKernelRequest($event = new GetResponseEvent($httpKernel, $request, HttpKernelInterface::MASTER_REQUEST));
 
-        self::assertEquals(new RedirectResponse('/books.json?search[fields][id][0]=1'), $event->getResponse());
+        self::assertEquals(new RedirectResponse('/books.json?search=id: 1;'), $event->getResponse());
         self::assertEquals(
             [
                 '_api_resource_class' => Dummy::class,
@@ -372,11 +372,11 @@ class SearchConditionListenerTest extends SearchIntegrationTestCase
 
         $searchPayload = new SearchPayload();
         $searchPayload->searchCondition = $condition = $this->createCondition();
-        $searchPayload->exportedFormat = 'array';
-        $searchPayload->exportedCondition = ['fields' => ['id' => ['single-values' => [1, 2]]]];
+        $searchPayload->exportedFormat = 'norm_string_query';
+        $searchPayload->exportedCondition = 'id: 1, 2;';
 
         $fieldSet = $this->getFactory()->createFieldSet(BookFieldSet::class);
-        $processorConfig = new ProcessorConfig($fieldSet, 'array');
+        $processorConfig = new ProcessorConfig($fieldSet, 'norm_string_query');
         $processorConfig->setCacheTTL(30);
         $processorConfig->setExportFormat('json');
 

--- a/lib/Core/Exporter/NormStringQueryExporter.php
+++ b/lib/Core/Exporter/NormStringQueryExporter.php
@@ -29,33 +29,19 @@ use Rollerworks\Component\Search\Value\ValuesGroup;
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-final class StringQueryExporter extends StringExporter
+final class NormStringQueryExporter extends StringExporter
 {
-    private $labelResolver;
-
-    /**
-     * Constructor.
-     *
-     * @param callable|null $labelResolver A callable to resolve the actual label
-     *                                     of the field, receives a
-     *                                     FieldConfigInterface instance.
-     *                                     If null the `label` option value is
-     *                                     used instead
-     */
-    public function __construct(callable $labelResolver = null)
+    protected function modelToExported($value, FieldConfig $field): string
     {
-        $this->labelResolver = $labelResolver ?? function (FieldConfig $field) {
-            return $field->getOption('label', $field->getName());
-        };
+        return $this->modelToNorm($value, $field);
     }
 
     protected function resolveLabels(FieldSet $fieldSet): array
     {
         $labels = [];
-        $callable = $this->labelResolver;
 
         foreach ($fieldSet->all() as $name => $field) {
-            $labels[$name] = $callable($field);
+            $labels[$name] = $name;
         }
 
         return $labels;

--- a/lib/Core/Exporter/StringExporter.php
+++ b/lib/Core/Exporter/StringExporter.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Exporter;
+
+use Rollerworks\Component\Search\Exception\UnknownFieldException;
+use Rollerworks\Component\Search\Field\FieldConfig;
+use Rollerworks\Component\Search\FieldSet;
+use Rollerworks\Component\Search\SearchCondition;
+use Rollerworks\Component\Search\Value\Compare;
+use Rollerworks\Component\Search\Value\ExcludedRange;
+use Rollerworks\Component\Search\Value\PatternMatch;
+use Rollerworks\Component\Search\Value\Range;
+use Rollerworks\Component\Search\Value\ValuesBag;
+use Rollerworks\Component\Search\Value\ValuesGroup;
+
+/**
+ * Exports the SearchCondition as StringQuery string.
+ *
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+abstract class StringExporter extends AbstractExporter
+{
+    protected $fields = [];
+
+    /**
+     * Exports a search condition.
+     *
+     * @param SearchCondition $condition The search condition to export
+     *
+     * @return string
+     */
+    public function exportCondition(SearchCondition $condition): string
+    {
+        $this->fields = $this->resolveLabels($condition->getFieldSet());
+
+        return $this->exportGroup($condition->getValuesGroup(), $condition->getFieldSet(), true);
+    }
+
+    abstract protected function resolveLabels(FieldSet $fieldSet): array;
+
+    protected function exportGroup(ValuesGroup $valuesGroup, FieldSet $fieldSet, bool $isRoot = false): string
+    {
+        $result = '';
+        $exportedGroups = '';
+
+        if ($isRoot &&
+            $valuesGroup->countValues() > 0 &&
+            ValuesGroup::GROUP_LOGICAL_OR === $valuesGroup->getGroupLogical()
+        ) {
+            $result .= '*';
+        }
+
+        foreach ($valuesGroup->getFields() as $name => $values) {
+            if (0 === $values->count()) {
+                continue;
+            }
+
+            $result .= $this->getFieldLabel($name);
+            $result .= ': '.$this->exportValues($values, $fieldSet->get($name)).'; ';
+        }
+
+        foreach ($valuesGroup->getGroups() as $group) {
+            $exportedGroup = '( '.trim($this->exportGroup($group, $fieldSet), ' ;').' ); ';
+
+            if ('(  ); ' !== $exportedGroup && ValuesGroup::GROUP_LOGICAL_OR === $group->getGroupLogical()) {
+                $exportedGroups .= '*';
+            }
+
+            $exportedGroups .= $exportedGroup;
+        }
+
+        $result .= $exportedGroups;
+
+        return trim($result);
+    }
+
+    protected function modelToExported($value, FieldConfig $field): string
+    {
+        return $this->modelToView($value, $field);
+    }
+
+    private function getFieldLabel(string $name): string
+    {
+        if (isset($this->fields[$name])) {
+            return $this->fields[$name];
+        }
+
+        throw new UnknownFieldException($name);
+    }
+
+    private function exportValues(ValuesBag $valuesBag, FieldConfig $field): string
+    {
+        $exportedValues = '';
+
+        foreach ($valuesBag->getSimpleValues() as $value) {
+            $exportedValues .= $this->exportValuePart($this->modelToExported($value, $field)).', ';
+        }
+
+        foreach ($valuesBag->getExcludedSimpleValues() as $value) {
+            $exportedValues .= '!'.$this->exportValuePart($this->modelToExported($value, $field)).', ';
+        }
+
+        foreach ($valuesBag->get(Range::class) as $value) {
+            $exportedValues .= $this->exportRangeValue($value, $field).', ';
+        }
+
+        foreach ($valuesBag->get(ExcludedRange::class) as $value) {
+            $exportedValues .= '!'.$this->exportRangeValue($value, $field).', ';
+        }
+
+        foreach ($valuesBag->get(Compare::class) as $value) {
+            $exportedValues .= $value->getOperator().' '.$this->exportValuePart($this->modelToExported($value->getValue(), $field)).', ';
+        }
+
+        foreach ($valuesBag->get(PatternMatch::class) as $value) {
+            $exportedValues .= $this->getPatternMatchOperator($value).' '.$this->exportValuePart($value->getValue()).', ';
+        }
+
+        return rtrim($exportedValues, ', ');
+    }
+
+    private function getPatternMatchOperator(PatternMatch $patternMatch): string
+    {
+        $operator = $patternMatch->isCaseInsensitive() ? '~i' : '~';
+
+        if ($patternMatch->isExclusive()) {
+            $operator .= '!';
+        }
+
+        switch ($patternMatch->getType()) {
+            case PatternMatch::PATTERN_CONTAINS:
+            case PatternMatch::PATTERN_NOT_CONTAINS:
+                $operator .= '*';
+                break;
+
+            case PatternMatch::PATTERN_STARTS_WITH:
+            case PatternMatch::PATTERN_NOT_STARTS_WITH:
+                $operator .= '>';
+                break;
+
+            case PatternMatch::PATTERN_ENDS_WITH:
+            case PatternMatch::PATTERN_NOT_ENDS_WITH:
+                $operator .= '<';
+                break;
+
+            case PatternMatch::PATTERN_EQUALS:
+            case PatternMatch::PATTERN_NOT_EQUALS:
+                $operator .= '=';
+                break;
+
+            default:
+                throw new \RuntimeException(
+                    sprintf(
+                        'Unsupported pattern-match type "%s" found. Please report this bug.',
+                        $patternMatch->getType()
+                    )
+                );
+        }
+
+        return $operator;
+    }
+
+    private function exportRangeValue(Range $range, FieldConfig $field): string
+    {
+        $result = !$range->isLowerInclusive() ? ']' : '';
+        $result .= $this->exportValuePart($this->modelToExported($range->getLower(), $field));
+        $result .= ' ~ ';
+        $result .= $this->exportValuePart($this->modelToExported($range->getUpper(), $field));
+        $result .= !$range->isUpperInclusive() ? '[' : '';
+
+        return $result;
+    }
+
+    private function exportValuePart($value): string
+    {
+        $value = (string) $value;
+
+        if (preg_match('/[<>[\](),;~!*?=&*"\s]/u', $value)) {
+            return '"'.str_replace('"', '""', $value).'"';
+        }
+
+        return $value;
+    }
+}

--- a/lib/Core/Input/NormStringQueryInput.php
+++ b/lib/Core/Input/NormStringQueryInput.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Input;
+
+use Rollerworks\Component\Search\ErrorList;
+use Rollerworks\Component\Search\Exception\InputProcessorException;
+use Rollerworks\Component\Search\Exception\InvalidSearchConditionException;
+use Rollerworks\Component\Search\Exception\StringLexerException;
+use Rollerworks\Component\Search\Exception\UnexpectedTypeException;
+use Rollerworks\Component\Search\Exception\UnknownFieldException;
+use Rollerworks\Component\Search\Field\FieldConfig;
+use Rollerworks\Component\Search\FieldSet;
+use Rollerworks\Component\Search\SearchCondition;
+use Rollerworks\Component\Search\Value\ValuesBag;
+use Rollerworks\Component\Search\Value\ValuesGroup;
+
+/**
+ * NormStringQueryInput - processes input in the StringInput syntax
+ * using the Normalized value format.
+ */
+final class NormStringQueryInput extends StringInput
+{
+    protected function initForProcess(ProcessorConfig $config): void
+    {
+        $this->fields = $this->resolveFieldNames($config->getFieldSet());
+        $this->valuesFactory = new FieldValuesFactory(
+            $this->errors,
+            $this->validator,
+            $this->config->getMaxValues()
+        );
+    }
+
+    private function resolveFieldNames(FieldSet $fieldSet): array
+    {
+        $names = [];
+
+        foreach ($fieldSet->all() as $name => $field) {
+            $names[$name] = $name;
+        }
+
+        return $names;
+    }
+}

--- a/lib/Core/Input/StringInput.php
+++ b/lib/Core/Input/StringInput.php
@@ -1,0 +1,370 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Input;
+
+use Rollerworks\Component\Search\ErrorList;
+use Rollerworks\Component\Search\Exception\InputProcessorException;
+use Rollerworks\Component\Search\Exception\InvalidSearchConditionException;
+use Rollerworks\Component\Search\Exception\StringLexerException;
+use Rollerworks\Component\Search\Exception\UnexpectedTypeException;
+use Rollerworks\Component\Search\Exception\UnknownFieldException;
+use Rollerworks\Component\Search\Field\FieldConfig;
+use Rollerworks\Component\Search\FieldSet;
+use Rollerworks\Component\Search\SearchCondition;
+use Rollerworks\Component\Search\Value\ValuesBag;
+use Rollerworks\Component\Search\Value\ValuesGroup;
+
+/**
+ * StringInput - processes input in the StringQuery format.
+ *
+ * The formats works as follow (whitespace between values is ignored).
+ *
+ * Caution: The error message reports the character position not the byte position.
+ * Multi byte may cause some problems when using substr() rather then mb_substr().
+ *
+ * Each query-pair is a 'field-name: value1, value2;'.
+ *
+ *  Query-pairs can be nested inside a group "(field-name: value1, value2;)"
+ *    Subgroups are threaded as AND-case to there parent,
+ *    multiple groups inside the same group are OR-case to each other.
+ *
+ *    By default all the query-pairs and other direct-subgroups are treated as AND-case.
+ *    To make a group OR-case (any of the fields), prefix the group with '*'
+ *    Example: *(field1=values; field2=values);
+ *
+ *    Groups are separated with a single semicolon ";".
+ *    If the subgroup is last in the group the semicolon can be omitted.
+ *
+ *  Query-Pairs are separated with a single semicolon ";"
+ *  If the query-pair is last in the group the semicolon can be omitted.
+ *
+ *  Each value inside a query-pair is separated with a single comma.
+ *  A value containing special characters (<>[](),;~!*?=) or spaces
+ *  must be surrounded by quotes.
+ *
+ *  Note surrounding spaces are ignored. Example: field: value , value2  ;
+ *
+ *  To escape a quote use it double.
+ *  Example: field: "va""lue";
+ *
+ *  Escaped quotes will be normalized to a single one.
+ *
+ * Line separators are allowed for better readability, but are not allowed
+ * within a value.
+ *
+ * Ranges
+ * ======
+ *
+ * A range consists of two sides, lower and upper bound (inclusive by default).
+ * Each side is considered a value-part and must follow the value convention (as described above).
+ *
+ * Example: field: 1~100; field2: -1 ~ 100
+ *
+ * Each side is inclusive by default, meaning 'the value' and anything lower/higher then it.
+ * The left delimiter can be `[` (inclusive) or `]` (exclusive).
+ * The right delimiter can be `[` (exclusive) or `]` (inclusive).
+ *
+ *   `]1 ~ 100`  is equal to (> 1 and <= 100)
+ *   `[1 ~ 100`  is equal to (>= 1 and <= 100)
+ *   `[1 ~ 100[` is equal to (>= 1 and < 100)
+ *   `]1 ~ 100[` is equal to (> 1 and < 100)
+ *
+ *   Example:
+ *     field: ]1 ~ 100;
+ *     field: [1 ~ 100;
+ *
+ * Excluded values
+ * ===============
+ *
+ * To mark a value as excluded (also done for ranges) prefix it with an '!'.
+ *
+ * Example: field: !value, !1 ~ 10;
+ *
+ * Comparison
+ * ==========
+ *
+ * Comparisons are as any programming language.
+ * Supported operators are: <, <=, <>, >, >=
+ *
+ * Followed by a value-part.
+ *
+ * Example: field: >= 1, < -10;
+ *
+ * Caution: Spaces are not allowed within the operator.
+ * Invalid: > =
+ *
+ * PatternMatch
+ * ============
+ *
+ * PatternMatch works similar to Comparison, everything that starts with a tilde (~)
+ * is considered a pattern match. Spaces within the operator are not allowed.
+ *
+ * Supported operators are:
+ *
+ *    ~* (contains)
+ *    ~> (starts with)
+ *    ~< (ends with)
+ *
+ * And not the NOT equivalent.
+ *
+ *     ~!* (does not contain)
+ *     ~!> (does not start with)
+ *     ~!< (does not end with)
+ *
+ * Example: field: ~> foo, ~*"bar";
+ *
+ * To mark the pattern case insensitive add an 'i' directly after the '~'.
+ *
+ * Example: field: ~i> foo, ~i!* "bar";
+ */
+abstract class StringInput extends AbstractInput
+{
+    /**
+     * @var FieldValuesFactory|null
+     */
+    protected $valuesFactory;
+
+    /**
+     * @var string[]
+     */
+    protected $fields = [];
+
+    private $lexer;
+
+    public function __construct(Validator $validator = null)
+    {
+        $this->lexer = new StringLexer();
+        parent::__construct($validator);
+    }
+
+    /**
+     * Process the input and returns the result.
+     *
+     * @param ProcessorConfig $config
+     * @param string          $input
+     *
+     * @throws InvalidSearchConditionException
+     *
+     * @return SearchCondition
+     */
+    public function process(ProcessorConfig $config, $input): SearchCondition
+    {
+        if (!is_string($input)) {
+            throw new UnexpectedTypeException($input, 'string');
+        }
+
+        $input = trim($input);
+
+        if ('' === $input) {
+            return new SearchCondition($config->getFieldSet(), new ValuesGroup());
+        }
+
+        $condition = null;
+        $this->errors = new ErrorList();
+        $this->config = $config;
+        $this->level = 0;
+
+        $this->initForProcess($config);
+
+        try {
+            $condition = new SearchCondition($config->getFieldSet(), $this->parse($config, $input));
+            $this->assertLevel0();
+        } catch (InputProcessorException $e) {
+            $this->errors[] = $e->toErrorMessageObj();
+        } finally {
+            $this->valuesFactory = null;
+        }
+
+        if (count($this->errors)) {
+            $errors = $this->errors->getArrayCopy();
+
+            throw new InvalidSearchConditionException($errors);
+        }
+
+        return $condition;
+    }
+
+    /**
+     * Initialize the fields ValuesFactory.
+     *
+     * @param ProcessorConfig $config
+     */
+    abstract protected function initForProcess(ProcessorConfig $config): void;
+
+    private function getFieldName(string $name): string
+    {
+        if (isset($this->fields[$name])) {
+            return $this->fields[$name];
+        }
+
+        throw new UnknownFieldException($name);
+    }
+
+    final protected function parse(ProcessorConfig $config, string $input): ValuesGroup
+    {
+        $this->config = $config;
+        $this->lexer->parse($input);
+
+        if (null !== $this->lexer->matchOptional('*')) {
+            $valuesGroup = new ValuesGroup(ValuesGroup::GROUP_LOGICAL_OR);
+        } else {
+            $valuesGroup = new ValuesGroup(ValuesGroup::GROUP_LOGICAL_AND);
+        }
+
+        $this->lexer->skipEmptyLines();
+
+        $this->fieldValuesPairs($valuesGroup);
+
+        return $valuesGroup;
+    }
+
+    private function fieldValuesPairs(ValuesGroup $valuesGroup, string $path = '', bool $inGroup = false)
+    {
+        $groupCount = 0;
+
+        while (!$this->lexer->isEnd()) {
+            if ($this->lexer->isGlimpse('/[*&]?\s*\(/A')) {
+                $this->validateGroupsCount($groupCount + 1, $path);
+
+                ++$groupCount;
+                ++$this->level;
+
+                $valuesGroup->addGroup($this->fieldGroup($path.'['.$groupCount.']'));
+
+                --$this->level;
+
+                continue;
+            } elseif ($this->lexer->isGlimpse('/[*&]/A')) {
+                throw $this->lexer->createFormatException(StringLexerException::GROUP_LOGICAL_WITHOUT_GROUP);
+            }
+
+            if ($this->lexer->isGlimpse(')')) {
+                if ($inGroup) {
+                    break;
+                }
+
+                throw $this->lexer->createFormatException(StringLexerException::CANNOT_CLOSE_UNOPENED_GROUP);
+            }
+
+            $fieldName = $this->getFieldName($this->lexer->fieldIdentification());
+            $fieldConfig = $this->config->getFieldSet()->get($fieldName);
+
+            $this->lexer->skipEmptyLines();
+            $valuesGroup->addField(
+                $fieldName,
+                $this->fieldValues($fieldConfig, new ValuesBag(), $path)
+            );
+
+            $this->lexer->skipEmptyLines();
+        }
+    }
+
+    private function fieldGroup(string $path = ''): ValuesGroup
+    {
+        $this->validateGroupNesting($path);
+
+        if (null !== $this->lexer->matchOptional('*')) {
+            $valuesGroup = new ValuesGroup(ValuesGroup::GROUP_LOGICAL_OR);
+        } else {
+            $valuesGroup = new ValuesGroup(ValuesGroup::GROUP_LOGICAL_AND);
+        }
+
+        $this->lexer->skipWhitespace();
+        $this->lexer->expects('(');
+        $this->lexer->skipEmptyLines();
+
+        $this->fieldValuesPairs($valuesGroup, $path, true);
+
+        $this->lexer->expects(')');
+        $this->lexer->skipEmptyLines();
+
+        $this->lexer->matchOptional(';');
+        $this->lexer->skipEmptyLines();
+
+        return $valuesGroup;
+    }
+
+    private function fieldValues(FieldConfig $field, ValuesBag $valuesBag, string $path)
+    {
+        $hasValues = false;
+        $this->valuesFactory->initContext($field, $valuesBag, $path);
+
+        $pathVal = '['.$field->getName().'][%d]';
+
+        while (!$this->lexer->isEnd() && !$this->lexer->isGlimpse('/[);]/A')) {
+            $valueType = $this->lexer->detectValueType();
+
+            switch ($valueType) {
+                case StringLexer::COMPARE:
+                    list($operator, $value) = $this->lexer->comparisonValue();
+                    $this->valuesFactory->addComparisonValue($operator, $value, [$pathVal, '', '']);
+                    break;
+
+                    case StringLexer::PATTERN_MATCH:
+                    list($caseInsensitive, $type, $value) = $this->lexer->patternMatchValue();
+                    $this->valuesFactory->addPatterMatch($type, $value, $caseInsensitive, [$pathVal, '', '']);
+                    break;
+
+                case StringLexer::RANGE:
+                    $negative = null !== $this->lexer->matchOptional('!');
+                    list($lowerInclusive, $lowerBound, $upperBound, $upperInclusive) = $this->lexer->rangeValue();
+
+                    if ($negative) {
+                        $this->valuesFactory->addExcludedRange(
+                            $lowerBound,
+                            $upperBound,
+                            $lowerInclusive,
+                            $upperInclusive,
+                            [$pathVal, '[lower]', '[upper]']
+                        );
+                    } else {
+                        $this->valuesFactory->addRange(
+                            $lowerBound,
+                            $upperBound,
+                            $lowerInclusive,
+                            $upperInclusive,
+                            [$pathVal, '[lower]', '[upper]']
+                        );
+                    }
+                    break;
+
+                case StringLexer::SIMPLE_VALUE:
+                    $negative = null !== $this->lexer->matchOptional('!');
+                    if ($negative) {
+                        $this->valuesFactory->addExcludedSimpleValue($this->lexer->stringValue(), $pathVal);
+                    } else {
+                        $this->valuesFactory->addSimpleValue($this->lexer->stringValue(), $pathVal);
+                    }
+                    break;
+            }
+
+            if (null !== $this->lexer->matchOptional(',') && $this->lexer->isGlimpse(';')) {
+                throw $this->lexer->createFormatException(StringLexerException::INCORRECT_VALUES_SEPARATOR);
+            }
+
+            $this->lexer->skipEmptyLines();
+
+            // We got here, so no errors.
+            $hasValues = true;
+        }
+
+        if (!$hasValues) {
+            throw $this->lexer->createFormatException(StringLexerException::FIELD_REQUIRES_VALUES);
+        }
+
+        $this->lexer->matchOptional(';');
+
+        return $valuesBag;
+    }
+}

--- a/lib/Core/Input/StringQueryInput.php
+++ b/lib/Core/Input/StringQueryInput.php
@@ -26,136 +26,15 @@ use Rollerworks\Component\Search\Value\ValuesBag;
 use Rollerworks\Component\Search\Value\ValuesGroup;
 
 /**
- * StringQuery - processes input in the StringQuery format.
- *
- * The formats works as follow (whitespace between values is ignored).
- *
- * Caution: The error message reports the character position not the byte position.
- * Multi byte may cause some problems when using substr() rather then mb_substr().
- *
- * Each query-pair is a 'field-name: value1, value2;'.
- *
- *  Query-pairs can be nested inside a group "(field-name: value1, value2;)"
- *    Subgroups are threaded as AND-case to there parent,
- *    multiple groups inside the same group are OR-case to each other.
- *
- *    By default all the query-pairs and other direct-subgroups are treated as AND-case.
- *    To make a group OR-case (any of the fields), prefix the group with '*'
- *    Example: *(field1=values; field2=values);
- *
- *    Groups are separated with a single semicolon ";".
- *    If the subgroup is last in the group the semicolon can be omitted.
- *
- *  Query-Pairs are separated with a single semicolon ";"
- *  If the query-pair is last in the group the semicolon can be omitted.
- *
- *  Each value inside a query-pair is separated with a single comma.
- *  A value containing special characters (<>[](),;~!*?=) or spaces
- *  must be surrounded by quotes.
- *
- *  Note surrounding spaces are ignored. Example: field: value , value2  ;
- *
- *  To escape a quote use it double.
- *  Example: field: "va""lue";
- *
- *  Escaped quotes will be normalized to a single one.
- *
- * Line separators are allowed for better readability, but are not allowed
- * within a value.
- *
- * Ranges
- * ======
- *
- * A range consists of two sides, lower and upper bound (inclusive by default).
- * Each side is considered a value-part and must follow the value convention (as described above).
- *
- * Example: field: 1~100; field2: -1 ~ 100
- *
- * Each side is inclusive by default, meaning 'the value' and anything lower/higher then it.
- * The left delimiter can be [ (inclusive) or ] (exclusive).
- * The right delimiter can be [ (exclusive) or ] (inclusive).
- *
- *   `]1 ~ 100`  is equal to (> 1 and <= 100)
- *   `[1 ~ 100`  is equal to (>= 1 and <= 100)
- *   `[1 ~ 100[` is equal to (>= 1 and < 100)
- *   `]1 ~ 100[` is equal to (> 1 and < 100)
- *
- *   Example:
- *     field: ]1 ~ 100;
- *     field: [1 ~ 100;
- *
- * Excluded values
- * ===============
- *
- * To mark a value as excluded (also done for ranges) prefix it with an '!'.
- *
- * Example: field: !value, !1 ~ 10;
- *
- * Comparison
- * ==========
- *
- * Comparisons are as any programming language.
- * Supported operators are: <, <=, <>, >, >=
- *
- * Followed by a value-part.
- *
- * Example: field: >= 1, < -10;
- *
- * Caution: Spaces are not allowed within the operator.
- * Invalid: > =
- *
- * PatternMatch
- * ============
- *
- * PatternMatch works similar to Comparison, everything that starts with a tilde (~)
- * is considered a pattern match. Spaces in the operator are not allowed.
- *
- * Supported operators are:
- *
- *    ~* (contains)
- *    ~> (starts with)
- *    ~< (ends with)
- *    ~? (regex matching)
- *
- * And not the NOT equivalent.
- *
- *     ~!* (does not contain)
- *     ~!> (does not start with)
- *     ~!< (does not end with)
- *     ~!? (does not match regex)
- *
- * Example: field: ~> foo, ~*"bar", ~? ^foo|bar$;
- *
- * To mark the pattern case insensitive add an 'i' directly after the '~'.
- *
- * Example: field: ~i> foo, ~i!* "bar", ~i? "^foo|bar$" ;
- *
- * Note: The regex is limited to simple POSIX expressions.
- * Actual usage is handled by the storage layer, and may not fully support complex expressions.
- *
- * Caution: Regex delimiters are not used.
+ * StringQueryInput - processes input in the StringInput syntax
+ * using the View value format.
  */
-final class StringQueryInput extends AbstractInput
+final class StringQueryInput extends StringInput
 {
-    /**
-     * @var FieldValuesByViewFactory|null
-     */
-    private $valuesFactory;
-
-    /**
-     * @var StringLexer
-     */
-    private $lexer;
-
     /**
      * @var callable
      */
     private $labelResolver;
-
-    /**
-     * @var array
-     */
-    private $fields = [];
 
     /**
      * Constructor.
@@ -169,60 +48,20 @@ final class StringQueryInput extends AbstractInput
      */
     public function __construct(Validator $validator = null, callable $labelResolver = null)
     {
-        $this->lexer = new StringLexer();
+        parent::__construct($validator);
         $this->labelResolver = $labelResolver ?? function (FieldConfig $field) {
             return $field->getOption('label', $field->getName());
         };
-
-        parent::__construct($validator);
     }
 
-    /**
-     * Process the input and returns the result.
-     *
-     * @param ProcessorConfig $config
-     * @param string          $input
-     *
-     * @throws InvalidSearchConditionException
-     *
-     * @return SearchCondition
-     */
-    public function process(ProcessorConfig $config, $input): SearchCondition
+    protected function initForProcess(ProcessorConfig $config): void
     {
-        if (!is_string($input)) {
-            throw new UnexpectedTypeException($input, 'string');
-        }
-
-        $input = trim($input);
-
-        if ('' === $input) {
-            return new SearchCondition($config->getFieldSet(), new ValuesGroup());
-        }
-
-        $condition = null;
-        $this->errors = new ErrorList();
-        $this->config = $config;
         $this->fields = $this->resolveLabels($config->getFieldSet());
-        $this->level = 0;
-
-        $this->valuesFactory = new FieldValuesByViewFactory($this->errors, $this->validator, $this->config->getMaxValues());
-
-        try {
-            $condition = new SearchCondition($config->getFieldSet(), $this->parse($config, $input));
-            $this->assertLevel0();
-        } catch (InputProcessorException $e) {
-            $this->errors[] = $e->toErrorMessageObj();
-        } finally {
-            $this->valuesFactory = null;
-        }
-
-        if (count($this->errors)) {
-            $errors = $this->errors->getArrayCopy();
-
-            throw new InvalidSearchConditionException($errors);
-        }
-
-        return $condition;
+        $this->valuesFactory = new FieldValuesByViewFactory(
+            $this->errors,
+            $this->validator,
+            $this->config->getMaxValues()
+        );
     }
 
     private function resolveLabels(FieldSet $fieldSet): array
@@ -236,177 +75,5 @@ final class StringQueryInput extends AbstractInput
         }
 
         return $labels;
-    }
-
-    private function getFieldName(string $name): string
-    {
-        if (isset($this->fields[$name])) {
-            return $this->fields[$name];
-        }
-
-        throw new UnknownFieldException($name);
-    }
-
-    /**
-     * @param ProcessorConfig $config
-     * @param string          $input
-     *
-     * @return ValuesGroup
-     */
-    private function parse(ProcessorConfig $config, $input)
-    {
-        $this->config = $config;
-        $this->lexer->parse($input);
-
-        if (null !== $this->lexer->matchOptional('*')) {
-            $valuesGroup = new ValuesGroup(ValuesGroup::GROUP_LOGICAL_OR);
-        } else {
-            $valuesGroup = new ValuesGroup(ValuesGroup::GROUP_LOGICAL_AND);
-        }
-
-        $this->lexer->skipEmptyLines();
-
-        $this->fieldValuesPairs($valuesGroup);
-
-        return $valuesGroup;
-    }
-
-    private function fieldValuesPairs(ValuesGroup $valuesGroup, string $path = '', bool $inGroup = false)
-    {
-        $groupCount = 0;
-
-        while (!$this->lexer->isEnd()) {
-            if ($this->lexer->isGlimpse('/[*&]?\s*\(/A')) {
-                $this->validateGroupsCount($groupCount + 1, $path);
-
-                ++$groupCount;
-                ++$this->level;
-
-                $valuesGroup->addGroup($this->fieldGroup($path.'['.$groupCount.']'));
-
-                --$this->level;
-
-                continue;
-            } elseif ($this->lexer->isGlimpse('/[*&]/A')) {
-                throw $this->lexer->createFormatException(StringLexerException::GROUP_LOGICAL_WITHOUT_GROUP);
-            }
-
-            if ($this->lexer->isGlimpse(')')) {
-                if ($inGroup) {
-                    break;
-                }
-
-                throw $this->lexer->createFormatException(StringLexerException::CANNOT_CLOSE_UNOPENED_GROUP);
-            }
-
-            $fieldName = $this->getFieldName($this->lexer->fieldIdentification());
-            $fieldConfig = $this->config->getFieldSet()->get($fieldName);
-
-            $this->lexer->skipEmptyLines();
-            $valuesGroup->addField(
-                $fieldName,
-                $this->fieldValues($fieldConfig, new ValuesBag(), $path)
-            );
-
-            $this->lexer->skipEmptyLines();
-        }
-    }
-
-    private function fieldGroup(string $path = ''): ValuesGroup
-    {
-        $this->validateGroupNesting($path);
-
-        if (null !== $this->lexer->matchOptional('*')) {
-            $valuesGroup = new ValuesGroup(ValuesGroup::GROUP_LOGICAL_OR);
-        } else {
-            $valuesGroup = new ValuesGroup(ValuesGroup::GROUP_LOGICAL_AND);
-        }
-
-        $this->lexer->skipWhitespace();
-        $this->lexer->expects('(');
-        $this->lexer->skipEmptyLines();
-
-        $this->fieldValuesPairs($valuesGroup, $path, true);
-
-        $this->lexer->expects(')');
-        $this->lexer->skipEmptyLines();
-
-        $this->lexer->matchOptional(';');
-        $this->lexer->skipEmptyLines();
-
-        return $valuesGroup;
-    }
-
-    private function fieldValues(FieldConfig $field, ValuesBag $valuesBag, string $path)
-    {
-        $hasValues = false;
-        $this->valuesFactory->initContext($field, $valuesBag, $path);
-
-        $pathVal = '['.$field->getName().'][%d]';
-
-        while (!$this->lexer->isEnd() && !$this->lexer->isGlimpse('/[);]/A')) {
-            $valueType = $this->lexer->detectValueType();
-
-            switch ($valueType) {
-                case StringLexer::COMPARE:
-                    list($operator, $value) = $this->lexer->comparisonValue();
-                    $this->valuesFactory->addComparisonValue($operator, $value, [$pathVal, '', '']);
-                    break;
-
-                    case StringLexer::PATTERN_MATCH:
-                    list($caseInsensitive, $type, $value) = $this->lexer->patternMatchValue();
-                    $this->valuesFactory->addPatterMatch($type, $value, $caseInsensitive, [$pathVal, '', '']);
-                    break;
-
-                case StringLexer::RANGE:
-                    $negative = null !== $this->lexer->matchOptional('!');
-                    list($lowerInclusive, $lowerBound, $upperBound, $upperInclusive) = $this->lexer->rangeValue();
-
-                    if ($negative) {
-                        $this->valuesFactory->addExcludedRange(
-                            $lowerBound,
-                            $upperBound,
-                            $lowerInclusive,
-                            $upperInclusive,
-                            [$pathVal, '[lower]', '[upper]']
-                        );
-                    } else {
-                        $this->valuesFactory->addRange(
-                            $lowerBound,
-                            $upperBound,
-                            $lowerInclusive,
-                            $upperInclusive,
-                            [$pathVal, '[lower]', '[upper]']
-                        );
-                    }
-                    break;
-
-                case StringLexer::SIMPLE_VALUE:
-                    $negative = null !== $this->lexer->matchOptional('!');
-                    if ($negative) {
-                        $this->valuesFactory->addExcludedSimpleValue($this->lexer->stringValue(), $pathVal);
-                    } else {
-                        $this->valuesFactory->addSimpleValue($this->lexer->stringValue(), $pathVal);
-                    }
-                    break;
-            }
-
-            if (null !== $this->lexer->matchOptional(',') && $this->lexer->isGlimpse(';')) {
-                throw $this->lexer->createFormatException(StringLexerException::INCORRECT_VALUES_SEPARATOR);
-            }
-
-            $this->lexer->skipEmptyLines();
-
-            // We got here, so no errors.
-            $hasValues = true;
-        }
-
-        if (!$hasValues) {
-            throw $this->lexer->createFormatException(StringLexerException::FIELD_REQUIRES_VALUES);
-        }
-
-        $this->lexer->matchOptional(';');
-
-        return $valuesBag;
     }
 }

--- a/lib/Core/Loader/ConditionExporterLoader.php
+++ b/lib/Core/Loader/ConditionExporterLoader.php
@@ -62,6 +62,9 @@ final class ConditionExporterLoader
                     'rollerworks_search.condition_exporter.string_query' => function () {
                         return new Exporter\StringQueryExporter();
                     },
+                    'rollerworks_search.condition_exporter.norm_string_query' => function () {
+                        return new Exporter\NormStringQueryExporter();
+                    },
                 ]
             ),
             [
@@ -69,6 +72,7 @@ final class ConditionExporterLoader
                 'json' => 'rollerworks_search.condition_exporter.json',
                 'xml' => 'rollerworks_search.condition_exporter.xml',
                 'string_query' => 'rollerworks_search.condition_exporter.string_query',
+                'norm_string_query' => 'rollerworks_search.condition_exporter.norm_string_query',
             ]
         );
     }

--- a/lib/Core/Loader/InputProcessorLoader.php
+++ b/lib/Core/Loader/InputProcessorLoader.php
@@ -66,6 +66,9 @@ final class InputProcessorLoader
                     'rollerworks_search.input.string_query' => function () use ($validator) {
                         return new Input\StringQueryInput($validator);
                     },
+                    'rollerworks_search.input.norm_string_query' => function () use ($validator) {
+                        return new Input\NormStringQueryInput($validator);
+                    },
                 ]
             ),
             [
@@ -73,6 +76,7 @@ final class InputProcessorLoader
                 'json' => 'rollerworks_search.input.json',
                 'xml' => 'rollerworks_search.input.xml',
                 'string_query' => 'rollerworks_search.input.string_query',
+                'norm_string_query' => 'rollerworks_search.input.norm_string_query',
             ]
         );
     }

--- a/lib/Core/Tests/Exporter/NormStringQueryExporterTest.php
+++ b/lib/Core/Tests/Exporter/NormStringQueryExporterTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Tests\Exporter;
+
+use Rollerworks\Component\Search\ConditionExporter;
+use Rollerworks\Component\Search\Exporter\NormStringQueryExporter;
+use Rollerworks\Component\Search\Exporter\StringQueryExporter;
+use Rollerworks\Component\Search\Field\FieldConfig;
+use Rollerworks\Component\Search\Input\NormStringQueryInput;
+use Rollerworks\Component\Search\Input\ProcessorConfig;
+use Rollerworks\Component\Search\Input\StringQueryInput;
+use Rollerworks\Component\Search\InputProcessor;
+use Rollerworks\Component\Search\SearchCondition;
+use Rollerworks\Component\Search\Test\SearchConditionExporterTestCase;
+use Rollerworks\Component\Search\Value\ValuesBag;
+use Rollerworks\Component\Search\Value\ValuesGroup;
+
+/**
+ * @internal
+ */
+final class NormStringQueryExporterTest extends SearchConditionExporterTestCase
+{
+    public function provideSingleValuePairTest()
+    {
+        return 'name: "value ", -value2, value2-, 10.00, "10,00", hÌ, ٤٤٤٦٥٤٦٠٠, "doctor""who""""", !value3;';
+    }
+
+    public function provideMultipleValuesTest()
+    {
+        return 'name: value, value2; date: 2014-12-16;';
+    }
+
+    public function provideRangeValuesTest()
+    {
+        return 'id: 1 ~ 10, 15 ~ 30, ]100 ~ 200, 310 ~ 400[, !50 ~ 70; date: 2014-12-16 ~ 2014-12-20;';
+    }
+
+    public function provideComparisonValuesTest()
+    {
+        return 'id: > 1, < 2, <= 5, >= 8; date: >= 2014-12-16;';
+    }
+
+    public function provideMatcherValuesTest()
+    {
+        return 'name: ~* value, ~i> value2, ~< value3, ~!* value4, ~i!* value5, ~= value9, ~!= value10, ~i= value11, ~i!= value12;';
+    }
+
+    public function provideGroupTest()
+    {
+        return 'name: value, value2; ( name: value3, value4 ); *( name: value8, value10 );';
+    }
+
+    public function provideMultipleSubGroupTest()
+    {
+        return '( name: value, value2 ); ( name: value3, value4 );';
+    }
+
+    public function provideNestedGroupTest()
+    {
+        return '( ( name: value, value2 ) );';
+    }
+
+    public function provideEmptyValuesTest()
+    {
+        return '';
+    }
+
+    public function provideEmptyGroupTest()
+    {
+        return '(  );';
+    }
+
+    protected function getExporter(): ConditionExporter
+    {
+        return new NormStringQueryExporter();
+    }
+
+    protected function getInputProcessor(): InputProcessor
+    {
+        return new NormStringQueryInput();
+    }
+}

--- a/lib/Core/Tests/Input/NormStringQueryInputTest.php
+++ b/lib/Core/Tests/Input/NormStringQueryInputTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Tests\Input;
+
+use Rollerworks\Component\Search\ConditionErrorMessage;
+use Rollerworks\Component\Search\Exception\InvalidSearchConditionException;
+use Rollerworks\Component\Search\Exception\UnknownFieldException;
+use Rollerworks\Component\Search\Extension\Core\Type\TextType;
+use Rollerworks\Component\Search\Input\ProcessorConfig;
+use Rollerworks\Component\Search\Input\NormStringQueryInput;
+use Rollerworks\Component\Search\SearchCondition;
+
+use Rollerworks\Component\Search\Extension\Core\Type\DateType;
+use Rollerworks\Component\Search\Extension\Core\Type\IntegerType;
+use Rollerworks\Component\Search\GenericFieldSetBuilder;
+use Rollerworks\Component\Search\Test\SearchIntegrationTestCase;
+use Rollerworks\Component\Search\Value\Compare;
+use Rollerworks\Component\Search\Value\PatternMatch;
+use Rollerworks\Component\Search\Value\Range;
+use Rollerworks\Component\Search\Value\ValuesBag;
+use Rollerworks\Component\Search\Value\ValuesGroup;
+
+/**
+ * Testing for the NormStringQueryInput.
+ *
+ * Note that NormStringQueryInput derives from StringInput
+ * and most of this logic is already tested by StringQueryInputTest.
+ *
+ * @internal
+ */
+final class NormStringQueryInputTest extends SearchIntegrationTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getFieldSet(bool $build = true)
+    {
+        $fieldSet = new GenericFieldSetBuilder($this->getFactory());
+        $fieldSet->add('id', IntegerType::class);
+        $fieldSet->add('name', TextType::class);
+        $fieldSet->add('lastname', TextType::class);
+        $fieldSet->add('date', DateType::class, ['pattern' => 'MM-dd-yyyy']);
+        $fieldSet->set(
+            $this->getFactory()->createField('no-range-field', IntegerType::class)
+                ->setValueTypeSupport(Range::class, false)
+        );
+
+        $fieldSet->set(
+            $this->getFactory()->createField('no-compares-field', IntegerType::class)->setValueTypeSupport(
+                Compare::class,
+                false
+            )
+        );
+
+        $fieldSet->set(
+            $this->getFactory()->createField('no-matchers-field', IntegerType::class)->setValueTypeSupport(
+                PatternMatch::class,
+                false
+            )
+        );
+
+        return $build ? $fieldSet->getFieldSet() : $fieldSet;
+    }
+
+    /**
+     * @param string $input
+     *
+     * @test
+     * @dataProvider provideMultipleValues
+     */
+    public function it_processes_multiple_fields(string $input)
+    {
+        $processor = new NormStringQueryInput();
+        $config = new ProcessorConfig($this->getFieldSet());
+
+        $expectedGroup = new ValuesGroup();
+
+        $values = new ValuesBag();
+        $values->addSimpleValue('value');
+        $values->addSimpleValue('value2');
+        $expectedGroup->addField('name', $values);
+
+        $date = new \DateTime('2014-12-16 00:00:00 UTC');
+
+        $values = new ValuesBag();
+        $values->addSimpleValue($date);
+        $expectedGroup->addField('date', $values);
+
+        $condition = new SearchCondition($config->getFieldSet(), $expectedGroup);
+        $this->assertConditionEquals($input, $condition, $processor, $config);
+    }
+
+    public function provideMultipleValues()
+    {
+        return [
+            ['name: value, value2; date: "2014-12-16 00:00:00 UTC";'],
+            ['name: value, value2; date: "2014-12-16 00:00:00"'],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function it_errors_when_the_field_does_not_exist_in_fieldset()
+    {
+        $config = new ProcessorConfig($this->getFieldSet());
+
+        $e = new UnknownFieldException('field2');
+        $error = $e->toErrorMessageObj();
+
+        try {
+            $processor = new NormStringQueryInput();
+            $processor->process($config, 'field2: value;');
+
+            $this->fail('Condition should be invalid.');
+        } catch (\Exception $e) {
+            /* @var InvalidSearchConditionException $e */
+            self::detectSystemException($e);
+            self::assertInstanceOf(InvalidSearchConditionException::class, $e);
+            self::assertEquals([$error], $e->getErrors());
+        }
+    }
+}

--- a/lib/Core/Tests/Loader/ConditionExporterLoaderTest.php
+++ b/lib/Core/Tests/Loader/ConditionExporterLoaderTest.php
@@ -50,6 +50,7 @@ final class ConditionExporterLoaderTest extends TestCase
             ['xml', Exporter\XmlExporter::class],
             ['array', Exporter\ArrayExporter::class],
             ['string_query', Exporter\StringQueryExporter::class],
+            ['norm_string_query', Exporter\NormStringQueryExporter::class],
         ];
     }
 

--- a/lib/Core/Tests/Loader/InputProcessorLoaderTest.php
+++ b/lib/Core/Tests/Loader/InputProcessorLoaderTest.php
@@ -50,6 +50,7 @@ final class InputProcessorLoaderTest extends TestCase
             ['xml', Input\XmlInput::class],
             ['array', Input\ArrayInput::class],
             ['string_query', Input\StringQueryInput::class],
+            ['norm_string_query', Input\NormStringQueryInput::class],
         ];
     }
 

--- a/lib/Processor/AbstractSearchProcessor.php
+++ b/lib/Processor/AbstractSearchProcessor.php
@@ -48,10 +48,11 @@ abstract class AbstractSearchProcessor implements SearchProcessor
      * @param ProcessorConfig   $config
      * @param string            $name
      * @param string|array|null $default
+     * @param string            $type    Eg. string or array
      *
      * @return array|null|string
      */
-    final protected function getRequestParam(array $parameters, ProcessorConfig $config, string $name, $default = null)
+    final protected function getRequestParam(array $parameters, ProcessorConfig $config, string $name, $default = null, string $type = null)
     {
         if ($prefix = $config->getRequestPrefix()) {
             $name = "[{$prefix}][{$name}]";
@@ -62,7 +63,12 @@ abstract class AbstractSearchProcessor implements SearchProcessor
         }
 
         try {
-            return $this->propertyAccessor->getValue($parameters, $name) ?? $default;
+            $value = $this->propertyAccessor->getValue($parameters, $name) ?? $default;
+            if (null !== $type && false === ('is_'.$type)($value)) {
+                return $default;
+            }
+
+            return $value;
         } catch (AccessException | UnexpectedTypeException $e) {
             return $default;
         }

--- a/lib/Symfony/SearchBundle/Resources/config/condition_exporter.xml
+++ b/lib/Symfony/SearchBundle/Resources/config/condition_exporter.xml
@@ -16,6 +16,9 @@
         <service id="rollerworks_search.exporter.string_query" class="Rollerworks\Component\Search\Exporter\StringQueryExporter">
             <tag name="rollerworks_search.condition_exporter" format="string_query" />
         </service>
+        <service id="rollerworks_search.exporter.norm_string_query" class="Rollerworks\Component\Search\Exporter\NormStringQueryExporter">
+            <tag name="rollerworks_search.condition_exporter" format="norm_string_query" />
+        </service>
         <service id="rollerworks_search.condition_exporter.array" class="Rollerworks\Component\Search\Exporter\ArrayExporter">
             <tag name="rollerworks_search.condition_exporter" format="array" />
         </service>

--- a/lib/Symfony/SearchBundle/Resources/config/input_processor.xml
+++ b/lib/Symfony/SearchBundle/Resources/config/input_processor.xml
@@ -18,6 +18,9 @@
             <tag name="rollerworks_search.input_processor" format="string_query" />
             <argument id="rollerworks_search.translator_based_alias_resolver" type="service" on-invalid="null" />
         </service>
+        <service id="rollerworks_search.input.norm_string_query" class="Rollerworks\Component\Search\Input\NormStringQueryInput" parent="rollerworks_search.input.abstract">
+            <tag name="rollerworks_search.input_processor" format="norm_string_query" />
+        </service>
         <service id="rollerworks_search.input.array" class="Rollerworks\Component\Search\Input\ArrayInput" parent="rollerworks_search.input.abstract">
             <tag name="rollerworks_search.input_processor" format="array" />
         </service>

--- a/lib/Symfony/SearchBundle/Tests/Functional/ApiPlatformTest.php
+++ b/lib/Symfony/SearchBundle/Tests/Functional/ApiPlatformTest.php
@@ -54,7 +54,7 @@ final class ApiPlatformTest extends FunctionalTestCase
         $client->request(
             'GET',
             '/books.json',
-            ['search' => ['fields' => ['title' => ['simple-values' => ['Symfony']]]]]
+            ['search' => 'title: Symfony;']
         );
 
         self::assertFalse($client->getResponse()->isRedirection());
@@ -68,12 +68,12 @@ final class ApiPlatformTest extends FunctionalTestCase
         $client->request(
             'GET',
             '/books.json',
-            ['search' => ['fields' => ['title' => ['simple-values' => ['Symfony', 'Symfony']]]]]
+            ['search' => 'title: Symfony, Symfony;']
         );
 
         $crawler = $client->followRedirect();
 
-        self::assertEquals('http://localhost/books.json?search%5Bfields%5D%5Btitle%5D%5Bsimple-values%5D%5B0%5D=Symfony', $crawler->getUri());
+        self::assertEquals('http://localhost/books.json?search=title%3A%20Symfony%3B', $crawler->getUri());
         self::assertInstanceOf(SearchCondition::class, $client->getRequest()->attributes->get('_api_search_condition'));
         self::assertEquals('[]', $client->getResponse()->getContent());
     }
@@ -81,17 +81,17 @@ final class ApiPlatformTest extends FunctionalTestCase
     public function testInvalidConditionHasErrors()
     {
         $client = self::newClient(['config' => 'api_platform.yml']);
-        $crawler = $client->request(
+        $client->request(
             'GET',
             '/books.json',
-            ['search' => ['fields' => ['id' => ['simple-values' => ['He']]]]]
+            ['search' => 'id: He;']
         );
 
         self::assertFalse($client->getResponse()->isRedirection());
-        self::assertEquals('/books.json?search%5Bfields%5D%5Bid%5D%5Bsimple-values%5D%5B0%5D=He', $client->getRequest()->getRequestUri());
+        self::assertEquals('/books.json?search=id%3A+He%3B', $client->getRequest()->getRequestUri());
         self::assertNull($client->getRequest()->attributes->get('_api_search_condition'));
         self::assertJsonStringEqualsJsonString(
-            '{"@context":"\/contexts\/ConstraintViolationList","@type":"ConstraintViolationList","hydra:title":"An error occurred","hydra:description":"[fields][id][simple-values][0]: This value is not valid.","violations":[{"propertyPath":"[fields][id][simple-values][0]","message":"This value is not valid."}]}',
+            '{"@context":"\/contexts\/ConstraintViolationList","@type":"ConstraintViolationList","hydra:title":"An error occurred","hydra:description":"[id][0]: This value is not valid.","violations":[{"propertyPath":"[id][0]","message":"This value is not valid."}]}',
             $client->getResponse()->getContent()
         );
     }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -25,6 +25,7 @@ parameters:
         - '#Psr\\SimpleCache\\DateInterval#'
         - '#Parameter \#3 \$previous of class PHPUnit\\Framework\\Exception constructor expects Exception\|null, Throwable given#'
         - '#Parameter \#1 \$range of static method Rollerworks\\Component\\Search\\Elasticsearch\\QueryConditionGenerator\:\:generateRangeParams\(\)#'
+        - '#Parameter \#3 \$format of method Rollerworks\\Component\\Search\\ApiPlatform\\Processor\\ApiSearchProcessor\:\:processInput\(\) expects string, array\|string\|null given#'
 
         ## Symony Config
         - '# Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition given#'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | Closes #176 
| License       | MIT
| Doc PR        | pending

This is a proof of RFC to allow a normalized value-format for the StringQuery syntax.

ApiPlatform integration is currently pending but I wonder what is the best way do this?
_In any siltation the NormStringQuery must be encoded for usage in the URL (SearchCode as done in the SearchProcessor component is properly not going to work as this requires a POST. Otherwise there are to many details in the client side)._

1. Allow both Array and NormStringQuery
2. Use only NormStringQuery