### PR TITLE
[ApiPlatform] Allow to set a pre-condition

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -1,3 +1,11 @@
+UPGRADE FROM 2.0-ALPHA5 to 2.0-ALPHA8
+=====================================
+
+## ApiPlatform
+
+* The `Rollerworks\Component\Search\ApiPlatform\EventListener\SearchConditionListener`
+  now requires an `EventDispatchInterface` instance as last argument.
+
 UPGRADE FROM 2.0-ALPHA2 to 2.0-ALPHA5
 =====================================
 

--- a/lib/ApiPlatform/SearchConditionEvent.php
+++ b/lib/ApiPlatform/SearchConditionEvent.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\ApiPlatform;
+
+use Rollerworks\Component\Search\SearchCondition;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * The SearchConditionEvent allows to set a pre-condition.
+ *
+ * Call getSearchCondition()->setPreCondition() to set a pre-condition.
+ *
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+final class SearchConditionEvent extends Event
+{
+    /**
+     * @Event
+     */
+    public const SEARCH_CONDITION_EVENT = 'rollerworks_search.process.pre_condition';
+
+    private $searchCondition;
+    private $resourceClass;
+    private $request;
+
+    public function __construct(?SearchCondition $searchCondition, string $resourceClass, Request $request)
+    {
+        $this->searchCondition = $searchCondition;
+        $this->resourceClass = $resourceClass;
+        $this->request = $request;
+    }
+
+    public function getSearchCondition(): ?SearchCondition
+    {
+        return $this->searchCondition;
+    }
+
+    public function getResourceClass(): string
+    {
+        return $this->resourceClass;
+    }
+
+    public function getRequest(): Request
+    {
+        return $this->request;
+    }
+}

--- a/lib/ApiPlatform/Tests/EventListener/SearchConditionListenerTest.php
+++ b/lib/ApiPlatform/Tests/EventListener/SearchConditionListenerTest.php
@@ -19,6 +19,7 @@ use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Resource\ResourceMetadata;
 use Prophecy\Argument;
 use Rollerworks\Component\Search\ApiPlatform\EventListener\SearchConditionListener;
+use Rollerworks\Component\Search\ApiPlatform\SearchConditionEvent;
 use Rollerworks\Component\Search\ApiPlatform\Tests\Fixtures\BookFieldSet;
 use Rollerworks\Component\Search\ApiPlatform\Tests\Fixtures\Dummy;
 use Rollerworks\Component\Search\FieldSet;
@@ -28,6 +29,7 @@ use Rollerworks\Component\Search\Processor\SearchProcessor;
 use Rollerworks\Component\Search\SearchCondition;
 use Rollerworks\Component\Search\Test\SearchIntegrationTestCase;
 use Rollerworks\Component\Search\Value\ValuesGroup;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -73,7 +75,8 @@ class SearchConditionListenerTest extends SearchIntegrationTestCase
         $urlGeneratorProphecy->generate(Argument::any(), Argument::any(), Argument::any())->shouldNotBeCalled();
         $urlGenerator = $urlGeneratorProphecy->reveal();
 
-        $listener = new SearchConditionListener($this->getFactory(), $searchProcessor, $urlGenerator, $resourceMetadataFactory);
+        $eventDispatcher = $this->expectingCallEventDispatcher($searchPayload, $request);
+        $listener = new SearchConditionListener($this->getFactory(), $searchProcessor, $urlGenerator, $resourceMetadataFactory, $eventDispatcher);
         $listener->onKernelRequest($event = new GetResponseEvent($httpKernel, $request, HttpKernelInterface::MASTER_REQUEST));
 
         self::assertNull($event->getResponse());
@@ -129,7 +132,8 @@ class SearchConditionListenerTest extends SearchIntegrationTestCase
         $urlGeneratorProphecy->generate(Argument::any(), Argument::any(), Argument::any())->shouldNotBeCalled();
         $urlGenerator = $urlGeneratorProphecy->reveal();
 
-        $listener = new SearchConditionListener($this->getFactory(), $searchProcessor, $urlGenerator, $resourceMetadataFactory);
+        $eventDispatcher = $this->expectingCallEventDispatcher($searchPayload, $request);
+        $listener = new SearchConditionListener($this->getFactory(), $searchProcessor, $urlGenerator, $resourceMetadataFactory, $eventDispatcher);
         $listener->onKernelRequest($event = new GetResponseEvent($httpKernel, $request, HttpKernelInterface::MASTER_REQUEST));
 
         self::assertNull($event->getResponse());
@@ -191,7 +195,8 @@ class SearchConditionListenerTest extends SearchIntegrationTestCase
 
         $urlGenerator = $urlGeneratorProphecy->reveal();
 
-        $listener = new SearchConditionListener($this->getFactory(), $searchProcessor, $urlGenerator, $resourceMetadataFactory);
+        $eventDispatcher = $this->expectingNoCallEventDispatcher();
+        $listener = new SearchConditionListener($this->getFactory(), $searchProcessor, $urlGenerator, $resourceMetadataFactory, $eventDispatcher);
         $listener->onKernelRequest($event = new GetResponseEvent($httpKernel, $request, HttpKernelInterface::MASTER_REQUEST));
 
         self::assertEquals(new RedirectResponse('/books?search[fields][id][0]=1'), $event->getResponse());
@@ -261,7 +266,8 @@ class SearchConditionListenerTest extends SearchIntegrationTestCase
 
         $urlGenerator = $urlGeneratorProphecy->reveal();
 
-        $listener = new SearchConditionListener($this->getFactory(), $searchProcessor, $urlGenerator, $resourceMetadataFactory);
+        $eventDispatcher = $this->expectingNoCallEventDispatcher();
+        $listener = new SearchConditionListener($this->getFactory(), $searchProcessor, $urlGenerator, $resourceMetadataFactory, $eventDispatcher);
         $listener->onKernelRequest($event = new GetResponseEvent($httpKernel, $request, HttpKernelInterface::MASTER_REQUEST));
 
         self::assertEquals(new RedirectResponse('/books.json?search[fields][id][0]=1'), $event->getResponse());
@@ -299,7 +305,8 @@ class SearchConditionListenerTest extends SearchIntegrationTestCase
         $urlGeneratorProphecy->generate(Argument::any(), Argument::any(), Argument::any())->shouldNotBeCalled();
         $urlGenerator = $urlGeneratorProphecy->reveal();
 
-        $listener = new SearchConditionListener($this->getFactory(), $searchProcessor, $urlGenerator, $resourceMetadataFactory);
+        $eventDispatcher = $this->expectingNoCallEventDispatcher();
+        $listener = new SearchConditionListener($this->getFactory(), $searchProcessor, $urlGenerator, $resourceMetadataFactory, $eventDispatcher);
         $listener->onKernelRequest($event = new GetResponseEvent($httpKernel, $request, HttpKernelInterface::MASTER_REQUEST));
 
         self::assertNull($event->getResponse());
@@ -326,7 +333,8 @@ class SearchConditionListenerTest extends SearchIntegrationTestCase
         $urlGeneratorProphecy->generate(Argument::any(), Argument::any(), Argument::any())->shouldNotBeCalled();
         $urlGenerator = $urlGeneratorProphecy->reveal();
 
-        $listener = new SearchConditionListener($this->getFactory(), $searchProcessor, $urlGenerator, $resourceMetadataFactory);
+        $eventDispatcher = $this->expectingNoCallEventDispatcher();
+        $listener = new SearchConditionListener($this->getFactory(), $searchProcessor, $urlGenerator, $resourceMetadataFactory, $eventDispatcher);
         $listener->onKernelRequest($event = new GetResponseEvent($httpKernel, $request, HttpKernelInterface::MASTER_REQUEST));
 
         self::assertNull($event->getResponse());
@@ -380,7 +388,8 @@ class SearchConditionListenerTest extends SearchIntegrationTestCase
         $urlGeneratorProphecy->generate(Argument::any(), Argument::any(), Argument::any())->shouldNotBeCalled();
         $urlGenerator = $urlGeneratorProphecy->reveal();
 
-        $listener = new SearchConditionListener($this->getFactory(), $searchProcessor, $urlGenerator, $resourceMetadataFactory);
+        $eventDispatcher = $this->expectingCallEventDispatcher($searchPayload, $request);
+        $listener = new SearchConditionListener($this->getFactory(), $searchProcessor, $urlGenerator, $resourceMetadataFactory, $eventDispatcher);
         $listener->onKernelRequest($event = new GetResponseEvent($httpKernel, $request, HttpKernelInterface::MASTER_REQUEST));
 
         self::assertNull($event->getResponse());
@@ -430,7 +439,8 @@ class SearchConditionListenerTest extends SearchIntegrationTestCase
         $urlGeneratorProphecy->generate(Argument::any(), Argument::any(), Argument::any())->shouldNotBeCalled();
         $urlGenerator = $urlGeneratorProphecy->reveal();
 
-        $listener = new SearchConditionListener($this->getFactory(), $searchProcessor, $urlGenerator, $resourceMetadataFactory);
+        $eventDispatcher = $this->expectingNoCallEventDispatcher();
+        $listener = new SearchConditionListener($this->getFactory(), $searchProcessor, $urlGenerator, $resourceMetadataFactory, $eventDispatcher);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage($message);
@@ -515,5 +525,25 @@ class SearchConditionListenerTest extends SearchIntegrationTestCase
         $fieldSet->getSetName()->willReturn($setName);
 
         return new SearchCondition($fieldSet->reveal(), new ValuesGroup());
+    }
+
+    private function expectingCallEventDispatcher(SearchPayload $searchPayload, Request $request): EventDispatcherInterface
+    {
+        $event = new SearchConditionEvent($searchPayload->searchCondition, Dummy::class, $request);
+
+        $eventDispatcherProphecy = $this->prophesize(EventDispatcherInterface::class);
+        $eventDispatcherProphecy->dispatch(SearchConditionEvent::SEARCH_CONDITION_EVENT, $event)->shouldBeCalled();
+        $eventDispatcherProphecy->dispatch(SearchConditionEvent::SEARCH_CONDITION_EVENT.Dummy::class, $event)->shouldBeCalled();
+
+        return $eventDispatcherProphecy->reveal();
+    }
+
+    private function expectingNoCallEventDispatcher(): EventDispatcherInterface
+    {
+        $eventDispatcherProphecy = $this->prophesize(EventDispatcherInterface::class);
+        $eventDispatcherProphecy->dispatch(SearchConditionEvent::SEARCH_CONDITION_EVENT, Argument::any())->shouldNotBeCalled();
+        $eventDispatcherProphecy->dispatch(SearchConditionEvent::SEARCH_CONDITION_EVENT.Dummy::class, Argument::any())->shouldNotBeCalled();
+
+        return $eventDispatcherProphecy->reveal();
     }
 }

--- a/lib/Symfony/SearchBundle/Resources/config/api_platform.xml
+++ b/lib/Symfony/SearchBundle/Resources/config/api_platform.xml
@@ -24,6 +24,7 @@
             <argument type="service" id="rollerworks_search.api_platform.search_processor" />
             <argument type="service" id="api_platform.router" />
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
+            <argument type="service" id="event_dispatcher" />
 
             <!-- kernel.request priority must be < 8 && > 4 to be executed after the Firewall but before ReadListener -->
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="5" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #182
| License       | MIT
| Doc PR        | pending

The SearchConditionListener dispatches an event to allow setting a pre-condition for QueryGenerator’s.

First a specific event is dispatched for the resource-class, and then a ‘generic’ event to allow for ease of listening _and_ enforcing ‘global’ defaults.