### PR TITLE
[Doctrine] Fix Cache key ignoring precondition

### DIFF
--- a/lib/Doctrine/Dbal/CachedConditionGenerator.php
+++ b/lib/Doctrine/Dbal/CachedConditionGenerator.php
@@ -140,6 +140,8 @@ final class CachedConditionGenerator implements ConditionGenerator
                 "\n".
                 serialize($searchCondition->getValuesGroup()).
                 "\n".
+                serialize($searchCondition->getPreCondition()).
+                "\n".
                 serialize($this->conditionGenerator->getFieldsMapping())
             );
         }

--- a/lib/Doctrine/Dbal/Tests/CachedConditionGeneratorTest.php
+++ b/lib/Doctrine/Dbal/Tests/CachedConditionGeneratorTest.php
@@ -13,13 +13,17 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Tests\Doctrine\Dbal;
 
+use Doctrine\DBAL\Types\Type;
 use Psr\SimpleCache\CacheInterface as Cache;
 use Rollerworks\Component\Search\Doctrine\Dbal\CachedConditionGenerator;
 use Rollerworks\Component\Search\Doctrine\Dbal\ConditionGenerator;
+use Rollerworks\Component\Search\Doctrine\Dbal\Query\QueryField;
 use Rollerworks\Component\Search\Doctrine\Dbal\SqlConditionGenerator;
+use Rollerworks\Component\Search\FieldSet;
 use Rollerworks\Component\Search\GenericFieldSet;
 use Rollerworks\Component\Search\SearchCondition;
 use Rollerworks\Component\Search\SearchConditionBuilder;
+use Rollerworks\Component\Search\SearchPreCondition;
 use Rollerworks\Component\Search\Value\ValuesGroup;
 
 final class CachedConditionGeneratorTest extends DbalTestCase
@@ -236,6 +240,36 @@ final class CachedConditionGeneratorTest extends DbalTestCase
         self::assertEquals('((I.id IN(18)))', $this->cachedConditionGenerator->getWhereClause());
     }
 
+    public function testGetWhereClauseCachedAndPreCond()
+    {
+        $fieldSet = $this->getFieldSet();
+
+        $cacheDriver = $this->prophesize(Cache::class);
+        $cacheDriver->has('7503457faa505a978544359616a2b503638538170931ce460b69fcf35566f771')->willReturn(true);
+        $cacheDriver->get('7503457faa505a978544359616a2b503638538170931ce460b69fcf35566f771')->willReturn("me = 'foo'");
+
+        $cacheDriver->has('cb136884ef8b94935e3df27498f8882cce67a40ba5f6e6eb30ba7c6b4db65841')->willReturn(true);
+        $cacheDriver->get('cb136884ef8b94935e3df27498f8882cce67a40ba5f6e6eb30ba7c6b4db65841')->willReturn("you = 'me' AND me = 'foo'");
+
+        $cachedConditionGenerator = $this->createCachedConditionGenerator(
+            $cacheDriver->reveal(),
+            new SearchCondition($fieldSet, new ValuesGroup()),
+            "me = 'foo'"
+        );
+
+        $searchCondition = new SearchCondition($fieldSet, new ValuesGroup());
+        $searchCondition->setPreCondition(new SearchPreCondition(new ValuesGroup()));
+
+        $cachedConditionGenerator2 = $this->createCachedConditionGenerator(
+            $cacheDriver->reveal(),
+            $searchCondition,
+            "you = 'me' AND me = 'foo2'"
+        );
+
+        self::assertEquals("me = 'foo'", $cachedConditionGenerator->getWhereClause());
+        self::assertEquals("you = 'me' AND me = 'foo'", $cachedConditionGenerator2->getWhereClause());
+    }
+
     protected function setUp()
     {
         parent::setUp();
@@ -247,5 +281,17 @@ final class CachedConditionGeneratorTest extends DbalTestCase
 
         $this->conditionGenerator->expects(self::any())->method('getSearchCondition')->willReturn($searchCondition);
         $this->cachedConditionGenerator = new CachedConditionGenerator($this->conditionGenerator, $this->cacheDriver, 60);
+    }
+
+    private function createCachedConditionGenerator(Cache $cacheDriver, SearchCondition $searchCondition, string $query): CachedConditionGenerator
+    {
+        $conditionGenerator = $this->prophesize(ConditionGenerator::class);
+        $conditionGenerator->getWhereClause()->willReturn($query);
+        $conditionGenerator->getFieldsMapping()->willReturn([
+            'id' => [new QueryField('id', $searchCondition->getFieldSet()->get('id'), Type::getType('integer'), 'id', 'i')]
+        ]);
+        $conditionGenerator->getSearchCondition()->willReturn($searchCondition);
+
+        return new CachedConditionGenerator($conditionGenerator->reveal(), $cacheDriver, 60);
     }
 }

--- a/lib/Doctrine/Orm/CachedDqlConditionGenerator.php
+++ b/lib/Doctrine/Orm/CachedDqlConditionGenerator.php
@@ -179,6 +179,8 @@ class CachedDqlConditionGenerator extends AbstractCachedConditionGenerator
                 "\n".
                 serialize($searchCondition->getValuesGroup()).
                 "\n".
+                serialize($searchCondition->getPreCondition()).
+                "\n".
                 serialize($this->conditionGenerator->getFieldsConfig()->getFields())
             );
         }

--- a/lib/Doctrine/Orm/CachedNativeQueryConditionGenerator.php
+++ b/lib/Doctrine/Orm/CachedNativeQueryConditionGenerator.php
@@ -116,6 +116,8 @@ class CachedNativeQueryConditionGenerator extends AbstractCachedConditionGenerat
                 "\n".
                 serialize($searchCondition->getValuesGroup()).
                 "\n".
+                serialize($searchCondition->getPreCondition()).
+                "\n".
                 serialize($this->conditionGenerator->getFieldsConfig()->getFields())
             );
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | n/a

The Doctrine DBAL/ORM Condition Caches did not include the pre-condition when computing the cache-key.

The PreCondition is part of the generated Query but the cache key doesn't change for a different PreCondition. If a non-restricting PreCondition was used before, the second cache hit will use this, ignoring the PreCondition with restrictions!

In practice leading to an information disclosure.
