### PR TITLE
[Core] Allow custom value Lexers for StringInput

### DIFF
--- a/lib/Core/Exporter/AbstractExporter.php
+++ b/lib/Core/Exporter/AbstractExporter.php
@@ -43,12 +43,14 @@ abstract class AbstractExporter implements ConditionExporter
     /**
      * Transforms the model value to a view representation.
      *
+     * @internal
+     *
      * @param mixed       $value
      * @param FieldConfig $field
      *
      * @return string
      */
-    protected function modelToView($value, FieldConfig $field): string
+    public function modelToView($value, FieldConfig $field): string
     {
         $transformer = $field->getViewTransformer();
 
@@ -76,12 +78,14 @@ abstract class AbstractExporter implements ConditionExporter
     /**
      * Transforms the model value to a normalized version.
      *
+     * @internal
+     *
      * @param mixed       $value
      * @param FieldConfig $field
      *
      * @return string
      */
-    protected function modelToNorm($value, FieldConfig $field): string
+    public function modelToNorm($value, FieldConfig $field): string
     {
         $transformer = $field->getNormTransformer() ?? $field->getViewTransformer();
 

--- a/lib/Core/Exporter/NormStringQueryExporter.php
+++ b/lib/Core/Exporter/NormStringQueryExporter.php
@@ -15,7 +15,7 @@ namespace Rollerworks\Component\Search\Exporter;
 
 use Rollerworks\Component\Search\Field\FieldConfig;
 use Rollerworks\Component\Search\FieldSet;
-use Rollerworks\Component\Search\SearchCondition;
+use Rollerworks\Component\Search\Input\NormStringQueryInput;
 
 /**
  * Exports the SearchCondition as StringQuery string.
@@ -24,9 +24,19 @@ use Rollerworks\Component\Search\SearchCondition;
  */
 final class NormStringQueryExporter extends StringExporter
 {
-    protected function modelToExported($value, FieldConfig $field): string
+    protected function modelToExported($value, FieldConfig $field, string $allowedNext = ',;)'): string
     {
-        return $this->modelToNorm($value, $field);
+        $valueExporter = $field->getOption(NormStringQueryInput::VALUE_EXPORTER_OPTION_NAME);
+
+        if (true === $valueExporter) {
+            return $this->modelToNorm($value, $field);
+        }
+
+        if (is_callable($valueExporter)) {
+            return $valueExporter($value, [$this, 'modelToNorm'], $field);
+        }
+
+        return $this->exportValueAsString($this->modelToNorm($value, $field));
     }
 
     protected function resolveLabels(FieldSet $fieldSet): array

--- a/lib/Core/Extension/Core/Type/SearchFieldType.php
+++ b/lib/Core/Extension/Core/Type/SearchFieldType.php
@@ -16,6 +16,8 @@ namespace Rollerworks\Component\Search\Extension\Core\Type;
 use Rollerworks\Component\Search\Extension\Core\ValueComparator\SimpleValueComparator;
 use Rollerworks\Component\Search\Field\AbstractFieldType;
 use Rollerworks\Component\Search\Field\FieldConfig;
+use Rollerworks\Component\Search\Input\NormStringQueryInput;
+use Rollerworks\Component\Search\Input\StringQueryInput;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -56,11 +58,19 @@ final class SearchFieldType extends AbstractFieldType
                 'translation_domain' => 'messages',
                 'invalid_message' => 'This value is not valid.',
                 'invalid_message_parameters' => [],
+                StringQueryInput::FIELD_LEXER_OPTION_NAME => null,
+                NormStringQueryInput::FIELD_LEXER_OPTION_NAME => null,
+                StringQueryInput::VALUE_EXPORTER_OPTION_NAME => null,
+                NormStringQueryInput::VALUE_EXPORTER_OPTION_NAME => null,
             ]
         );
 
         $resolver->setAllowedTypes('invalid_message', ['string']);
         $resolver->setAllowedTypes('invalid_message_parameters', ['array']);
+        $resolver->setAllowedTypes(StringQueryInput::FIELD_LEXER_OPTION_NAME, ['null', \Closure::class]);
+        $resolver->setAllowedTypes(StringQueryInput::VALUE_EXPORTER_OPTION_NAME, ['null', 'bool', \Closure::class]);
+        $resolver->setAllowedTypes(NormStringQueryInput::FIELD_LEXER_OPTION_NAME, ['null', \Closure::class]);
+        $resolver->setAllowedTypes(NormStringQueryInput::VALUE_EXPORTER_OPTION_NAME, ['null', 'bool', \Closure::class]);
     }
 
     /**

--- a/lib/Core/Input/NormStringQueryInput.php
+++ b/lib/Core/Input/NormStringQueryInput.php
@@ -13,32 +13,32 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Input;
 
-use Rollerworks\Component\Search\FieldSet;
-
 /**
  * NormStringQueryInput - processes input in the StringInput syntax
  * using the Normalized value format.
  */
 final class NormStringQueryInput extends StringInput
 {
+    public const FIELD_LEXER_OPTION_NAME = 'norm_string_query.value_lexer';
+    public const VALUE_EXPORTER_OPTION_NAME = 'norm_string_query.value_exporter';
+
     protected function initForProcess(ProcessorConfig $config): void
     {
-        $this->fields = $this->resolveFieldNames($config->getFieldSet());
+        $names = [];
+
+        foreach ($config->getFieldSet()->all() as $name => $field) {
+            $names[$name] = $name;
+
+            if (null !== $customerMatcher = $field->getOption(self::FIELD_LEXER_OPTION_NAME)) {
+                $this->valueLexers[$name] = $customerMatcher;
+            }
+        }
+
+        $this->fields = $names;
         $this->valuesFactory = new FieldValuesFactory(
             $this->errors,
             $this->validator,
             $this->config->getMaxValues()
         );
-    }
-
-    private function resolveFieldNames(FieldSet $fieldSet): array
-    {
-        $names = [];
-
-        foreach ($fieldSet->all() as $name => $field) {
-            $names[$name] = $name;
-        }
-
-        return $names;
     }
 }

--- a/lib/Core/Test/SearchConditionExporterTestCase.php
+++ b/lib/Core/Test/SearchConditionExporterTestCase.php
@@ -16,6 +16,7 @@ namespace Rollerworks\Component\Search\Test;
 use Rollerworks\Component\Search\ConditionExporter;
 use Rollerworks\Component\Search\Extension\Core\Type\DateType;
 use Rollerworks\Component\Search\Extension\Core\Type\IntegerType;
+use Rollerworks\Component\Search\Extension\Core\Type\MoneyType;
 use Rollerworks\Component\Search\Extension\Core\Type\TextType;
 use Rollerworks\Component\Search\GenericFieldSetBuilder;
 use Rollerworks\Component\Search\Input\ProcessorConfig;
@@ -44,11 +45,16 @@ abstract class SearchConditionExporterTestCase extends SearchIntegrationTestCase
      */
     protected function getFieldSet(bool $build = true)
     {
+        $priceField = $this->getFactory()->createField('price', MoneyType::class);
+        $priceField->setNormTransformer(null);
+        $priceField->setViewTransformer(null);
+
         $fieldSet = new GenericFieldSetBuilder($this->getFactory());
         $fieldSet->add('id', IntegerType::class);
         $fieldSet->add('name', TextType::class);
         $fieldSet->add('lastname', TextType::class);
         $fieldSet->add('date', DateType::class, ['pattern' => 'MM-dd-yyyy']);
+        $fieldSet->set($priceField);
 
         return $build ? $fieldSet->getFieldSet() : $fieldSet;
     }
@@ -73,7 +79,6 @@ abstract class SearchConditionExporterTestCase extends SearchIntegrationTestCase
         $values->addSimpleValue('٤٤٤٦٥٤٦٠٠');
         $values->addSimpleValue('doctor"who""');
         $values->addExcludedSimpleValue('value3');
-
         $expectedGroup->addField('name', $values);
 
         $condition = new SearchCondition($config->getFieldSet(), $expectedGroup);

--- a/lib/Core/Tests/Exporter/StringQueryExporterTest.php
+++ b/lib/Core/Tests/Exporter/StringQueryExporterTest.php
@@ -62,9 +62,44 @@ final class StringQueryExporterTest extends SearchConditionExporterTestCase
         $processor->process($config, 'firstname: value, value2;');
     }
 
+    /**
+     * @test
+     */
+    public function it_exporters_values()
+    {
+        $exporter = $this->getExporter();
+        $config = new ProcessorConfig($this->getFieldSet());
+
+        $expectedGroup = new ValuesGroup();
+
+        $values = new ValuesBag();
+        $values->addSimpleValue('value ');
+        $values->addSimpleValue('-value2');
+        $values->addSimpleValue('value2-');
+        $values->addSimpleValue('10.00');
+        $values->addSimpleValue('10,00');
+        $values->addSimpleValue('hÌ');
+        $values->addSimpleValue('٤٤٤٦٥٤٦٠٠');
+        $values->addSimpleValue('doctor"who""');
+        $values->addExcludedSimpleValue('value3');
+        $expectedGroup->addField('name', $values);
+
+        $values = new ValuesBag();
+        $values->addSimpleValue('€ 12.00');
+        $values->addSimpleValue('12,00 $');
+        $values->addSimpleValue('$ 12.00');
+        $expectedGroup->addField('price', $values);
+
+        $condition = new SearchCondition($config->getFieldSet(), $expectedGroup);
+        $this->assertExportEquals($this->provideSingleValuePairTest(), $exporter->exportCondition($condition));
+
+        $processor = $this->getInputProcessor();
+        $this->assertConditionEquals($this->provideSingleValuePairTest(), $condition, $processor, $config);
+    }
+
     public function provideSingleValuePairTest()
     {
-        return 'name: "value ", -value2, value2-, 10.00, "10,00", hÌ, ٤٤٤٦٥٤٦٠٠, "doctor""who""""", !value3;';
+        return 'name: "value ", -value2, value2-, 10.00, "10,00", hÌ, ٤٤٤٦٥٤٦٠٠, "doctor""who""""", !value3; price: € 12.00, "12,00 $", $ 12.00;';
     }
 
     public function provideMultipleValuesTest()

--- a/lib/Core/Tests/Input/NormStringQueryInputTest.php
+++ b/lib/Core/Tests/Input/NormStringQueryInputTest.php
@@ -21,6 +21,7 @@ use Rollerworks\Component\Search\Extension\Core\Type\TextType;
 use Rollerworks\Component\Search\GenericFieldSetBuilder;
 use Rollerworks\Component\Search\Input\NormStringQueryInput;
 use Rollerworks\Component\Search\Input\ProcessorConfig;
+use Rollerworks\Component\Search\Input\StringLexer;
 use Rollerworks\Component\Search\SearchCondition;
 use Rollerworks\Component\Search\Test\SearchIntegrationTestCase;
 use Rollerworks\Component\Search\Value\Compare;
@@ -28,6 +29,7 @@ use Rollerworks\Component\Search\Value\PatternMatch;
 use Rollerworks\Component\Search\Value\Range;
 use Rollerworks\Component\Search\Value\ValuesBag;
 use Rollerworks\Component\Search\Value\ValuesGroup;
+use Rollerworks\Component\Search\ValueComparator;
 
 /**
  * Testing for the NormStringQueryInput.
@@ -68,6 +70,42 @@ final class NormStringQueryInputTest extends SearchIntegrationTestCase
             )
         );
 
+        $field = $this->getFactory()->createField(
+            'geo',
+            TextType::class,
+            [
+                NormStringQueryInput::FIELD_LEXER_OPTION_NAME => function (StringLexer $lexer): string {
+                    $result = $lexer->expects('(');
+                    $result .= $lexer->expects('/-?\d+,\h*-?\d+/A', 'Geographic points 12,24');
+                    $result .= $lexer->expects(')');
+
+                    return $result;
+                },
+            ]
+        );
+
+        $field->setValueTypeSupport(Compare::class, true);
+        $field->setValueTypeSupport(Range::class, true);
+        $field->setValueTypeSupport(PatternMatch::class, false);
+        $field->setValueComparator(new class() implements ValueComparator {
+            public function isHigher($higher, $lower, array $options): bool
+            {
+                return false;
+            }
+
+            public function isLower($lower, $higher, array $options): bool
+            {
+                return true;
+            }
+
+            public function isEqual($value, $nextValue, array $options): bool
+            {
+                return false;
+            }
+        });
+
+        $fieldSet->set($field);
+
         return $build ? $fieldSet->getFieldSet() : $fieldSet;
     }
 
@@ -105,6 +143,26 @@ final class NormStringQueryInputTest extends SearchIntegrationTestCase
             ['name: value, value2; date: "2014-12-16 00:00:00 UTC";'],
             ['name: value, value2; date: "2014-12-16 00:00:00"'],
         ];
+    }
+
+    /**
+     * @test
+     */
+    public function it_processes_with_customer_value_lexer()
+    {
+        $processor = new NormStringQueryInput();
+        $config = new ProcessorConfig($this->getFieldSet());
+
+        $expectedGroup = new ValuesGroup();
+
+        $values = new ValuesBag();
+        $values->addSimpleValue('(12,24)');
+        $values->add(new Compare('(12,24)', '>'));
+        $values->add(new Range('(12,24)', '(12,25)'));
+        $expectedGroup->addField('geo', $values);
+
+        $condition = new SearchCondition($config->getFieldSet(), $expectedGroup);
+        $this->assertConditionEquals('geo: (12,24), >(12,24), (12,24)~(12,25);', $condition, $processor, $config);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #185 
| License       | MIT
| Doc PR        | (pending)

This allows to use a custom Lexer operation for field values in StringInput (`NormStringQueryInput` and `StringQueryInput`).

To use this new feature, the FieldConfiguration (FieldType) must configure (set) a lexical callback (Closure) which is called whenever a value-part is "analyzed" (being matched). That's it.

In practice you set eg. the `norm_string_query.value_lexer` option (and/or `string_query.value_lexer` respectively) with the following Closure:

```php
function (StringLexer $lexer): string {
    $result = $lexer->expects('(');
    $result .= $lexer->expects('/-?\d+,\h*-?\d+/A', 'Geographic points; eg. 12,24');
    $result .= $lexer->expects(')');

    return $result;
}
```

Which matches a value like `(24, 28)`.

**Note:** The field still needs a DataTransformer, this is only allow to allow a complex value syntax without having to quote everything.

The PatternMatch value-type does not use the custom value-lexer as this type is mainly for text.