### PR TITLE
[Api-platform] Automatically detect search-format

### DIFF
--- a/lib/ApiPlatform/Processor/ApiSearchProcessor.php
+++ b/lib/ApiPlatform/Processor/ApiSearchProcessor.php
@@ -26,7 +26,11 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * ApiSearchProcessor handles a search provided with a Symfony Request.
  *
- * The input search condition must be provided as a NormStringQuery.
+ * The search-query needs to be provided as either a string (norm_string_query)
+ * or as an array. The default search-format is silently ignored.
+ *
+ * Note: Unlike the Psr7SearchProcessor the exportedCondition must be used
+ * for the URI, the search-code is used caching only and cannot be processed.
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
@@ -60,7 +64,7 @@ final class ApiSearchProcessor extends AbstractSearchProcessor
         }
 
         $input = $request->query->get('search', '');
-        $format = $this->getRequestParam($request->query->all(), $config, 'search-format', $config->getDefaultFormat(), 'string');
+        $format = is_array($input) ? 'array' : 'norm_string_query';
         $payload = $this->processInput($config, $input, $format);
 
         if (!$payload->changed && !empty($input) && $input !== $payload->exportedCondition) {

--- a/lib/ApiPlatform/Tests/Processor/ApiSearchProcessorTest.php
+++ b/lib/ApiPlatform/Tests/Processor/ApiSearchProcessorTest.php
@@ -117,7 +117,7 @@ final class ApiSearchProcessorTest extends SearchIntegrationTestCase
     public function testProcessSearchCodeFromQueryAsArray()
     {
         $config = new ProcessorConfig($this->fieldSet);
-        $request = Request::create('/books', 'GET', ['search-format' => 'array', 'search' => ['fields' => ['title' => ['simple-values' => ['Symfony']]]]]);
+        $request = Request::create('/books', 'GET', ['search' => ['fields' => ['title' => ['simple-values' => ['Symfony']]]]]);
 
         $payload = $this->createProcessor()->processRequest($request, $config);
 
@@ -333,7 +333,7 @@ final class ApiSearchProcessorTest extends SearchIntegrationTestCase
     public function testProcessSearchCodeFromArrayQueryWithNoCache()
     {
         $config = new ProcessorConfig($this->fieldSet, 'norm_string_query');
-        $request = Request::create('/books', 'GET', ['search-format' => 'array', 'search' => ['fields' => ['title' => ['simple-values' => ['Symfony']]]]]);
+        $request = Request::create('/books', 'GET', ['search' => ['fields' => ['title' => ['simple-values' => ['Symfony']]]]]);
 
         $this->cache
             ->expects(self::once())
@@ -367,7 +367,7 @@ final class ApiSearchProcessorTest extends SearchIntegrationTestCase
     public function testProcessSearchCodeFromArrayQueryStoresOptimized()
     {
         $config = new ProcessorConfig($this->fieldSet);
-        $request = Request::create('/books', 'GET', ['search-format' => 'array', 'search' => ['fields' => ['title' => ['simple-values' => ['Symfony', 'Symfony']]]]]);
+        $request = Request::create('/books', 'GET', ['search' => ['fields' => ['title' => ['simple-values' => ['Symfony', 'Symfony']]]]]);
 
         $this->cache
             ->expects(self::once())
@@ -403,7 +403,7 @@ final class ApiSearchProcessorTest extends SearchIntegrationTestCase
         // This condition would have given an transformer error,
         // so getting one means the transformer was never executed.
         $config = new ProcessorConfig($this->fieldSet);
-        $request = Request::create('/books', 'GET', ['search-format' => 'array', 'search' => ['fields' => ['id' => ['simple-values' => ['He']]]]]);
+        $request = Request::create('/books', 'GET', ['search' => ['fields' => ['id' => ['simple-values' => ['He']]]]]);
 
         $storedPayload = new SearchPayload(false);
         $storedPayload->searchCondition = $this->getFactory()->getSerializer()->serialize($this->condition);
@@ -448,19 +448,19 @@ final class ApiSearchProcessorTest extends SearchIntegrationTestCase
         $this->cache
             ->expects(self::once())
             ->method('get')
-            ->with('097af4e25add550ba5efe087202af72fee0490b45197d8acb15daf747307429a')
+            ->with('f46ae6c70dbd72c18cf3d24623c30aedfc277831cc05f147d925ed26ebff54b1')
             ->willReturn($storedPayload);
 
         $this->cache
             ->expects(self::once())
             ->method('delete')
-            ->with('097af4e25add550ba5efe087202af72fee0490b45197d8acb15daf747307429a');
+            ->with('f46ae6c70dbd72c18cf3d24623c30aedfc277831cc05f147d925ed26ebff54b1');
 
         $payload = new SearchPayload();
         $payload->searchCondition = $this->condition;
         $payload->searchCode = 'S:title%3A+Symfony%3B';
         $payload->exportedCondition = 'title: Symfony;';
-        $payload->exportedFormat = 'string_query';
+        $payload->exportedFormat = 'norm_string_query';
         $payload->messages = [];
 
         $newPayload = clone $payload;
@@ -469,7 +469,7 @@ final class ApiSearchProcessorTest extends SearchIntegrationTestCase
         $this->cache
             ->expects(self::once())
             ->method('set')
-            ->with('097af4e25add550ba5efe087202af72fee0490b45197d8acb15daf747307429a', $newPayload);
+            ->with('f46ae6c70dbd72c18cf3d24623c30aedfc277831cc05f147d925ed26ebff54b1', $newPayload);
 
         $payload = $this->createProcessor()->processRequest($request, $config);
 
@@ -477,7 +477,7 @@ final class ApiSearchProcessorTest extends SearchIntegrationTestCase
         self::assertTrue($payload->isValid());
         self::assertEmpty($payload->messages);
         self::assertEquals($this->condition, $payload->searchCondition);
-        self::assertEquals('string_query', $payload->exportedFormat);
+        self::assertEquals('norm_string_query', $payload->exportedFormat);
         self::assertEquals('title: Symfony;', $payload->exportedCondition);
         self::assertEquals('S:title%3A+Symfony%3B', $payload->searchCode);
     }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -18,14 +18,11 @@ parameters:
         - '#Call to an undefined static method Money\\Money\:\:#'
         - '#Call to an undefined method Exception\:\:getErrors\(\)#'
         - '#Call to an undefined method object\:\:[a-z]+\(\)#i'
-        - '#Parameter \$ttl of method Rollerworks\\Component\\Search\\ApiPlatform\\Processor\\NullCache\:\:set#'
         - '#Parameter \#\d \$searchCondition of class Rollerworks\\Component\\Search\\ApiPlatform\\SearchConditionEvent constructor expects Rollerworks\\Component\\Search\\SearchCondition\|null, array\|Rollerworks\\Component\\Search\\SearchCondition\|null given#'
         - '#Strict comparison using [!=]== between (null|string) and (float\|int|string) will always evaluate to (true|false)#'
         - '#Strict comparison using !== between (false|null) and (array\|true|int) will always evaluate to true#'
-        - '#Psr\\SimpleCache\\DateInterval#'
         - '#Parameter \#3 \$previous of class PHPUnit\\Framework\\Exception constructor expects Exception\|null, Throwable given#'
         - '#Parameter \#1 \$range of static method Rollerworks\\Component\\Search\\Elasticsearch\\QueryConditionGenerator\:\:generateRangeParams\(\)#'
-        - '#Parameter \#3 \$format of method Rollerworks\\Component\\Search\\ApiPlatform\\Processor\\ApiSearchProcessor\:\:processInput\(\) expects string, array\|string\|null given#'
 
         ## Symony Config
         - '# Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition given#'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | Closes #214
| License       | MIT
| Doc PR        | rollerworks/search-docs#... <!--highly recommended for new features-->

If the input is an array use the ArrayInput processor otherwise a string is expected for norm_string_query. The (default) search-format is silently ignored.

This makes the usage of API-Platform SearchProcessor easier and allows for using array by a client-side (either React/Angular, etc) or a Normalized StringQuery for communicating by 3rd party client.

Related to https://github.com/rollerworks/search/pull/202#issuecomment-350550520