### PR TITLE
[ApiPlatform] Ensure a SearchCondition is present

### DIFF
--- a/lib/ApiPlatform/Processor/ApiSearchProcessor.php
+++ b/lib/ApiPlatform/Processor/ApiSearchProcessor.php
@@ -20,7 +20,9 @@ use Rollerworks\Component\Search\Loader\InputProcessorLoader;
 use Rollerworks\Component\Search\Processor\AbstractSearchProcessor;
 use Rollerworks\Component\Search\Processor\ProcessorConfig;
 use Rollerworks\Component\Search\Processor\SearchPayload;
+use Rollerworks\Component\Search\SearchCondition;
 use Rollerworks\Component\Search\SearchFactory;
+use Rollerworks\Component\Search\Value\ValuesGroup;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -80,6 +82,9 @@ final class ApiSearchProcessor extends AbstractSearchProcessor
         $payload->searchCode = '';
 
         if ([] === $input || (is_scalar($input) && '' === trim((string) $input))) {
+            // Input is empty, but a SearchCondition should always be set to allow for a pre-condition.
+            $payload->searchCondition = new SearchCondition($config->getFieldSet(), new ValuesGroup());
+
             return $payload;
         }
 

--- a/lib/ApiPlatform/Tests/Processor/ApiSearchProcessorTest.php
+++ b/lib/ApiPlatform/Tests/Processor/ApiSearchProcessorTest.php
@@ -93,7 +93,7 @@ final class ApiSearchProcessorTest extends SearchIntegrationTestCase
         self::assertFalse($payload->isChanged());
         self::assertTrue($payload->isValid());
         self::assertEmpty($payload->messages);
-        self::assertNull($payload->searchCondition);
+        self::assertEquals(new SearchCondition($config->getFieldSet(), new ValuesGroup()), $payload->searchCondition);
         self::assertNull($payload->exportedFormat);
         self::assertEmpty($payload->searchCode);
     }
@@ -210,7 +210,7 @@ final class ApiSearchProcessorTest extends SearchIntegrationTestCase
 
         self::assertTrue($payload->isValid());
         self::assertFalse($payload->isChanged());
-        self::assertNull($payload->searchCondition);
+        self::assertEquals(new SearchCondition($config->getFieldSet(), new ValuesGroup()), $payload->searchCondition);
         self::assertEquals('', $payload->exportedCondition);
         self::assertEquals('', $payload->searchCode);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #216 
| License       | MIT
| Doc PR        | 

The ApiSearchProcessor now always ensures a SearchCondition is set, even the condition is empty.
Which allows to set a pre-condition, when there is no actual SearchCondition.

Only in the case of a format error or validation constraint violation the SearchCondition is empty, but this is already handled by the Symfony API-Platform ExceptionHandler.