### PR TITLE
[ApiPlatform] Deprecate support for ArrayInput

### DIFF
--- a/lib/ApiPlatform/EventListener/SearchConditionListener.php
+++ b/lib/ApiPlatform/EventListener/SearchConditionListener.php
@@ -162,7 +162,16 @@ final class SearchConditionListener
     private function getCondition(Request $request, ProcessorConfig $config): SearchCondition
     {
         $input = $request->query->get('search', '');
-        $format = is_array($input) ? 'array' : 'norm_string_query';
+
+        if (is_array($input)) {
+            @trigger_error('ArrayInput is no longer supported, and will throw an exception after v2.0.0-ALPHA11, use a json object instead.', E_USER_DEPRECATED);
+
+            $input = json_encode($input);
+            $format = 'json';
+        } else {
+            $format = '{' === ($input[0] ?? 'n') ? 'json' : 'norm_string_query';
+        }
+
         $inputProcessor = $this->inputProcessorLoader->get($format);
 
         if (null !== $this->cache && null !== $ttl = $config->getCacheTTL()) {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -33,4 +33,8 @@
         </whitelist>
     </filter>
 
+    <listeners>
+        <listener class="\Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
+
 </phpunit>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

Using an ArrayInput is extreme verbose and can be easier solved using a JSON string, the SearchConditionListener automatically detects if a JSON string is provided, and expects the string_norm_query otherwise.