### PR TITLE
Rename PreConditon to PrimaryCondition

### DIFF
--- a/lib/ApiPlatform/SearchConditionEvent.php
+++ b/lib/ApiPlatform/SearchConditionEvent.php
@@ -18,9 +18,9 @@ use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * The SearchConditionEvent allows to set a pre-condition.
+ * The SearchConditionEvent allows to set a primary-condition.
  *
- * Call getSearchCondition()->setPreCondition() to set a pre-condition.
+ * Call getSearchCondition()->setPrimaryCondition() to set a primary-condition.
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
@@ -29,7 +29,7 @@ final class SearchConditionEvent extends Event
     /**
      * @Event
      */
-    public const SEARCH_CONDITION_EVENT = 'rollerworks_search.process.pre_condition';
+    public const SEARCH_CONDITION_EVENT = 'rollerworks_search.process.primary_condition';
 
     private $searchCondition;
     private $resourceClass;

--- a/lib/Core/SearchCondition.php
+++ b/lib/Core/SearchCondition.php
@@ -25,7 +25,7 @@ class SearchCondition
 {
     private $fieldSet;
     private $values;
-    private $preCondition;
+    private $primaryCondition;
 
     public function __construct(FieldSet $fieldSet, ValuesGroup $valuesGroup)
     {
@@ -43,14 +43,14 @@ class SearchCondition
         return $this->values;
     }
 
-    public function setPreCondition(SearchPreCondition $condition): void
+    public function setPrimaryCondition(SearchPrimaryCondition $condition): void
     {
-        $this->preCondition = $condition;
+        $this->primaryCondition = $condition;
     }
 
-    public function getPreCondition(): ?SearchPreCondition
+    public function getPrimaryCondition(): ?SearchPrimaryCondition
     {
-        return $this->preCondition;
+        return $this->primaryCondition;
     }
 
     public function isEmpty(): bool

--- a/lib/Core/SearchPrimaryCondition.php
+++ b/lib/Core/SearchPrimaryCondition.php
@@ -16,16 +16,16 @@ namespace Rollerworks\Component\Search;
 use Rollerworks\Component\Search\Value\ValuesGroup;
 
 /**
- * SearchPreCondition contains a condition that must be fulfilled at all times.
+ * SearchPrimaryCondition contains a condition that must be fulfilled at all times.
  *
- * A Pre-condition is applied as `(SearchPreCondition) AND (SearchCondition)`.
+ * A SearchPrimaryCondition is applied as `(SearchPrimaryCondition) AND (SearchCondition)`.
  *
- * Caution: It's important for QueryGenerator to always apply
- * the pre-condition even if the SearchCondition itself is empty!
+ * Caution: It's important for a QueryGenerator to always apply
+ * the primary-condition even if the search-condition itself is empty!
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-final class SearchPreCondition
+final class SearchPrimaryCondition
 {
     private $values;
 

--- a/lib/Core/Tests/SearchConditionTest.php
+++ b/lib/Core/Tests/SearchConditionTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Rollerworks\Component\Search\Exception\UnsupportedFieldSetException;
 use Rollerworks\Component\Search\FieldSet;
 use Rollerworks\Component\Search\SearchCondition;
-use Rollerworks\Component\Search\SearchPreCondition;
+use Rollerworks\Component\Search\SearchPrimaryCondition;
 use Rollerworks\Component\Search\Value\ValuesBag;
 use Rollerworks\Component\Search\Value\ValuesGroup;
 
@@ -60,11 +60,11 @@ final class SearchConditionTest extends TestCase
         $fieldSet = $this->createMock(FieldSet::class);
         $fieldSet->expects(self::any())->method('getSetName')->willReturn('test');
 
-        $preCondition = new SearchPreCondition((new ValuesGroup())->addField('id', new ValuesBag()));
+        $primaryCondition = new SearchPrimaryCondition((new ValuesGroup())->addField('id', new ValuesBag()));
 
         $condition = new SearchCondition($fieldSet, new ValuesGroup());
-        $condition->setPreCondition($preCondition);
+        $condition->setPrimaryCondition($primaryCondition);
 
-        self::assertEquals($preCondition, $condition->getPreCondition());
+        self::assertEquals($primaryCondition, $condition->getPrimaryCondition());
     }
 }

--- a/lib/Doctrine/Dbal/CachedConditionGenerator.php
+++ b/lib/Doctrine/Dbal/CachedConditionGenerator.php
@@ -140,7 +140,7 @@ final class CachedConditionGenerator implements ConditionGenerator
                 "\n".
                 serialize($searchCondition->getValuesGroup()).
                 "\n".
-                serialize($searchCondition->getPreCondition()).
+                serialize($searchCondition->getPrimaryCondition()).
                 "\n".
                 serialize($this->conditionGenerator->getFieldsMapping())
             );

--- a/lib/Doctrine/Dbal/Query/QueryGenerator.php
+++ b/lib/Doctrine/Dbal/Query/QueryGenerator.php
@@ -71,8 +71,8 @@ final class QueryGenerator
     {
         $conditions = [];
 
-        if (null !== $preCondition = $searchCondition->getPreCondition()) {
-            $conditions[] = $this->getGroupQuery($preCondition->getValuesGroup());
+        if (null !== $primaryCondition = $searchCondition->getPrimaryCondition()) {
+            $conditions[] = $this->getGroupQuery($primaryCondition->getValuesGroup());
         }
 
         $conditions[] = $this->getGroupQuery($searchCondition->getValuesGroup());

--- a/lib/Doctrine/Dbal/Tests/CachedConditionGeneratorTest.php
+++ b/lib/Doctrine/Dbal/Tests/CachedConditionGeneratorTest.php
@@ -22,7 +22,7 @@ use Rollerworks\Component\Search\Doctrine\Dbal\SqlConditionGenerator;
 use Rollerworks\Component\Search\GenericFieldSet;
 use Rollerworks\Component\Search\SearchCondition;
 use Rollerworks\Component\Search\SearchConditionBuilder;
-use Rollerworks\Component\Search\SearchPreCondition;
+use Rollerworks\Component\Search\SearchPrimaryCondition;
 use Rollerworks\Component\Search\Value\ValuesGroup;
 
 final class CachedConditionGeneratorTest extends DbalTestCase
@@ -239,7 +239,7 @@ final class CachedConditionGeneratorTest extends DbalTestCase
         self::assertEquals('((I.id IN(18)))', $this->cachedConditionGenerator->getWhereClause());
     }
 
-    public function testGetWhereClauseCachedAndPreCond()
+    public function testGetWhereClauseCachedAndPrimaryCond()
     {
         $fieldSet = $this->getFieldSet();
 
@@ -247,8 +247,8 @@ final class CachedConditionGeneratorTest extends DbalTestCase
         $cacheDriver->has('7503457faa505a978544359616a2b503638538170931ce460b69fcf35566f771')->willReturn(true);
         $cacheDriver->get('7503457faa505a978544359616a2b503638538170931ce460b69fcf35566f771')->willReturn("me = 'foo'");
 
-        $cacheDriver->has('cb136884ef8b94935e3df27498f8882cce67a40ba5f6e6eb30ba7c6b4db65841')->willReturn(true);
-        $cacheDriver->get('cb136884ef8b94935e3df27498f8882cce67a40ba5f6e6eb30ba7c6b4db65841')->willReturn("you = 'me' AND me = 'foo'");
+        $cacheDriver->has('55a05d0537821dd5ae26cfc4e1f4ea5fda29bf8d881554a1b629a45c78bfbf51')->willReturn(true);
+        $cacheDriver->get('55a05d0537821dd5ae26cfc4e1f4ea5fda29bf8d881554a1b629a45c78bfbf51')->willReturn("you = 'me' AND me = 'foo'");
 
         $cachedConditionGenerator = $this->createCachedConditionGenerator(
             $cacheDriver->reveal(),
@@ -257,7 +257,7 @@ final class CachedConditionGeneratorTest extends DbalTestCase
         );
 
         $searchCondition = new SearchCondition($fieldSet, new ValuesGroup());
-        $searchCondition->setPreCondition(new SearchPreCondition(new ValuesGroup()));
+        $searchCondition->setPrimaryCondition(new SearchPrimaryCondition(new ValuesGroup()));
 
         $cachedConditionGenerator2 = $this->createCachedConditionGenerator(
             $cacheDriver->reveal(),

--- a/lib/Doctrine/Dbal/Tests/Functional/SqlConditionGeneratorResultsTest.php
+++ b/lib/Doctrine/Dbal/Tests/Functional/SqlConditionGeneratorResultsTest.php
@@ -23,7 +23,7 @@ use Rollerworks\Component\Search\Extension\Core\Type\MoneyType;
 use Rollerworks\Component\Search\Extension\Core\Type\TextType;
 use Rollerworks\Component\Search\Input\ProcessorConfig;
 use Rollerworks\Component\Search\Input\StringQueryInput;
-use Rollerworks\Component\Search\SearchPreCondition;
+use Rollerworks\Component\Search\SearchPrimaryCondition;
 use Rollerworks\Component\Search\Tests\Doctrine\Dbal\SchemaRecord;
 
 /**
@@ -318,11 +318,11 @@ SQL;
     /**
      * @test
      */
-    public function it_finds_by_customer_and_status_and_total_with_preCond()
+    public function it_finds_by_customer_and_status_and_total_with_primaryCond()
     {
-        $this->makeTestWithPreCond('customer: 2;', 'customer: 3;', []);
-        $this->makeTestWithPreCond('customer: 2;', 'status: paid; customer: 3;', []);
-        $this->makeTestWithPreCond('customer: 2;', 'status: paid;', [2]);
+        $this->makeTestWithPrimaryCond('customer: 2;', 'customer: 3;', []);
+        $this->makeTestWithPrimaryCond('customer: 2;', 'status: paid; customer: 3;', []);
+        $this->makeTestWithPrimaryCond('customer: 2;', 'status: paid;', [2]);
     }
 
     /**
@@ -377,13 +377,13 @@ SQL;
         }
     }
 
-    private function makeTestWithPreCond($preCondition, $input, array $expectedRows)
+    private function makeTestWithPrimaryCond($primaryCondition, $input, array $expectedRows)
     {
         $config = new ProcessorConfig($this->getFieldSet());
 
         try {
             $condition = $this->inputProcessor->process($config, $input);
-            $condition->setPreCondition(new SearchPreCondition($this->inputProcessor->process($config, $preCondition)->getValuesGroup()));
+            $condition->setPrimaryCondition(new SearchPrimaryCondition($this->inputProcessor->process($config, $primaryCondition)->getValuesGroup()));
             $this->assertRecordsAreFound($condition, $expectedRows);
         } catch (\Exception $e) {
             self::detectSystemException($e);

--- a/lib/Doctrine/Dbal/Tests/SqlConditionGeneratorTest.php
+++ b/lib/Doctrine/Dbal/Tests/SqlConditionGeneratorTest.php
@@ -22,7 +22,7 @@ use Rollerworks\Component\Search\Extension\Core\Type\IntegerType;
 use Rollerworks\Component\Search\Extension\Core\Type\TextType;
 use Rollerworks\Component\Search\SearchCondition;
 use Rollerworks\Component\Search\SearchConditionBuilder;
-use Rollerworks\Component\Search\SearchPreCondition;
+use Rollerworks\Component\Search\SearchPrimaryCondition;
 use Rollerworks\Component\Search\Value\Compare;
 use Rollerworks\Component\Search\Value\ExcludedRange;
 use Rollerworks\Component\Search\Value\PatternMatch;
@@ -89,7 +89,7 @@ final class SqlConditionGeneratorTest extends DbalTestCase
         $this->assertEquals('', $conditionGenerator->getWhereClause('WHERE '));
     }
 
-    public function testQueryWithPrependAndPreCond()
+    public function testQueryWithPrependAndPrimaryCond()
     {
         $condition = SearchConditionBuilder::create($this->getFieldSet())
             ->field('customer')
@@ -98,8 +98,8 @@ final class SqlConditionGeneratorTest extends DbalTestCase
             ->end()
         ->getSearchCondition();
 
-        $condition->setPreCondition(
-            new SearchPreCondition(
+        $condition->setPrimaryCondition(
+            new SearchPrimaryCondition(
                 SearchConditionBuilder::create($this->getFieldSet())
                     ->field('status')
                         ->addSimpleValue(1)
@@ -115,7 +115,7 @@ final class SqlConditionGeneratorTest extends DbalTestCase
         $this->assertEquals('WHERE ((I.status IN(1, 2))) AND ((I.customer IN(2, 5)))', $conditionGenerator->getWhereClause('WHERE '));
     }
 
-    public function testEmptyQueryWithPrependAndPreCond()
+    public function testEmptyQueryWithPrependAndPrimaryCond()
     {
         $condition = SearchConditionBuilder::create($this->getFieldSet())
             ->field('id')
@@ -124,8 +124,8 @@ final class SqlConditionGeneratorTest extends DbalTestCase
             ->end()
         ->getSearchCondition();
 
-        $condition->setPreCondition(
-            new SearchPreCondition(
+        $condition->setPrimaryCondition(
+            new SearchPrimaryCondition(
                 SearchConditionBuilder::create($this->getFieldSet())
                     ->field('status')
                         ->addSimpleValue(1)

--- a/lib/Doctrine/Orm/CachedDqlConditionGenerator.php
+++ b/lib/Doctrine/Orm/CachedDqlConditionGenerator.php
@@ -179,7 +179,7 @@ class CachedDqlConditionGenerator extends AbstractCachedConditionGenerator
                 "\n".
                 serialize($searchCondition->getValuesGroup()).
                 "\n".
-                serialize($searchCondition->getPreCondition()).
+                serialize($searchCondition->getPrimaryCondition()).
                 "\n".
                 serialize($this->conditionGenerator->getFieldsConfig()->getFields())
             );

--- a/lib/Doctrine/Orm/CachedNativeQueryConditionGenerator.php
+++ b/lib/Doctrine/Orm/CachedNativeQueryConditionGenerator.php
@@ -116,7 +116,7 @@ class CachedNativeQueryConditionGenerator extends AbstractCachedConditionGenerat
                 "\n".
                 serialize($searchCondition->getValuesGroup()).
                 "\n".
-                serialize($searchCondition->getPreCondition()).
+                serialize($searchCondition->getPrimaryCondition()).
                 "\n".
                 serialize($this->conditionGenerator->getFieldsConfig()->getFields())
             );

--- a/lib/Doctrine/Orm/Tests/CachedDqlConditionGeneratorTest.php
+++ b/lib/Doctrine/Orm/Tests/CachedDqlConditionGeneratorTest.php
@@ -19,7 +19,7 @@ use Rollerworks\Component\Search\Doctrine\Orm\CachedDqlConditionGenerator;
 use Rollerworks\Component\Search\Doctrine\Orm\DqlConditionGenerator;
 use Rollerworks\Component\Search\SearchCondition;
 use Rollerworks\Component\Search\SearchConditionBuilder;
-use Rollerworks\Component\Search\SearchPreCondition;
+use Rollerworks\Component\Search\SearchPrimaryCondition;
 
 /**
  * @group non-functional
@@ -198,13 +198,11 @@ class CachedDqlConditionGeneratorTest extends OrmTestCase
         );
     }
 
-    public function testGetWhereClauseWithCacheAndPreCond()
+    public function testGetWhereClauseWithCacheAndPrimaryCond()
     {
         $cacheDriverProphecy = $this->prophesize(CacheInterface::class);
-        $cacheDriverProphecy->has('41329a2e34ac65573fb097e858a5b12685b0327e3e55b5bb48902e4731b42afa')->willReturn(true);
         $cacheDriverProphecy->get('41329a2e34ac65573fb097e858a5b12685b0327e3e55b5bb48902e4731b42afa')->willReturn(["me = 'foo'", ['1' => 'he']]);
-        $cacheDriverProphecy->has('7f1ddddc8869a6cdd6308b790b854f2cac46f67e22e8fd978ead76ab881df323')->willReturn(true);
-        $cacheDriverProphecy->get('7f1ddddc8869a6cdd6308b790b854f2cac46f67e22e8fd978ead76ab881df323')->willReturn(["you = 'me' AND me = 'foo'", ['1' => 'he']]);
+        $cacheDriverProphecy->get('4202f64ad8bb0d7a4bcc23ca1b1a27980897bc112182ac35401bd3a64c11cdc7')->willReturn(["you = 'me' AND me = 'foo'", ['1' => 'he']]);
         $cacheDriver = $cacheDriverProphecy->reveal();
 
         $searchCondition = SearchConditionBuilder::create($this->getFieldSet())
@@ -222,7 +220,7 @@ class CachedDqlConditionGeneratorTest extends OrmTestCase
             ->end()
         ->getSearchCondition();
 
-        $searchCondition2->setPreCondition(new SearchPreCondition(
+        $searchCondition2->setPrimaryCondition(new SearchPrimaryCondition(
             SearchConditionBuilder::create($this->getFieldSet())
                 ->field('customer')
                     ->addSimpleValue(2)

--- a/lib/Doctrine/Orm/Tests/CachedNativeQueryConditionGeneratorTest.php
+++ b/lib/Doctrine/Orm/Tests/CachedNativeQueryConditionGeneratorTest.php
@@ -20,7 +20,7 @@ use Rollerworks\Component\Search\Doctrine\Orm\CachedNativeQueryConditionGenerato
 use Rollerworks\Component\Search\Doctrine\Orm\NativeQueryConditionGenerator;
 use Rollerworks\Component\Search\SearchCondition;
 use Rollerworks\Component\Search\SearchConditionBuilder;
-use Rollerworks\Component\Search\SearchPreCondition;
+use Rollerworks\Component\Search\SearchPrimaryCondition;
 
 /**
  * @group non-functional
@@ -218,13 +218,11 @@ final class CachedNativeQueryConditionGeneratorTest extends OrmTestCase
         );
     }
 
-    public function testGetWhereClauseWithCacheAndPreCond()
+    public function testGetWhereClauseWithCacheAndPrimaryCond()
     {
         $cacheDriverProphecy = $this->prophesize(CacheInterface::class);
-        $cacheDriverProphecy->has('1b52f5c77746dc39806f6bccd58cda29752d4773decd12e3773a99a3ec0b8478')->willReturn(true);
         $cacheDriverProphecy->get('1b52f5c77746dc39806f6bccd58cda29752d4773decd12e3773a99a3ec0b8478')->willReturn("me = 'foo'");
-        $cacheDriverProphecy->has('e782734c8c65fa986046b3b17f007c72e733246d532864ed95c9641676fca138')->willReturn(true);
-        $cacheDriverProphecy->get('e782734c8c65fa986046b3b17f007c72e733246d532864ed95c9641676fca138')->willReturn("you = 'me' AND me = 'foo'");
+        $cacheDriverProphecy->get('ff906fb8642689a2267dfaebe057a011bed6fc97d978f7728a190d87c4dd1371')->willReturn("you = 'me' AND me = 'foo'");
         $cacheDriver = $cacheDriverProphecy->reveal();
 
         $searchCondition = SearchConditionBuilder::create($this->getFieldSet())
@@ -242,7 +240,7 @@ final class CachedNativeQueryConditionGeneratorTest extends OrmTestCase
             ->end()
         ->getSearchCondition();
 
-        $searchCondition2->setPreCondition(new SearchPreCondition(
+        $searchCondition2->setPrimaryCondition(new SearchPrimaryCondition(
             SearchConditionBuilder::create($this->getFieldSet())
                 ->field('customer')
                     ->addSimpleValue(2)

--- a/lib/Doctrine/Orm/Tests/ConditionGeneratorResultsTestCase.php
+++ b/lib/Doctrine/Orm/Tests/ConditionGeneratorResultsTestCase.php
@@ -22,7 +22,7 @@ use Rollerworks\Component\Search\Extension\Core\Type\MoneyType;
 use Rollerworks\Component\Search\Extension\Core\Type\TextType;
 use Rollerworks\Component\Search\Input\ProcessorConfig;
 use Rollerworks\Component\Search\Input\StringQueryInput;
-use Rollerworks\Component\Search\SearchPreCondition;
+use Rollerworks\Component\Search\SearchPrimaryCondition;
 use Rollerworks\Component\Search\Tests\Doctrine\Dbal\SchemaRecord;
 
 /**
@@ -263,11 +263,11 @@ abstract class ConditionGeneratorResultsTestCase extends OrmTestCase
     /**
      * @test
      */
-    public function it_finds_by_customer_and_status_and_total_with_preCond()
+    public function it_finds_by_customer_and_status_and_total_with_primaryCond()
     {
-        $this->makeTestWithPreCond('customer: 2;', 'customer: 3;', []);
-        $this->makeTestWithPreCond('customer: 2;', 'status: paid; customer: 3;', []);
-        $this->makeTestWithPreCond('customer: 2;', 'status: paid;', [2]);
+        $this->makeTestWithPrimaryCond('customer: 2;', 'customer: 3;', []);
+        $this->makeTestWithPrimaryCond('customer: 2;', 'status: paid; customer: 3;', []);
+        $this->makeTestWithPrimaryCond('customer: 2;', 'status: paid;', [2]);
     }
 
     /**
@@ -322,13 +322,13 @@ abstract class ConditionGeneratorResultsTestCase extends OrmTestCase
         }
     }
 
-    private function makeTestWithPreCond($preCondition, $input, array $expectedRows)
+    private function makeTestWithPrimaryCond($primaryCondition, $input, array $expectedRows)
     {
         $config = new ProcessorConfig($this->getFieldSet());
 
         try {
             $condition = $this->inputProcessor->process($config, $input);
-            $condition->setPreCondition(new SearchPreCondition($this->inputProcessor->process($config, $preCondition)->getValuesGroup()));
+            $condition->setPrimaryCondition(new SearchPrimaryCondition($this->inputProcessor->process($config, $primaryCondition)->getValuesGroup()));
             $this->assertRecordsAreFound($condition, $expectedRows);
         } catch (\Exception $e) {
             self::detectSystemException($e);

--- a/lib/Doctrine/Orm/Tests/DqlConditionGeneratorTest.php
+++ b/lib/Doctrine/Orm/Tests/DqlConditionGeneratorTest.php
@@ -28,7 +28,7 @@ use Rollerworks\Component\Search\Extension\Core\Type\IntegerType;
 use Rollerworks\Component\Search\Extension\Core\Type\TextType;
 use Rollerworks\Component\Search\SearchCondition;
 use Rollerworks\Component\Search\SearchConditionBuilder;
-use Rollerworks\Component\Search\SearchPreCondition;
+use Rollerworks\Component\Search\SearchPrimaryCondition;
 use Rollerworks\Component\Search\Value\Compare;
 use Rollerworks\Component\Search\Value\ExcludedRange;
 use Rollerworks\Component\Search\Value\PatternMatch;
@@ -656,7 +656,7 @@ final class DqlConditionGeneratorTest extends OrmTestCase
         $this->assertDqlCompiles($conditionGenerator);
     }
 
-    public function testQueryWithPrependAndPreCond()
+    public function testQueryWithPrependAndPrimaryCond()
     {
         $condition = SearchConditionBuilder::create($this->getFieldSet())
             ->field('customer')
@@ -665,8 +665,8 @@ final class DqlConditionGeneratorTest extends OrmTestCase
             ->end()
         ->getSearchCondition();
 
-        $condition->setPreCondition(
-            new SearchPreCondition(
+        $condition->setPrimaryCondition(
+            new SearchPrimaryCondition(
                 SearchConditionBuilder::create($this->getFieldSet())
                     ->field('status')
                         ->addSimpleValue(1)
@@ -689,7 +689,7 @@ final class DqlConditionGeneratorTest extends OrmTestCase
         );
     }
 
-    public function testEmptyQueryWithPrependAndPreCond()
+    public function testEmptyQueryWithPrependAndPrimaryCond()
     {
         $condition = SearchConditionBuilder::create($this->getFieldSet())
             ->field('id2')
@@ -698,8 +698,8 @@ final class DqlConditionGeneratorTest extends OrmTestCase
             ->end()
         ->getSearchCondition();
 
-        $condition->setPreCondition(
-            new SearchPreCondition(
+        $condition->setPrimaryCondition(
+            new SearchPrimaryCondition(
                 SearchConditionBuilder::create($this->getFieldSet())
                     ->field('status')
                         ->addSimpleValue(1)

--- a/lib/Doctrine/Orm/Tests/NativeQueryConditionGeneratorTest.php
+++ b/lib/Doctrine/Orm/Tests/NativeQueryConditionGeneratorTest.php
@@ -21,7 +21,7 @@ use Rollerworks\Component\Search\Extension\Core\Type\DateType;
 use Rollerworks\Component\Search\Extension\Core\Type\IntegerType;
 use Rollerworks\Component\Search\SearchCondition;
 use Rollerworks\Component\Search\SearchConditionBuilder;
-use Rollerworks\Component\Search\SearchPreCondition;
+use Rollerworks\Component\Search\SearchPrimaryCondition;
 use Rollerworks\Component\Search\Value\ValuesGroup;
 
 /**
@@ -256,7 +256,7 @@ class NativeQueryConditionGeneratorTest extends OrmTestCase
         );
     }
 
-    public function testQueryWithPrependAndPreCond()
+    public function testQueryWithPrependAndPrimaryCond()
     {
         $condition = SearchConditionBuilder::create($this->getFieldSet())
             ->field('customer')
@@ -265,8 +265,8 @@ class NativeQueryConditionGeneratorTest extends OrmTestCase
             ->end()
         ->getSearchCondition();
 
-        $condition->setPreCondition(
-            new SearchPreCondition(
+        $condition->setPrimaryCondition(
+            new SearchPrimaryCondition(
                 SearchConditionBuilder::create($this->getFieldSet())
                     ->field('status')
                         ->addSimpleValue(1)
@@ -288,7 +288,7 @@ class NativeQueryConditionGeneratorTest extends OrmTestCase
         }
     }
 
-    public function testEmptyQueryWithPrependAndPreCond()
+    public function testEmptyQueryWithPrependAndPrimaryCond()
     {
         $condition = SearchConditionBuilder::create($this->getFieldSet())
             ->field('id2')
@@ -297,8 +297,8 @@ class NativeQueryConditionGeneratorTest extends OrmTestCase
             ->end()
         ->getSearchCondition();
 
-        $condition->setPreCondition(
-            new SearchPreCondition(
+        $condition->setPrimaryCondition(
+            new SearchPrimaryCondition(
                 SearchConditionBuilder::create($this->getFieldSet())
                     ->field('status')
                         ->addSimpleValue(1)

--- a/lib/Elasticsearch/QueryConditionGenerator.php
+++ b/lib/Elasticsearch/QueryConditionGenerator.php
@@ -101,20 +101,20 @@ use Rollerworks\Component\Search\Value\ValuesGroup;
     {
         $rootGroupCondition = $this->processGroup($this->searchCondition->getValuesGroup());
 
-        if (null !== ($precondition = $this->searchCondition->getPreCondition())) {
-            $preconditionGroupCondition = $this->processGroup($precondition->getValuesGroup());
+        if (null !== ($primaryCondition = $this->searchCondition->getPrimaryCondition())) {
+            $primaryConditionGroupCondition = $this->processGroup($primaryCondition->getValuesGroup());
 
             if ($rootGroupCondition) {
                 $rootGroupCondition = [
                     self::QUERY_BOOL => [
                         self::CONDITION_AND => [
-                            $preconditionGroupCondition,
+                            $primaryConditionGroupCondition,
                             $rootGroupCondition,
                         ],
                     ],
                 ];
             } else {
-                $rootGroupCondition = $preconditionGroupCondition;
+                $rootGroupCondition = $primaryConditionGroupCondition;
             }
         }
 
@@ -135,8 +135,8 @@ use Rollerworks\Component\Search\Value\ValuesGroup;
 
         $this->extractMappings($group, $mappings);
 
-        if (null !== $precondition = $this->searchCondition->getPreCondition()) {
-            $this->extractMappings($precondition->getValuesGroup(), $mappings);
+        if (null !== $primaryCondition = $this->searchCondition->getPrimaryCondition()) {
+            $this->extractMappings($primaryCondition->getValuesGroup(), $mappings);
         }
 
         return $mappings;

--- a/lib/Elasticsearch/Tests/QueryConditionGeneratorTest.php
+++ b/lib/Elasticsearch/Tests/QueryConditionGeneratorTest.php
@@ -17,7 +17,7 @@ use Rollerworks\Component\Search\Elasticsearch\FieldMapping;
 use Rollerworks\Component\Search\Elasticsearch\QueryConditionGenerator;
 use Rollerworks\Component\Search\FieldSet;
 use Rollerworks\Component\Search\SearchConditionBuilder;
-use Rollerworks\Component\Search\SearchPreCondition;
+use Rollerworks\Component\Search\SearchPrimaryCondition;
 use Rollerworks\Component\Search\Test\SearchIntegrationTestCase;
 use Rollerworks\Component\Search\Value\Compare;
 use Rollerworks\Component\Search\Value\ExcludedRange;
@@ -412,9 +412,9 @@ final class QueryConditionGeneratorTest extends SearchIntegrationTestCase
     }
 
     /** @test */
-    public function it_applies_the_precondition_without_a_query()
+    public function it_applies_the_primaryCondition_without_a_query()
     {
-        $precondition = new SearchPreCondition(
+        $primaryCondition = new SearchPrimaryCondition(
             $this->createCondition()
                 ->field('restrict')
                     ->addSimpleValue('Some')
@@ -427,7 +427,7 @@ final class QueryConditionGeneratorTest extends SearchIntegrationTestCase
         $condition = $this
             ->createCondition()
             ->getSearchCondition();
-        $condition->setPreCondition($precondition);
+        $condition->setPrimaryCondition($primaryCondition);
 
         $generator = new QueryConditionGenerator($condition);
         $generator->registerField('restrict', 'restrict');
@@ -456,9 +456,9 @@ final class QueryConditionGeneratorTest extends SearchIntegrationTestCase
     }
 
     /** @test */
-    public function it_applies_the_precondition_with_a_query()
+    public function it_applies_the_primaryCondition_with_a_query()
     {
-        $precondition = new SearchPreCondition(
+        $primaryCondition = new SearchPrimaryCondition(
             $this->createCondition()
                 ->field('restrict')
                     ->addSimpleValue('Some')
@@ -475,7 +475,7 @@ final class QueryConditionGeneratorTest extends SearchIntegrationTestCase
                 ->addSimpleValue('Foo')
             ->end()
             ->getSearchCondition();
-        $condition->setPreCondition($precondition);
+        $condition->setPrimaryCondition($primaryCondition);
 
         $generator = new QueryConditionGenerator($condition);
         $generator->registerField('restrict', 'restrict');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The implementation for this functionality was introduced rather rapid without a good consideration for a proper name. PrimaryCondition describes exactly what this functionality is about it, it should always be applied (even if the user provided search condition is empty).