### PR TITLE
Add support for private fields

### DIFF
--- a/lib/ApiPlatform/Tests/Mock/FieldSetStub.php
+++ b/lib/ApiPlatform/Tests/Mock/FieldSetStub.php
@@ -37,4 +37,9 @@ final class FieldSetStub implements FieldSet
     {
         return false;
     }
+
+    public function isPrivate(string $name): bool
+    {
+        return '_' === $name[0];
+    }
 }

--- a/lib/Core/Exporter/JsonExporter.php
+++ b/lib/Core/Exporter/JsonExporter.php
@@ -48,7 +48,7 @@ final class JsonExporter extends AbstractExporter
         $fields = $valuesGroup->getFields();
 
         foreach ($fields as $name => $values) {
-            if (0 === $values->count()) {
+            if ($fieldSet->isPrivate($name) || 0 === $values->count()) {
                 continue;
             }
 

--- a/lib/Core/Exporter/StringExporter.php
+++ b/lib/Core/Exporter/StringExporter.php
@@ -63,7 +63,7 @@ abstract class StringExporter extends AbstractExporter
         }
 
         foreach ($valuesGroup->getFields() as $name => $values) {
-            if (0 === $values->count()) {
+            if ($fieldSet->isPrivate($name) || 0 === $values->count()) {
                 continue;
             }
 

--- a/lib/Core/Field/SearchField.php
+++ b/lib/Core/Field/SearchField.php
@@ -84,10 +84,10 @@ class SearchField implements FieldConfig
      */
     public function __construct(string $name, ResolvedFieldType $type, array $options = [])
     {
-        if (!preg_match('/^[a-zA-Z][a-zA-Z0-9_\-]*$/D', $name)) {
+        if (!preg_match('/^_?[a-zA-Z][a-zA-Z0-9_\-]*$/D', $name)) {
             throw new InvalidArgumentException(
                 sprintf(
-                    'The name "%s" contains illegal characters. Name must start with a letter '.
+                    'The name "%s" contains illegal characters. Name must start with a letter or underscore '.
                     'and only contain letters, digits, numbers, underscores ("_") and hyphens ("-").',
                     $name
                 )

--- a/lib/Core/FieldSet.php
+++ b/lib/Core/FieldSet.php
@@ -56,4 +56,13 @@ interface FieldSet
      * @return bool
      */
     public function has(string $name): bool;
+
+    /**
+     * Returns whether the field is a private field (primary condition only).
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function isPrivate(string $name): bool;
 }

--- a/lib/Core/GenericFieldSet.php
+++ b/lib/Core/GenericFieldSet.php
@@ -77,6 +77,11 @@ final class GenericFieldSet implements FieldSetWithView
         return isset($this->fields[$name]);
     }
 
+    public function isPrivate(string $name): bool
+    {
+        return '_' === $name[0];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/lib/Core/Input/JsonInput.php
+++ b/lib/Core/Input/JsonInput.php
@@ -18,6 +18,7 @@ use Rollerworks\Component\Search\ErrorList;
 use Rollerworks\Component\Search\Exception\InputProcessorException;
 use Rollerworks\Component\Search\Exception\InvalidSearchConditionException;
 use Rollerworks\Component\Search\Exception\UnexpectedTypeException;
+use Rollerworks\Component\Search\Exception\UnknownFieldException;
 use Rollerworks\Component\Search\Field\FieldConfig;
 use Rollerworks\Component\Search\SearchCondition;
 use Rollerworks\Component\Search\Value\ValuesBag;
@@ -171,6 +172,10 @@ final class JsonInput extends AbstractInput
     private function processFields(array $values, ValuesGroup $valuesGroup, string $path)
     {
         foreach ($values as $name => $value) {
+            if ($this->config->getFieldSet()->isPrivate($name)) {
+                throw new UnknownFieldException($name);
+            }
+
             $value = array_merge(
                 [
                     'simple-values' => [],

--- a/lib/Core/Input/NormStringQueryInput.php
+++ b/lib/Core/Input/NormStringQueryInput.php
@@ -25,8 +25,13 @@ final class NormStringQueryInput extends StringInput
     protected function initForProcess(ProcessorConfig $config): void
     {
         $names = [];
+        $fieldSet = $config->getFieldSet();
 
-        foreach ($config->getFieldSet()->all() as $name => $field) {
+        foreach ($fieldSet->all() as $name => $field) {
+            if ($fieldSet->isPrivate($name)) {
+                continue;
+            }
+
             $names[$name] = $name;
 
             if (null !== $customerMatcher = $field->getOption(self::FIELD_LEXER_OPTION_NAME)) {

--- a/lib/Core/Input/StringLexer.php
+++ b/lib/Core/Input/StringLexer.php
@@ -20,7 +20,7 @@ use Rollerworks\Component\Search\Exception\StringLexerException;
  */
 final class StringLexer
 {
-    private const FIELD_NAME = '/(\p{L}[\p{L}\p{N}_-]*)\s*:/Au';
+    private const FIELD_NAME = '/_?(\p{L}[\p{L}\p{N}_-]*)\s*:/Au';
 
     public const PATTERN_MATCH = 'pattern-match';
     public const SIMPLE_VALUE = 'simple-value';

--- a/lib/Core/Input/StringQueryInput.php
+++ b/lib/Core/Input/StringQueryInput.php
@@ -51,8 +51,13 @@ final class StringQueryInput extends StringInput
     {
         $labels = [];
         $callable = $this->labelResolver;
+        $fieldSet = $config->getFieldSet();
 
-        foreach ($config->getFieldSet()->all() as $name => $field) {
+        foreach ($fieldSet->all() as $name => $field) {
+            if ($fieldSet->isPrivate($name)) {
+                continue;
+            }
+
             $label = $callable($field);
             $labels[$label] = $name;
 

--- a/lib/Core/Test/SearchConditionExporterTestCase.php
+++ b/lib/Core/Test/SearchConditionExporterTestCase.php
@@ -129,6 +129,40 @@ abstract class SearchConditionExporterTestCase extends SearchIntegrationTestCase
     /**
      * @test
      */
+    public function it_ignores_private_fields()
+    {
+        $exporter = $this->getExporter();
+        $config = new ProcessorConfig($this->getFieldSet());
+
+        $expectedGroup = new ValuesGroup();
+
+        $values = new ValuesBag();
+        $values->addSimpleValue('value');
+        $values->addSimpleValue('value2');
+        $expectedGroup->addField('name', $values);
+
+        $date = new \DateTime('2014-12-16 00:00:00 UTC');
+
+        $values = new ValuesBag();
+        $values->addSimpleValue($date);
+        $expectedGroup->addField('date', $values);
+
+        $values = new ValuesBag();
+        $values->addSimpleValue(1);
+        $expectedGroup->addField('_id', $values);
+
+        $condition = new SearchCondition($config->getFieldSet(), $expectedGroup);
+        $this->assertExportEquals($this->provideMultipleValuesTest(), $exporter->exportCondition($condition));
+    }
+
+    /**
+     * @return mixed
+     */
+    abstract public function providePrivateFieldsTest();
+
+    /**
+     * @test
+     */
     public function it_exporters_range_values()
     {
         $exporter = $this->getExporter();

--- a/lib/Core/Tests/Exporter/JsonExporterTest.php
+++ b/lib/Core/Tests/Exporter/JsonExporterTest.php
@@ -63,6 +63,22 @@ final class JsonExporterTest extends SearchConditionExporterTestCase
         );
     }
 
+    public function providePrivateFieldsTest()
+    {
+        return json_encode(
+            [
+                'fields' => [
+                    'name' => [
+                        'simple-values' => ['value', 'value2'],
+                    ],
+                    'date' => [
+                        'simple-values' => ['2014-12-16'],
+                    ],
+                ],
+            ]
+        );
+    }
+
     public function provideRangeValuesTest()
     {
         return json_encode(

--- a/lib/Core/Tests/Exporter/NormStringQueryExporterTest.php
+++ b/lib/Core/Tests/Exporter/NormStringQueryExporterTest.php
@@ -72,6 +72,11 @@ final class NormStringQueryExporterTest extends SearchConditionExporterTestCase
         return 'name: value, value2; date: 2014-12-16;';
     }
 
+    public function providePrivateFieldsTest()
+    {
+        return 'name: value, value2; date: 2014-12-16;';
+    }
+
     public function provideRangeValuesTest()
     {
         return 'id: 1 ~ 10, 15 ~ 30, ]100 ~ 200, 310 ~ 400[, !50 ~ 70; date: 2014-12-16 ~ 2014-12-20;';

--- a/lib/Core/Tests/Exporter/StringQueryExporterTest.php
+++ b/lib/Core/Tests/Exporter/StringQueryExporterTest.php
@@ -107,6 +107,11 @@ final class StringQueryExporterTest extends SearchConditionExporterTestCase
         return 'name: value, value2; date: 12-16-2014;';
     }
 
+    public function providePrivateFieldsTest()
+    {
+        return 'name: value, value2; date: 12-16-2014;';
+    }
+
     public function provideRangeValuesTest()
     {
         return 'id: 1 ~ 10, 15 ~ 30, ]100 ~ 200, 310 ~ 400[, !50 ~ 70; date: 12-16-2014 ~ 12-20-2014;';

--- a/lib/Core/Tests/Input/JsonInputTest.php
+++ b/lib/Core/Tests/Input/JsonInputTest.php
@@ -516,6 +516,39 @@ final class JsonInputTest extends InputProcessorTestCase
         ];
     }
 
+    public function providePrivateFieldTests()
+    {
+        return [
+            [
+                json_encode(
+                    [
+                        'fields' => [
+                            '_id' => [
+                                'simple-values' => [1, 2],
+                            ],
+                        ],
+                    ]
+                ),
+                '_id',
+            ],
+            [
+                json_encode(
+                    [
+                        'fields' => [
+                            'id' => [
+                                'simple-values' => [1, 2],
+                            ],
+                            '_id' => [
+                                'simple-values' => [1, 2],
+                            ],
+                        ],
+                    ]
+                ),
+                '_id',
+            ],
+        ];
+    }
+
     public function provideUnknownFieldTests()
     {
         return [

--- a/lib/Core/Tests/Input/StringQueryInputTest.php
+++ b/lib/Core/Tests/Input/StringQueryInputTest.php
@@ -386,6 +386,14 @@ final class StringQueryInputTest extends InputProcessorTestCase
         ];
     }
 
+    public function providePrivateFieldTests()
+    {
+        return [
+            ['_id: 1;', '_id'],
+            ['id: 1; _id: 2;', '_id'],
+        ];
+    }
+
     public function provideUnknownFieldTests()
     {
         return [

--- a/lib/Core/Tests/Mock/FieldSetStub.php
+++ b/lib/Core/Tests/Mock/FieldSetStub.php
@@ -36,4 +36,9 @@ final class FieldSetStub implements FieldSet
     {
         return false;
     }
+
+    public function isPrivate(string $name): bool
+    {
+        return '_' === $name[0];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #219
| License       | MIT
| Doc PR        | 

A field name accepts a single underscore prefix to indicate it’s private, eg. `_id`.
There is no BC break here as field-names did not accept this format before.

Private fields can only be used in a PrimaryCondition and are simple ignored for user-input.