### PR TITLE
Reduce the default allowed maximum values

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -5,6 +5,16 @@ UPGRADE FROM 2.0-ALPHA12 to 2.0-ALPHA13
  
  * ApiPlatform SearchConditionListener no longer supports array-input. 
    Use JSON or the NormStringQuery input-format instead.
+   
+ * The default restriction values of `ProcessorConfig` have been changed
+   to provide a better default;
+   
+   * Maximum values per field is now 100 (was 1000)
+   * Maximum number of groups is now 10 (was 100)
+   * Nesting is now 5 (was 100)
+   
+   Unless you must support a higher number of values 
+   it is advised to not increase these values.
 
 UPGRADE FROM 2.0-ALPHA8 to 2.0-ALPHA12
 ======================================

--- a/lib/Core/Input/ProcessorConfig.php
+++ b/lib/Core/Input/ProcessorConfig.php
@@ -25,17 +25,17 @@ class ProcessorConfig
     /**
      * @var int
      */
-    private $maxNestingLevel = 100;
+    private $maxNestingLevel = 5;
 
     /**
      * @var int
      */
-    private $maxValues = 1000;
+    private $maxValues = 100;
 
     /**
      * @var int
      */
-    private $maxGroups = 100;
+    private $maxGroups = 10;
 
     /**
      * @var FieldSet

--- a/lib/Core/Tests/Input/InputProcessorTestCase.php
+++ b/lib/Core/Tests/Input/InputProcessorTestCase.php
@@ -601,6 +601,8 @@ abstract class InputProcessorTestCase extends SearchIntegrationTestCase
     public function it_checks_nested_fields($input, array $errors)
     {
         $config = new ProcessorConfig($this->getFieldSet());
+        $config->setMaxNestingLevel(10);
+
         $this->assertConditionContainsErrorsWithoutCause($input, $config, $errors);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Allowing  1000 values per field or allowing a maximum nesting level of a 100?
This reduces the Processor default values to more sensible values, to prevent DoS attacks.