### PR TITLE
[Core] Allow to unset the PrimaryCondition

### DIFF
--- a/lib/Core/SearchCondition.php
+++ b/lib/Core/SearchCondition.php
@@ -43,7 +43,7 @@ class SearchCondition
         return $this->values;
     }
 
-    public function setPrimaryCondition(SearchPrimaryCondition $condition): void
+    public function setPrimaryCondition(?SearchPrimaryCondition $condition): void
     {
         $this->primaryCondition = $condition;
     }

--- a/lib/Core/Tests/SearchConditionTest.php
+++ b/lib/Core/Tests/SearchConditionTest.php
@@ -55,7 +55,7 @@ final class SearchConditionTest extends TestCase
     }
 
     /** @test */
-    public function it_allows_setting_a_pre_condition()
+    public function it_allows_setting_a_primary_condition()
     {
         $fieldSet = $this->createMock(FieldSet::class);
         $fieldSet->expects(self::any())->method('getSetName')->willReturn('test');
@@ -66,5 +66,20 @@ final class SearchConditionTest extends TestCase
         $condition->setPrimaryCondition($primaryCondition);
 
         self::assertEquals($primaryCondition, $condition->getPrimaryCondition());
+    }
+
+    /** @test */
+    public function it_allows_unsetting_the_primary_condition()
+    {
+        $fieldSet = $this->createMock(FieldSet::class);
+        $fieldSet->expects(self::any())->method('getSetName')->willReturn('test');
+
+        $primaryCondition = new SearchPrimaryCondition((new ValuesGroup())->addField('id', new ValuesBag()));
+
+        $condition = new SearchCondition($fieldSet, new ValuesGroup());
+        $condition->setPrimaryCondition($primaryCondition);
+        $condition->setPrimaryCondition(null);
+
+        self::assertNull($condition->getPrimaryCondition());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #216 
| License       | MIT
| Doc PR        | 

BC break only if one overwrites the `Rollerworks\Component\Search\SearchCondition::setPrimaryCondition` method in a child class.

Closes #216 