### PR TITLE
[Elasticsearch] order-by support

### DIFF
--- a/lib/ApiPlatform/Tests/Elasticsearch/Extension/SearchExtensionTest.php
+++ b/lib/ApiPlatform/Tests/Elasticsearch/Extension/SearchExtensionTest.php
@@ -59,6 +59,11 @@ class SearchExtensionTest extends TestCase
         $queryBuilderProphecy->getFirstResult()->shouldBeCalled();
         $queryBuilderProphecy->getMaxResults()->shouldBeCalled();
         $queryBuilderProphecy->getRootAliases()->willReturn(['o']);
+        $queryBuilderProphecy->setParameter('id0', 3)->shouldBeCalled();
+        $queryBuilderProphecy->setParameter('id1', 1)->shouldBeCalled();
+        $queryBuilderProphecy->setParameter('id2', 5)->shouldBeCalled();
+        $queryBuilderProphecy->addSelect('CASE WHEN o.id = :id0 THEN 0 WHEN o.id = :id1 THEN 1 WHEN o.id = :id2 THEN 2 ELSE 3 END AS HIDDEN order_by')->willReturn($queryBuilderProphecy);
+        $queryBuilderProphecy->orderBy('order_by', 'ASC')->shouldBeCalled();
         $queryBuilder = $queryBuilderProphecy->reveal();
 
         $classMetadataProphecy = $this->prophesize(ClassMetadata::class);
@@ -81,8 +86,8 @@ class SearchExtensionTest extends TestCase
         $conditionGenerator = $conditionGeneratorProphecy->reveal();
 
         $cachedConditionGeneratorProphecy = $this->prophesize(CachedConditionGenerator::class);
-        $cachedConditionGeneratorProphecy->registerField('dummy-id', 'id', [])->shouldBeCalled();
-        $cachedConditionGeneratorProphecy->registerField('dummy-name', 'name', [])->shouldBeCalled();
+        $cachedConditionGeneratorProphecy->registerField('dummy-id', 'id', [], [])->shouldBeCalled();
+        $cachedConditionGeneratorProphecy->registerField('dummy-name', 'name', [], [])->shouldBeCalled();
         $cachedConditionGeneratorProphecy->getQuery()->willReturn($query);
         $cachedConditionGeneratorProphecy->getMappings()->shouldBeCalled();
         $cachedConditionGenerator = $cachedConditionGeneratorProphecy->reveal();

--- a/lib/Elasticsearch/CachedConditionGenerator.php
+++ b/lib/Elasticsearch/CachedConditionGenerator.php
@@ -59,9 +59,9 @@ class CachedConditionGenerator implements ConditionGenerator
         $this->cacheTtl = $ttl;
     }
 
-    public function registerField(string $fieldName, string $mapping, array $conditions = [])
+    public function registerField(string $fieldName, string $mapping, array $conditions = [], array $options = [])
     {
-        $this->conditionGenerator->registerField($fieldName, $mapping, $conditions);
+        $this->conditionGenerator->registerField($fieldName, $mapping, $conditions, $options);
 
         return $this;
     }

--- a/lib/Elasticsearch/ConditionGenerator.php
+++ b/lib/Elasticsearch/ConditionGenerator.php
@@ -67,10 +67,11 @@ interface ConditionGenerator
      * @param string $fieldName  Field set name
      * @param string $mapping    Elasticsearch property mapping
      * @param array  $conditions Additional conditions to apply if this mapping is used
+     * @param array  $options    Additional options to send directly to Elasticsearch
      *
      * @return static
      */
-    public function registerField(string $fieldName, string $mapping, array $conditions = []);
+    public function registerField(string $fieldName, string $mapping, array $conditions = [], array $options = []);
 
     /**
      * Return a valid Elastica\Query search query. Query can be sent to a _search endpoint as is.

--- a/lib/Elasticsearch/QueryPreparationHints.php
+++ b/lib/Elasticsearch/QueryPreparationHints.php
@@ -15,12 +15,15 @@ namespace Rollerworks\Component\Search\Elasticsearch;
 
 class QueryPreparationHints
 {
+    public const CONTEXT_PRECONDITION_VALUE = 'PRECONDITION_VALUE';
+    public const CONTEXT_PRECONDITION_QUERY = 'PRECONDITION_QUERY';
     public const CONTEXT_SIMPLE_VALUES = 'SIMPLE_VALUES';
     public const CONTEXT_EXCLUDED_SIMPLE_VALUES = 'EXCLUDED_SIMPLE_VALUES';
     public const CONTEXT_RANGE_VALUES = 'RANGE_VALUES';
     public const CONTEXT_EXCLUDED_RANGE_VALUES = 'EXCLUDED_RANGE_VALUES';
     public const CONTEXT_COMPARISON = 'COMPARISON';
     public const CONTEXT_PATTERN_MATCH = 'PATTERN_MATCH';
+    public const CONTEXT_ORDER = 'ORDER';
 
     /** @var bool */
     public $identifier = false;

--- a/lib/Elasticsearch/Tests/Functional/ConditionGeneratorResultsTest.php
+++ b/lib/Elasticsearch/Tests/Functional/ConditionGeneratorResultsTest.php
@@ -202,6 +202,54 @@ class ConditionGeneratorResultsTest extends FunctionalElasticsearchTestCase
     }
 
     /**
+     * @test
+     */
+    public function it_sorts_by_total()
+    {
+        $this->makeTest('@total: ASC', [3, 6, 2, 4, 1, 5]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_sorts_by_total_desc()
+    {
+        $this->makeTest('@total: DESC', [5, 4, 1, 2, 6, 3]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_sorts_by_customer_name()
+    {
+        $this->makeTest('@customer-name: ASC', [5, 2, 4, 3, 1, 6]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_applies_conditional_conditions_from_order_mappings()
+    {
+        $this->makeTest('@customer-pubdate: ASC', [3, 2, 1, 4]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_sorts_by_has_child_query()
+    {
+        $this->makeTest('@customer-note-pubdate: ASC', [4, 3, 2, 1]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_sorts_by_has_child_query_desc()
+    {
+        $this->makeTest('@customer-note-pubdate: DESC', [1, 2, 3, 4]);
+    }
+
+    /**
      * @param string $input
      * @param array  $expectedRows
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #241 
| License       | MIT
| Doc PR        | N/A

Based on #255, that must be merged first.

TODO:

- [x] tests for ordering by `has_child` queries
- [x] functionality and tests for API Platform integration (`options`, order from Doctrine must be identical to what Elasticsearch returns)