### PR TITLE
[Elasticsearch] pass custom field options even if no condition is set

### DIFF
--- a/lib/Elasticsearch/QueryConditionGenerator.php
+++ b/lib/Elasticsearch/QueryConditionGenerator.php
@@ -248,7 +248,8 @@ use Rollerworks\Component\Search\Value\ValuesGroup;
                     $nested,
                     $join,
                     $injectParams,
-                    $conditions
+                    $conditions,
+                    $options
                 ));
             }
             if ($valuesBag->hasExcludedSimpleValues()) {
@@ -262,7 +263,8 @@ use Rollerworks\Component\Search\Value\ValuesGroup;
                     $nested,
                     $join,
                     $injectParams,
-                    $conditions
+                    $conditions,
+                    $options
                 ));
             }
 
@@ -272,7 +274,7 @@ use Rollerworks\Component\Search\Value\ValuesGroup;
                 foreach ($valuesBag->get(Range::class) as $range) {
                     $hints->context = QueryPreparationHints::CONTEXT_RANGE_VALUES;
                     $range = $this->convertRangeValues($range, $valueConverter, $injectParams);
-                    $this->mergeQuery($bool, $includingType, $this->prepareQuery($propertyName, $range, $hints, $queryConverter, $nested, $join, $conditions));
+                    $this->mergeQuery($bool, $includingType, $this->prepareQuery($propertyName, $range, $hints, $queryConverter, $nested, $join, $conditions, $options));
                 }
             }
             if ($valuesBag->has(ExcludedRange::class)) {
@@ -280,7 +282,7 @@ use Rollerworks\Component\Search\Value\ValuesGroup;
                 foreach ($valuesBag->get(ExcludedRange::class) as $range) {
                     $hints->context = QueryPreparationHints::CONTEXT_EXCLUDED_RANGE_VALUES;
                     $range = $this->convertRangeValues($range, $valueConverter, $injectParams);
-                    $this->mergeQuery($bool, self::CONDITION_NOT, $this->prepareQuery($propertyName, $range, $hints, $queryConverter, $nested, $join, $conditions));
+                    $this->mergeQuery($bool, self::CONDITION_NOT, $this->prepareQuery($propertyName, $range, $hints, $queryConverter, $nested, $join, $conditions, $options));
                 }
             }
 
@@ -291,7 +293,7 @@ use Rollerworks\Component\Search\Value\ValuesGroup;
                     $hints->context = QueryPreparationHints::CONTEXT_COMPARISON;
                     $compare = $this->convertCompareValue($compare, $valueConverter, $injectParams);
                     $localIncludingType = self::COMPARISON_UNEQUAL === $compare->getOperator() ? self::CONDITION_NOT : $includingType;
-                    $this->mergeQuery($bool, $localIncludingType, $this->prepareQuery($propertyName, $compare, $hints, $queryConverter, $nested, $join, $conditions));
+                    $this->mergeQuery($bool, $localIncludingType, $this->prepareQuery($propertyName, $compare, $hints, $queryConverter, $nested, $join, $conditions, $options));
                 }
             }
 
@@ -302,7 +304,7 @@ use Rollerworks\Component\Search\Value\ValuesGroup;
                     $patternMatch = $this->convertMatcherValue($patternMatch, $valueConverter, $injectParams);
                     $hints->context = QueryPreparationHints::CONTEXT_PATTERN_MATCH;
                     $localIncludingType = $patternMatch->isExclusive() ? self::CONDITION_NOT : $includingType;
-                    $this->mergeQuery($bool, $localIncludingType, $this->prepareQuery($propertyName, $patternMatch, $hints, $queryConverter, $nested, $join, $conditions));
+                    $this->mergeQuery($bool, $localIncludingType, $this->prepareQuery($propertyName, $patternMatch, $hints, $queryConverter, $nested, $join, $conditions, $options));
                 }
             }
         }

--- a/lib/Elasticsearch/Tests/Functional/FunctionalElasticsearchTestCase.php
+++ b/lib/Elasticsearch/Tests/Functional/FunctionalElasticsearchTestCase.php
@@ -241,7 +241,7 @@ abstract class FunctionalElasticsearchTestCase extends ElasticsearchTestCase
     protected function configureConditionGenerator(QueryConditionGenerator $conditionGenerator)
     {
         // customer
-        $conditionGenerator->registerField('customer-comment', 'customers/customers/#note>comment', [], ['_id' => ['unmapped_type' => 'long']]);
+        $conditionGenerator->registerField('customer-comment', 'customers/customers/#note>comment');
         $conditionGenerator->registerField(
             'customer-comment-restricted',
             'customers/customers/#note>comment',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #270 
| License       | MIT
| Doc PR        | 

As I don't know elasticasearch internals good enough I'm not sure about other possible use cases besides "inner_hits". This option has to be set for nested/joined field conditionally (when field is really used in the query) and I can only solve it dirty way after generating of query...

I was thinking that we actually need to distinguish field options from conditions options and proper method signature could be:

```php
public function registerField(string $fieldName, string $property, array $conditions = [], array $conditionOptions = [], array $options = [])
{
}
```

prepareProcessedValuesQuery/prepareQuery updated accordingly.

This also brings even more complexity to the code, so other way round could be to leave it solely on developer and use only one "options" argument for all cases but later it could bite us.

@dkarlovi WDYT?