### PR TITLE
[Core] Add support for unbound values in StringInput

### DIFF
--- a/lib/Core/Input/ProcessorConfig.php
+++ b/lib/Core/Input/ProcessorConfig.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Input;
 
+use Rollerworks\Component\Search\Exception\InputProcessorException;
 use Rollerworks\Component\Search\FieldSet;
 
 /**
@@ -46,6 +47,9 @@ class ProcessorConfig
      * @var int|\DateInterval|null
      */
     private $cacheTTL;
+
+    /** @var string|null */
+    private $defaultField;
 
     public function __construct(FieldSet $fieldSet)
     {
@@ -126,5 +130,19 @@ class ProcessorConfig
     public function getCacheTTL()
     {
         return $this->cacheTTL;
+    }
+
+    public function getDefaultField(bool $error = false): ?string
+    {
+        if ($this->defaultField === null && $error) {
+            throw new InputProcessorException('', 'No default field was configured.');
+        }
+
+        return $this->defaultField;
+    }
+
+    public function setDefaultField(string $defaultField): void
+    {
+        $this->defaultField = $defaultField;
     }
 }

--- a/lib/Core/Input/StringInput.php
+++ b/lib/Core/Input/StringInput.php
@@ -35,7 +35,10 @@ use Rollerworks\Component\Search\Value\ValuesGroup;
  * Caution: The error message reports the character position not the byte position.
  * Multi byte may cause some problems when using substr() rather then mb_substr().
  *
- * Each query-pair is a 'field-name: value1, value2;'.
+ * Each query-pair is a 'field-name: value1, value2;' or 'value1, value2;'.
+ *
+ * Tip: The field-name can be omitted, which uses the default field-name configured
+ * in the ProcessorConfig. This should only be used for the first values list.
  *
  *  Query-pairs can be nested inside a group "(field-name: value1, value2;)"
  *    Subgroups are threaded as AND-case to there parent,
@@ -53,7 +56,7 @@ use Rollerworks\Component\Search\Value\ValuesGroup;
  *
  *  Each value inside a query-pair is separated with a single comma.
  *  A value containing special characters (<>[](),;~!*?=) or spaces
- *  must be surrounded by quotes.
+ *  must be surrounded by quotes or use a custom value lexer.
  *
  *  Note surrounding spaces are ignored. Example: field: value , value2  ;
  *
@@ -268,7 +271,11 @@ abstract class StringInput extends AbstractInput
                 throw $this->lexer->createFormatException(StringLexerException::CANNOT_CLOSE_UNOPENED_GROUP);
             }
 
-            $fieldName = $this->getFieldName($this->lexer->fieldIdentification());
+            if ($this->lexer->isGlimpse(StringLexer::FIELD_NAME)) {
+                $fieldName = $this->getFieldName($this->lexer->fieldIdentification());
+            } else {
+                $fieldName = $this->config->getDefaultField(true);
+            }
 
             $this->lexer->skipEmptyLines();
             $this->fieldValues($fieldName);

--- a/lib/Core/Input/StringLexer.php
+++ b/lib/Core/Input/StringLexer.php
@@ -20,7 +20,7 @@ use Rollerworks\Component\Search\Exception\StringLexerException;
  */
 final class StringLexer
 {
-    private const FIELD_NAME = '/@?_?(\p{L}[\p{L}\p{N}_-]*)\s*:/Au';
+    public const FIELD_NAME = '/@?_?(\p{L}[\p{L}\p{N}_-]*)\s*:/Au';
 
     public const PATTERN_MATCH = 'pattern-match';
     public const SIMPLE_VALUE = 'simple-value';

--- a/lib/Core/Tests/Input/InputProcessorTestCase.php
+++ b/lib/Core/Tests/Input/InputProcessorTestCase.php
@@ -112,6 +112,7 @@ abstract class InputProcessorTestCase extends SearchIntegrationTestCase
     {
         $processor = $this->getProcessor();
         $config = new ProcessorConfig($this->getFieldSet(true, true));
+        $config->setDefaultField('id');
 
         $expectedGroup = new ValuesGroup();
 
@@ -156,6 +157,7 @@ abstract class InputProcessorTestCase extends SearchIntegrationTestCase
     {
         $processor = $this->getProcessor();
         $config = new ProcessorConfig($this->getFieldSet());
+        $config->setDefaultField('name');
 
         $expectedGroup = new ValuesGroup();
 
@@ -189,6 +191,7 @@ abstract class InputProcessorTestCase extends SearchIntegrationTestCase
     {
         $processor = $this->getProcessor();
         $config = new ProcessorConfig($this->getFieldSet());
+        $config->setDefaultField('id');
 
         $expectedGroup = new ValuesGroup();
 
@@ -226,6 +229,7 @@ abstract class InputProcessorTestCase extends SearchIntegrationTestCase
     {
         $processor = $this->getProcessor();
         $config = new ProcessorConfig($this->getFieldSet());
+        $config->setDefaultField('id');
 
         $expectedGroup = new ValuesGroup();
 
@@ -296,6 +300,7 @@ abstract class InputProcessorTestCase extends SearchIntegrationTestCase
     {
         $processor = $this->getProcessor();
         $config = new ProcessorConfig($this->getFieldSet());
+        $config->setDefaultField('name');
 
         $expectedGroup = new ValuesGroup();
 
@@ -339,6 +344,7 @@ abstract class InputProcessorTestCase extends SearchIntegrationTestCase
     {
         $processor = $this->getProcessor();
         $config = new ProcessorConfig($this->getFieldSet());
+        $config->setDefaultField('name');
 
         $expectedGroup = new ValuesGroup($logical);
 
@@ -366,6 +372,7 @@ abstract class InputProcessorTestCase extends SearchIntegrationTestCase
     {
         $processor = $this->getProcessor();
         $config = new ProcessorConfig($this->getFieldSet());
+        $config->setDefaultField('name');
 
         $expectedGroup = new ValuesGroup();
 
@@ -404,6 +411,7 @@ abstract class InputProcessorTestCase extends SearchIntegrationTestCase
     {
         $processor = $this->getProcessor();
         $config = new ProcessorConfig($this->getFieldSet());
+        $config->setDefaultField('name');
 
         $expectedGroup = new ValuesGroup();
         $nestedGroup = new ValuesGroup();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | Closes #230 
| License       | MIT

Aka "search anything", if no field name is specified this uses the default configured field.

Additionally we might add support for a default operator (or type in our case) in the future.
Secondly only StringInput has support for this now.