### PR TITLE
[Doctrine] Fix cache storing prepend with cache

### DIFF
--- a/lib/Doctrine/Orm/CachedDqlConditionGenerator.php
+++ b/lib/Doctrine/Orm/CachedDqlConditionGenerator.php
@@ -86,7 +86,7 @@ class CachedDqlConditionGenerator extends AbstractCachedConditionGenerator
 
             if (null !== $cacheItem = $this->cacheDriver->get($cacheKey)) {
                 list($this->whereClause, $this->parameters) = $cacheItem;
-            } elseif ('' !== $this->whereClause = $this->conditionGenerator->getWhereClause($prependQuery)) {
+            } elseif ('' !== $this->whereClause = $this->conditionGenerator->getWhereClause()) {
                 $this->parameters = $this->conditionGenerator->getParameters();
 
                 $this->cacheDriver->set(

--- a/lib/Doctrine/Orm/CachedNativeQueryConditionGenerator.php
+++ b/lib/Doctrine/Orm/CachedNativeQueryConditionGenerator.php
@@ -69,7 +69,7 @@ class CachedNativeQueryConditionGenerator extends AbstractCachedConditionGenerat
             $cacheKey = $this->getCacheKey();
 
             if (null === $this->whereClause = $this->cacheDriver->get($cacheKey)) {
-                if ('' !== $this->whereClause = $this->conditionGenerator->getWhereClause($prependQuery)) {
+                if ('' !== $this->whereClause = $this->conditionGenerator->getWhereClause()) {
                     $this->cacheDriver->set($cacheKey, $this->whereClause, $this->ttl);
                 }
             }

--- a/lib/Doctrine/Orm/Tests/CachedDqlConditionGeneratorTest.php
+++ b/lib/Doctrine/Orm/Tests/CachedDqlConditionGeneratorTest.php
@@ -65,7 +65,7 @@ class CachedDqlConditionGeneratorTest extends OrmTestCase
             ->method('set')
             ->with(self::CACHE_KEY, ['((C.id IN(2, 5)))', []], 60);
 
-        self::assertEquals('((C.id IN(2, 5)))', $this->cachedConditionGenerator->getWhereClause());
+        self::assertEquals('WHERE ((C.id IN(2, 5)))', $this->cachedConditionGenerator->getWhereClause('WHERE '));
     }
 
     public function testGetWhereClauseWithCache()

--- a/lib/Doctrine/Orm/Tests/CachedNativeQueryConditionGeneratorTest.php
+++ b/lib/Doctrine/Orm/Tests/CachedNativeQueryConditionGeneratorTest.php
@@ -69,9 +69,9 @@ final class CachedNativeQueryConditionGeneratorTest extends OrmTestCase
             ->with(self::CACHE_KEY, 'sqlite' === $name ? '((I.customer IN(2, 5)))' : "((I.customer IN('2', '5')))", 60);
 
         if ('sqlite' === $name) {
-            self::assertEquals('((I.customer IN(2, 5)))', $this->cachedConditionGenerator->getWhereClause());
+            self::assertEquals('WHERE ((I.customer IN(2, 5)))', $this->cachedConditionGenerator->getWhereClause('WHERE '));
         } else {
-            self::assertEquals("((I.customer IN('2', '5')))", $this->cachedConditionGenerator->getWhereClause());
+            self::assertEquals("WHERE ((I.customer IN('2', '5')))", $this->cachedConditionGenerator->getWhereClause('WHERE '));
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

Calling `getWhereClause()` with a prepend value stored the the prepend value within the cache, while only the actual where-clause must be stored.