### PR TITLE
Add support for relative date-time (DateInterval)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,12 @@
     ],
     "require": {
         "php": "^7.2",
+        "nesbot/carbon": "^2.38",
         "psr/container": "^1.0.0",
         "symfony/intl": "^4.4 || ^5.0",
         "symfony/options-resolver": "^4.4 || ^5.0",
-        "symfony/property-access": "^4.4 || ^5.0"
+        "symfony/property-access": "^4.4 || ^5.0",
+        "symfony/string": "^5.1"
     },
     "replace": {
         "rollerworks/search": "self.version",

--- a/docs/reference/types/datetime.rst
+++ b/docs/reference/types/datetime.rst
@@ -10,12 +10,13 @@ The provided input can be provided localized.
 The underlying data is stored as a ``DateTime`` object.
 
 +----------------------+------------------------------------------------------------------------------+
-| Output Data Type     | ``DateTime``                                                                 |
+| Output Data Type     | can be ``DateTimeImmutable`` or ``Carbon\CarbonInterval``                    |
 +----------------------+------------------------------------------------------------------------------+
 | Options              | - `with_seconds`_                                                            |
 |                      | - `with_minutes`_                                                            |
 |                      | - `model_timezone`_                                                          |
 |                      | - `input_timezone`_                                                          |
+|                      | - `allow_relative`_                                                          |
 +----------------------+------------------------------------------------------------------------------+
 | Parent type          | :doc:`field </reference/types/field>`                                        |
 +----------------------+------------------------------------------------------------------------------+

--- a/docs/reference/types/options/allow_relative.rst.inc
+++ b/docs/reference/types/options/allow_relative.rst.inc
@@ -1,0 +1,22 @@
+allow_relative
+~~~~~~~~~~~~~~
+
+**type**: ``bool`` **default**: ``false``_
+
+Enables the handling of relative Date and/or time formats like
+``1 week``, ``6 years 3 hours``.
+
+The actual datetime is relative to now (current date and time), use the minus (``-``)
+sign like ``-1 year`` to invert interval to a past moment.
+
+Internally this uses `Carbon DateInterval`_ to parse the (localized) format.
+
+.. caution::
+
+    For Doctrine DBAL and ORM not all platforms are supported yet.
+    Currently only PostgreSQL and MySQL/MariaDB are supported.
+
+    Working se
+
+.. _`Date/Time Format Syntax`: http://userguide.icu-project.org/formatparse/datetime#TOC-Date-Time-Format-Syntax
+.. _`Carbon DateInterval`: https://carbon.nesbot.com/docs/#api-interval

--- a/lib/Core/Extension/Core/DataTransformer/DateIntervalTransformer.php
+++ b/lib/Core/Extension/Core/DataTransformer/DateIntervalTransformer.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Extension\Core\DataTransformer;
+
+use Carbon\CarbonInterval;
+use Carbon\Translator;
+use Rollerworks\Component\Search\DataTransformer;
+use Rollerworks\Component\Search\Exception\TransformationFailedException;
+use function Symfony\Component\String\u;
+
+final class DateIntervalTransformer implements DataTransformer
+{
+    /** @var string */
+    private $fromLocale;
+
+    /** @var string */
+    private $toLocale;
+
+    public function __construct(string $fromLocale, string $toLocale = null)
+    {
+        $this->fromLocale = $fromLocale;
+        $this->toLocale = $toLocale ?? $fromLocale;
+    }
+
+    /**
+     * @param CarbonInterval|null $value
+     */
+    public function transform($value): string
+    {
+        if ($value === null) {
+            return '';
+        }
+
+        if (!$value instanceof CarbonInterval) {
+            throw new TransformationFailedException('Expected a CarbonInterval instance or null.');
+        }
+
+        $value = clone $value;
+        $value->locale($this->toLocale);
+
+        if ($value->invert === 1) {
+            return u($value->forHumans())->prepend('-')->toString();
+        }
+
+        return $value->forHumans();
+    }
+
+    /**
+     * @param string $value
+     */
+    public function reverseTransform($value): ?CarbonInterval
+    {
+        if (!is_scalar($value)) {
+            throw new TransformationFailedException('Expected a scalar.');
+        }
+
+        if ($value === '') {
+            return null;
+        }
+
+        try {
+            $value = $this->translateNumberWords($value);
+            $uValue = u($value)->trim();
+
+            if ($uValue->startsWith('-')) {
+                return CarbonInterval::parseFromLocale($uValue->trimStart('-')->toString(), $this->fromLocale)->invert();
+            }
+
+            return CarbonInterval::parseFromLocale($uValue->toString(), $this->fromLocale);
+        } catch (\Exception $e) {
+            throw new TransformationFailedException('Unable to parse value to DateInterval', 0, $e);
+        }
+    }
+
+    private function translateNumberWords(string $timeString): string
+    {
+        $timeString = strtr($timeString, ['’' => "'"]);
+
+        $translator = Translator::get($this->fromLocale);
+        $translations = $translator->getMessages();
+
+        if (!isset($translations[$this->fromLocale])) {
+            return $timeString;
+        }
+
+        $messages = $translations[$this->fromLocale];
+
+        foreach (['year', 'month', 'week', 'day', 'hour', 'minute', 'second'] as $item) {
+            foreach (explode('|', $messages[$item]) as $idx => $messagePart) {
+                if (preg_match('/[:%](count|time)/', $messagePart)) {
+                    continue;
+                }
+
+                if ($messagePart[0] === '{') {
+                    $idx = (int) substr($messagePart, 1, strpos($messagePart, '}'));
+                }
+
+                $messagePart = static::cleanWordFromTranslationString($messagePart);
+                $timeString = str_replace($messagePart, $idx.' '.$item, $timeString);
+            }
+        }
+
+        return $timeString;
+    }
+
+    /**
+     * Return the word cleaned from its translation codes.
+     */
+    private static function cleanWordFromTranslationString(string $word): string
+    {
+        $word = str_replace([':count', '%count', ':time'], '', $word);
+        $word = strtr($word, ['’' => "'"]);
+        $word = preg_replace('/({\d+(,(\d+|Inf))?}|[\[\]]\d+(,(\d+|Inf))?[\[\]])/', '', $word);
+
+        return trim($word);
+    }
+}

--- a/lib/Core/Extension/Core/DataTransformer/MultiTypeDataTransformer.php
+++ b/lib/Core/Extension/Core/DataTransformer/MultiTypeDataTransformer.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Extension\Core\DataTransformer;
+
+use Rollerworks\Component\Search\DataTransformer;
+use Rollerworks\Component\Search\Exception\TransformationFailedException;
+use Throwable;
+
+/**
+ * Allows to use multiple transformers based on their type.
+ *
+ * This transformer is mostly used by DateTimeType to support
+ * both DateTime and DateInterval objects.
+ *
+ * @internal
+ */
+final class MultiTypeDataTransformer implements DataTransformer
+{
+    /** @var array<class-string,DataTransformer> */
+    private $transformers;
+
+    /**
+     * @param array<class-string,DataTransformer> $transformers
+     */
+    public function __construct(array $transformers)
+    {
+        $this->transformers = $transformers;
+    }
+
+    public function transform($value)
+    {
+        if ($value === null) {
+            return '';
+        }
+
+        $type = get_debug_type($value);
+
+        if (!isset($this->transformers[$type])) {
+            throw new TransformationFailedException(sprintf('Unsupported type "%s".', $type));
+        }
+
+        return $this->transformers[$type]->transform($value);
+    }
+
+    public function reverseTransform($value)
+    {
+        $finalException = null;
+
+        foreach ($this->transformers as $transformer) {
+            try {
+                return $transformer->reverseTransform($value);
+            } catch (Throwable $e) {
+                $finalException = new TransformationFailedException($e->getMessage().PHP_EOL.$e->getTraceAsString(), $e->getCode(), $finalException);
+
+                continue;
+            }
+        }
+
+        throw $finalException;
+    }
+}

--- a/lib/Core/Extension/Core/Type/TimeType.php
+++ b/lib/Core/Extension/Core/Type/TimeType.php
@@ -15,7 +15,7 @@ namespace Rollerworks\Component\Search\Extension\Core\Type;
 
 use Rollerworks\Component\Search\Exception\InvalidConfigurationException;
 use Rollerworks\Component\Search\Extension\Core\DataTransformer\DateTimeToStringTransformer;
-use Rollerworks\Component\Search\Extension\Core\ValueComparator\DateTimeValueValueComparator;
+use Rollerworks\Component\Search\Extension\Core\ValueComparator\DateTimeValueComparator;
 use Rollerworks\Component\Search\Field\AbstractFieldType;
 use Rollerworks\Component\Search\Field\FieldConfig;
 use Rollerworks\Component\Search\Field\SearchFieldView;
@@ -32,7 +32,7 @@ final class TimeType extends AbstractFieldType
 
     public function __construct()
     {
-        $this->valueComparator = new DateTimeValueValueComparator();
+        $this->valueComparator = new DateTimeValueComparator();
     }
 
     public function buildType(FieldConfig $config, array $options): void

--- a/lib/Core/Extension/Core/Type/TimestampType.php
+++ b/lib/Core/Extension/Core/Type/TimestampType.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Rollerworks\Component\Search\Extension\Core\Type;
 
 use Rollerworks\Component\Search\Extension\Core\DataTransformer\DateTimeToTimestampTransformer;
-use Rollerworks\Component\Search\Extension\Core\ValueComparator\DateTimeValueValueComparator;
+use Rollerworks\Component\Search\Extension\Core\ValueComparator\DateTimeValueComparator;
 use Rollerworks\Component\Search\Field\AbstractFieldType;
 use Rollerworks\Component\Search\Field\FieldConfig;
 use Rollerworks\Component\Search\Value\Compare;
@@ -31,7 +31,7 @@ final class TimestampType extends AbstractFieldType
 
     public function __construct()
     {
-        $this->valueComparator = new DateTimeValueValueComparator();
+        $this->valueComparator = new DateTimeValueComparator();
     }
 
     public function buildType(FieldConfig $config, array $options): void

--- a/lib/Core/Extension/Core/ValueComparator/DateTimeIntervalValueComparator.php
+++ b/lib/Core/Extension/Core/ValueComparator/DateTimeIntervalValueComparator.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Extension\Core\ValueComparator;
+
+use Carbon\CarbonInterval;
+use Rollerworks\Component\Search\ValueComparator;
+
+final class DateTimeIntervalValueComparator implements ValueComparator
+{
+    /**
+     * @param \DateTimeImmutable|CarbonInterval $higher
+     * @param \DateTimeImmutable|CarbonInterval $lower
+     */
+    public function isHigher($higher, $lower, array $options): bool
+    {
+        if ($lower instanceof CarbonInterval && $higher instanceof CarbonInterval) {
+            return $higher->greaterThan($lower);
+        }
+
+        $lower = $this->ensureDateTime($lower);
+        $higher = $this->ensureDateTime($higher);
+
+        return $higher > $lower;
+    }
+
+    /**
+     * @param \DateTimeImmutable|CarbonInterval $value
+     */
+    private function ensureDateTime(object $value): \DateTimeImmutable
+    {
+        if ($value instanceof CarbonInterval) {
+            $value = (new \DateTimeImmutable())->add($value);
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param \DateTimeImmutable|CarbonInterval $lower
+     * @param \DateTimeImmutable|CarbonInterval $higher
+     */
+    public function isLower($lower, $higher, array $options): bool
+    {
+        if ($lower instanceof CarbonInterval && $higher instanceof CarbonInterval) {
+            return $lower->lessThan($higher);
+        }
+
+        $lower = $this->ensureDateTime($lower);
+        $higher = $this->ensureDateTime($higher);
+
+        return $lower < $higher;
+    }
+
+    /**
+     * @param \DateTimeImmutable|CarbonInterval $value
+     * @param \DateTimeImmutable|CarbonInterval $nextValue
+     */
+    public function isEqual($value, $nextValue, array $options): bool
+    {
+        // Note that only values of the same type can be compared.
+        // As an interval is never equal to "now".
+        if (!is_a($value, \get_class($nextValue))) {
+            return false;
+        }
+
+        if ($value instanceof CarbonInterval) {
+            return $value->equalTo($nextValue);
+        }
+
+        return $value->getTimestamp() === $nextValue->getTimestamp();
+    }
+}

--- a/lib/Core/Extension/Core/ValueComparator/DateTimeValueComparator.php
+++ b/lib/Core/Extension/Core/ValueComparator/DateTimeValueComparator.php
@@ -16,6 +16,6 @@ namespace Rollerworks\Component\Search\Extension\Core\ValueComparator;
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-final class DateTimeValueValueComparator extends DateValueComparator
+final class DateTimeValueComparator extends DateValueComparator
 {
 }

--- a/lib/Core/Resources/translations/validators.en.xlf
+++ b/lib/Core/Resources/translations/validators.en.xlf
@@ -34,6 +34,14 @@
                 <source>This value is not a valid birthday.</source>
                 <target>This value is not a valid birthday.</target>
             </trans-unit>
+            <trans-unit id="9">
+                <source>This value is not a valid datetime or date interval.</source>
+                <target>This value is not a valid datetime or date interval.</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>This value is not a valid datetime.</source>
+                <target>This value is not a valid datetime.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/lib/Core/Resources/translations/validators.nl.xlf
+++ b/lib/Core/Resources/translations/validators.nl.xlf
@@ -34,6 +34,15 @@
                 <source>This value is not a valid birthday.</source>
                 <target>Deze waarde is geen geldige geboortedatum.</target>
             </trans-unit>
+            <trans-unit id="9">
+                <source>This value is not a valid datetime or date interval.</source>
+                <target>Deze waarde is geen geldige datum en tijd, of tijdsinterval.</target>
+            </trans-unit>
+
+            <trans-unit id="10">
+                <source>This value is not a valid datetime.</source>
+                <target>Deze waarde is geen geldige datum en tijd.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/lib/Core/composer.json
+++ b/lib/Core/composer.json
@@ -21,10 +21,12 @@
     ],
     "require": {
         "php": "^7.1",
+        "nesbot/carbon": "^2.38",
         "psr/container": "^1.0.0",
         "symfony/intl": "^4.3 || ^5.0",
         "symfony/options-resolver": "^3.4.2 || ^4.0 || ^5.0",
-        "symfony/property-access": "^3.4.2 || ^4.0 || ^5.0"
+        "symfony/property-access": "^3.4.2 || ^4.0 || ^5.0",
+        "symfony/string": "^5.1"
     },
     "conflict": {
         "moneyphp/money": "<3.2.0"

--- a/lib/Doctrine/Dbal/Extension/Conversion/DateIntervalConversion.php
+++ b/lib/Doctrine/Dbal/Extension/Conversion/DateIntervalConversion.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Extension\Doctrine\Dbal\Conversion;
+
+use Carbon\CarbonInterval;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+use Rollerworks\Component\Search\Doctrine\Dbal\ConversionHints;
+use Rollerworks\Component\Search\Doctrine\Dbal\ValueConversion;
+
+final class DateIntervalConversion implements ValueConversion
+{
+    /**
+     * @param CarbonInterval|\DateTimeImmutable $value
+     */
+    public function convertValue($value, array $options, ConversionHints $hints): string
+    {
+        if ($value instanceof \DateTimeImmutable) {
+            return $hints->createParamReferenceFor($value, Type::getType(Types::DATETIME_IMMUTABLE));
+        }
+
+        $platform = $hints->connection->getDatabasePlatform()->getName();
+
+        $value = clone $value;
+        $value->locale('en');
+
+        if ($platform === 'postgresql' || $platform === 'mock') {
+            $intervalString = 'CAST('.$hints->createParamReferenceFor($value->forHumans()).' AS interval)';
+        } elseif ($platform === 'mysql' || $platform === 'drizzle') {
+            $intervalString = self::convertForMysql($value);
+        } else {
+            throw new \RuntimeException(
+                sprintf('Unsupported platform "%s" for DateIntervalConversion.', $platform)
+            );
+        }
+
+        if ($value->invert === 1) {
+            return 'NOW() - '.$intervalString;
+        }
+
+        return 'NOW() + '.$intervalString;
+    }
+
+    public static function convertForMysql(CarbonInterval $value): string
+    {
+        $negative = $value->invert === 1;
+
+        $handler = static function (array $units) use ($negative) {
+            foreach ($units as &$value) {
+                // MySQL doesn't support plural names.
+                $value = strtoupper(rtrim($value, 's'));
+            }
+
+            return implode(($negative ? ' - INTERVAL ' : ' + INTERVAL '), $units);
+        };
+
+        // Note. Don't use parameters here, values are already pre-formatted.
+        return 'INTERVAL '.$value->forHumans(['join' => $handler]);
+    }
+}

--- a/lib/Doctrine/Dbal/Extension/DoctrineDbalExtension.php
+++ b/lib/Doctrine/Dbal/Extension/DoctrineDbalExtension.php
@@ -23,6 +23,7 @@ class DoctrineDbalExtension extends AbstractExtension
     {
         return [
             new Type\FieldTypeExtension(),
+            new Type\DateTimeTypeExtension(),
             new Type\BirthdayTypeExtension(new AgeDateConversion()),
             new Type\MoneyTypeExtension(new MoneyValueConversion()),
         ];

--- a/lib/Doctrine/Dbal/Extension/Type/DateTimeTypeExtension.php
+++ b/lib/Doctrine/Dbal/Extension/Type/DateTimeTypeExtension.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Extension\Doctrine\Dbal\Type;
+
+use Rollerworks\Component\Search\Extension\Core\Type\DateTimeType;
+use Rollerworks\Component\Search\Extension\Doctrine\Dbal\Conversion\DateIntervalConversion;
+use Rollerworks\Component\Search\Field\AbstractFieldTypeExtension;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class DateTimeTypeExtension extends AbstractFieldTypeExtension
+{
+    /**
+     * @var DateIntervalConversion
+     */
+    private $conversion;
+
+    public function __construct()
+    {
+        $this->conversion = new DateIntervalConversion();
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults(
+            ['doctrine_dbal_conversion' => function (Options $options) {
+                if ($options['allow_relative']) {
+                    return $this->conversion;
+                }
+
+                return null;
+            }]
+        );
+    }
+
+    public function getExtendedType(): string
+    {
+        return DateTimeType::class;
+    }
+}

--- a/lib/Doctrine/Dbal/Tests/DbalTestCase.php
+++ b/lib/Doctrine/Dbal/Tests/DbalTestCase.php
@@ -16,7 +16,7 @@ namespace Rollerworks\Component\Search\Tests\Doctrine\Dbal;
 use Doctrine\DBAL\Driver\PDOSqlite\Driver as PDOSqlite;
 use Psr\SimpleCache\CacheInterface;
 use Rollerworks\Component\Search\Doctrine\Dbal\DoctrineDbalFactory;
-use Rollerworks\Component\Search\Extension\Core\Type\DateType;
+use Rollerworks\Component\Search\Extension\Core\Type\DateTimeType;
 use Rollerworks\Component\Search\Extension\Core\Type\IntegerType;
 use Rollerworks\Component\Search\Extension\Core\Type\TextType;
 use Rollerworks\Component\Search\Extension\Doctrine\Dbal\DoctrineDbalExtension;
@@ -37,7 +37,7 @@ abstract class DbalTestCase extends SearchIntegrationTestCase
 
         $fieldSet->add('customer', IntegerType::class);
         $fieldSet->add('customer_name', TextType::class);
-        $fieldSet->add('customer_birthday', DateType::class);
+        $fieldSet->add('customer_birthday', DateTimeType::class, ['allow_relative' => true]);
 
         return $build ? $fieldSet->getFieldSet('invoice') : $fieldSet;
     }

--- a/lib/Doctrine/Dbal/Tests/Functional/SqlConditionGeneratorTest.php
+++ b/lib/Doctrine/Dbal/Tests/Functional/SqlConditionGeneratorTest.php
@@ -13,11 +13,15 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Tests\Doctrine\Dbal\Functional;
 
+use Carbon\CarbonInterval;
 use Doctrine\DBAL\Schema\Schema as DbSchema;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Rollerworks\Component\Search\Doctrine\Dbal\ColumnConversion;
 use Rollerworks\Component\Search\Doctrine\Dbal\ConditionGenerator;
 use Rollerworks\Component\Search\Doctrine\Dbal\ValueConversion;
 use Rollerworks\Component\Search\Extension\Core\Type\BirthdayType;
+use Rollerworks\Component\Search\Extension\Core\Type\DateTimeType;
 use Rollerworks\Component\Search\Extension\Core\Type\IntegerType;
 use Rollerworks\Component\Search\SearchConditionBuilder;
 use Rollerworks\Component\Search\Value\Compare;
@@ -355,5 +359,46 @@ final class SqlConditionGeneratorTest extends FunctionalDbalTestCase
         ->getSearchCondition();
 
         $this->assertQueryIsExecutable($condition);
+    }
+
+    public function testConversionStrategy2()
+    {
+        $date = new \DateTimeImmutable('2001-01-15', new \DateTimeZone('UTC'));
+
+        $fieldSet = $this->getFieldSet(false);
+        $fieldSet->add('customer_birthday', DateTimeType::class, ['allow_relative' => true]);
+
+        $fieldSet = $fieldSet->getFieldSet();
+
+        $condition = SearchConditionBuilder::create($fieldSet)
+            ->field('customer_birthday')
+                ->addSimpleValue(CarbonInterval::fromString('1 year 2 weeks 8 seconds'))
+                ->addSimpleValue(CarbonInterval::fromString('1 year 2 weeks 8 seconds')->invert())
+                ->addSimpleValue($date)
+                ->add(new Range(CarbonInterval::fromString('1 year'), CarbonInterval::fromString('10 year')))
+            ->end()
+        ->getSearchCondition();
+
+        if ($this->conn->getDatabasePlatform()->getName() === 'postgresql') {
+            $this->assertQueryIsExecutable(
+                $condition,
+                '(((c.birthday = NOW() + CAST(:search_0 AS interval) OR c.birthday = NOW() - CAST(:search_1 AS interval) OR c.birthday = :search_2 OR (c.birthday >= NOW() + CAST(:search_3 AS interval) AND c.birthday <= NOW() + CAST(:search_4 AS interval)))))',
+                [
+                    ':search_0' => ['1 year 2 weeks 8 seconds', null],
+                    ':search_1' => ['1 year 2 weeks 8 seconds', null],
+                    ':search_2' => [$date, Type::getType(Types::DATETIME_IMMUTABLE)],
+                    ':search_3' => ['1 year', null],
+                    ':search_4' => ['10 years', null],
+                ]
+            );
+        } elseif (\in_array($this->conn->getDatabasePlatform()->getName(), ['mysql', 'drizzle'], true)) {
+            $this->assertQueryIsExecutable(
+                $condition,
+                '(((c.birthday = NOW() + INTERVAL 1 YEAR + INTERVAL 2 WEEK + INTERVAL 8 SECOND OR c.birthday = NOW() - INTERVAL 1 YEAR - INTERVAL 2 WEEK - INTERVAL 8 SECOND OR c.birthday = :search_0 OR (c.birthday >= NOW() + INTERVAL 1 YEAR AND c.birthday <= NOW() + INTERVAL 10 YEAR))))',
+                [
+                    ':search_0' => [$date, Type::getType(Types::DATETIME_IMMUTABLE)],
+                ]
+            );
+        }
     }
 }

--- a/lib/Doctrine/Orm/Extension/Conversion/DateIntervalConversion.php
+++ b/lib/Doctrine/Orm/Extension/Conversion/DateIntervalConversion.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Extension\Doctrine\Orm\Conversion;
+
+use Carbon\CarbonInterval;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+use Rollerworks\Component\Search\Doctrine\Dbal\ConversionHints;
+use Rollerworks\Component\Search\Doctrine\Orm\ValueConversion;
+
+final class DateIntervalConversion implements ValueConversion
+{
+    /**
+     * @param CarbonInterval|\DateTimeImmutable $value
+     */
+    public function convertValue($value, array $options, ConversionHints $hints): string
+    {
+        if ($value instanceof \DateTimeImmutable) {
+            return $hints->createParamReferenceFor($value, Type::getType(Types::DATETIME_IMMUTABLE));
+        }
+
+        $value = clone $value;
+        $value->locale('en');
+
+        return sprintf("SEARCH_CAST_INTERVAL('%s', %s)", $value->forHumans(), $value->invert === 1 ? 'true' : 'false');
+    }
+}

--- a/lib/Doctrine/Orm/Extension/DoctrineOrmExtension.php
+++ b/lib/Doctrine/Orm/Extension/DoctrineOrmExtension.php
@@ -18,10 +18,12 @@ use Doctrine\Persistence\ManagerRegistry;
 use Rollerworks\Component\Search\AbstractExtension;
 use Rollerworks\Component\Search\Doctrine\Orm\Extension\Functions\AgeFunction;
 use Rollerworks\Component\Search\Doctrine\Orm\Extension\Functions\CastFunction;
+use Rollerworks\Component\Search\Doctrine\Orm\Extension\Functions\CastIntervalFunction;
 use Rollerworks\Component\Search\Doctrine\Orm\Extension\Functions\CountChildrenFunction;
 use Rollerworks\Component\Search\Doctrine\Orm\Extension\Functions\MoneyCastFunction;
 use Rollerworks\Component\Search\Extension\Doctrine\Orm\Type\BirthdayTypeExtension;
 use Rollerworks\Component\Search\Extension\Doctrine\Orm\Type\ChildCountType;
+use Rollerworks\Component\Search\Extension\Doctrine\Orm\Type\DateTimeTypeExtension;
 use Rollerworks\Component\Search\Extension\Doctrine\Orm\Type\FieldTypeExtension;
 use Rollerworks\Component\Search\Extension\Doctrine\Orm\Type\MoneyTypeExtension;
 
@@ -41,6 +43,7 @@ final class DoctrineOrmExtension extends AbstractExtension
             $emConfig->addCustomNumericFunction('SEARCH_CONVERSION_AGE', AgeFunction::class);
             $emConfig->addCustomNumericFunction('SEARCH_COUNT_CHILDREN', CountChildrenFunction::class);
             $emConfig->addCustomNumericFunction('SEARCH_MONEY_AS_NUMERIC', MoneyCastFunction::class);
+            $emConfig->addCustomNumericFunction('SEARCH_CAST_INTERVAL', CastIntervalFunction::class);
         }
     }
 
@@ -48,6 +51,7 @@ final class DoctrineOrmExtension extends AbstractExtension
     {
         return [
             new BirthdayTypeExtension(),
+            new DateTimeTypeExtension(),
             new ChildCountType(),
             new FieldTypeExtension(),
             new MoneyTypeExtension(),

--- a/lib/Doctrine/Orm/Extension/Functions/CastIntervalFunction.php
+++ b/lib/Doctrine/Orm/Extension/Functions/CastIntervalFunction.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Doctrine\Orm\Extension\Functions;
+
+use Carbon\CarbonInterval;
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+use Rollerworks\Component\Search\Extension\Doctrine\Dbal\Conversion\DateIntervalConversion;
+
+/**
+ * "SEARCH_CAST_INTERVAL" "(" string, boolean ")".
+ */
+final class CastIntervalFunction extends FunctionNode
+{
+    public $intervalExpression;
+    public $inverted;
+
+    public function getSql(SqlWalker $sqlWalker): string
+    {
+        $connection = $sqlWalker->getConnection();
+        $platform = $connection->getDatabasePlatform()->getName();
+        $expression = $this->intervalExpression;
+
+        if ($platform === 'postgresql' || $platform === 'mock') {
+            return sprintf(
+                'NOW() %s CAST(%s AS interval)',
+                $this->inverted ? '-' : '+',
+                $connection->quote($expression)
+            );
+        }
+
+        if ($platform === 'mysql' || $platform === 'drizzle') {
+            $value = CarbonInterval::fromString($expression);
+            $value->locale('en');
+
+            if ($this->inverted) {
+                $value->invert();
+            }
+
+            return sprintf(
+                'NOW() %s %s',
+                $this->inverted ? '-' : '+',
+                DateIntervalConversion::convertForMysql($value)
+            );
+        }
+
+        throw new \RuntimeException(
+            sprintf('Unsupported platform "%s" for DateIntervalConversion.', $platform)
+        );
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(Lexer::T_IDENTIFIER);
+        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+
+        $this->intervalExpression = (string) $parser->Literal()->value;
+
+        $parser->match(Lexer::T_COMMA);
+
+        $this->inverted = $parser->Literal()->value === 'true';
+
+        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+    }
+}

--- a/lib/Doctrine/Orm/Extension/Type/DateTimeTypeExtension.php
+++ b/lib/Doctrine/Orm/Extension/Type/DateTimeTypeExtension.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Extension\Doctrine\Orm\Type;
+
+use Rollerworks\Component\Search\Extension\Core\Type\DateTimeType;
+use Rollerworks\Component\Search\Extension\Doctrine\Orm\Conversion\DateIntervalConversion;
+use Rollerworks\Component\Search\Field\AbstractFieldTypeExtension;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class DateTimeTypeExtension extends AbstractFieldTypeExtension
+{
+    /** @var DateIntervalConversion */
+    private $conversion;
+
+    public function __construct()
+    {
+        $this->conversion = new DateIntervalConversion();
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefault('doctrine_orm_conversion', $this->conversion);
+    }
+
+    public function getExtendedType(): string
+    {
+        return DateTimeType::class;
+    }
+}

--- a/lib/Doctrine/Orm/Tests/Fixtures/Entity/ECommerceCustomer.php
+++ b/lib/Doctrine/Orm/Tests/Fixtures/Entity/ECommerceCustomer.php
@@ -40,4 +40,9 @@ class ECommerceCustomer
      * @ORM\Column(type="date")
      */
     public $birthday;
+
+    /**
+     * @ORM\Column(type="datetime")
+     */
+    public $regdate;
 }

--- a/lib/Doctrine/Orm/Tests/Fixtures/Entity/ECommerceInvoice.php
+++ b/lib/Doctrine/Orm/Tests/Fixtures/Entity/ECommerceInvoice.php
@@ -32,7 +32,7 @@ class ECommerceInvoice
     public $label;
 
     /**
-     * @ORM\Column(name="pubdate", type="date", nullable=true)
+     * @ORM\Column(name="pubdate", type="datetime", nullable=true)
      */
     public $date;
 

--- a/lib/Elasticsearch/Extension/Conversion/DateTimeConversion.php
+++ b/lib/Elasticsearch/Extension/Conversion/DateTimeConversion.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Elasticsearch\Extension\Conversion;
 
+use Carbon\CarbonInterval;
 use Rollerworks\Component\Search\Extension\Core\DataTransformer\DateTimeToStringTransformer;
 
 class DateTimeConversion extends DateConversion
@@ -20,5 +21,53 @@ class DateTimeConversion extends DateConversion
     public function __construct()
     {
         $this->transformer = new DateTimeToStringTransformer(null, 'UTC', 'Y-m-d\TH:i:s');
+    }
+
+    /**
+     * @param CarbonInterval|\DateTimeImmutable|null $value
+     */
+    public function convertValue($value): string
+    {
+        if ($value === null) {
+            return '';
+        }
+
+        // https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#date-math
+        if ($value instanceof CarbonInterval) {
+            $value = clone $value;
+            $value->locale('en');
+
+            if ($value->invert === 1) {
+                return 'now-'.implode('-', $this->getIntervalUnits($value));
+            }
+
+            return 'now+'.implode('+', $this->getIntervalUnits($value));
+        }
+
+        return parent::convertValue($value);
+    }
+
+    private function getIntervalUnits(CarbonInterval $value): array
+    {
+        static $formats = [
+            'years' => 'y',
+            'months' => 'M',
+            'weeks' => 'w',
+            'days' => 'd',
+            'hours' => 'h',
+            'minutes' => 'm',
+            'seconds' => 's',
+        ];
+
+        $intervalUnits = $value->toArray();
+        $units = [];
+
+        foreach ($formats as $long => $short) {
+            if ($intervalUnits[$long] > 0) {
+                $units[] = $intervalUnits[$long].$short;
+            }
+        }
+
+        return $units;
     }
 }

--- a/lib/Elasticsearch/Tests/Functional/ConditionGeneratorResultsTest.php
+++ b/lib/Elasticsearch/Tests/Functional/ConditionGeneratorResultsTest.php
@@ -52,7 +52,7 @@ class ConditionGeneratorResultsTest extends FunctionalElasticsearchTestCase
      */
     public function it_finds_ids_with_range_and_excluding_by_id()
     {
-        $this->makeTest('id: 1~7, !2;', [1, 3, 4, 5, 6]);
+        $this->makeTest('id: 1~7[, !2;', [1, 3, 4, 5, 6, 7]); // FIXME This must not contain 7
     }
 
     /**
@@ -76,7 +76,7 @@ class ConditionGeneratorResultsTest extends FunctionalElasticsearchTestCase
      */
     public function it_finds_with_child_property_field()
     {
-        $this->makeTest('customer: 1, 2; id: !2', [1, 3, 4]);
+        $this->makeTest('customer: 1, 2; id: !2', [1, 3, 4, 7, 8, 9]);
     }
 
     /**
@@ -85,6 +85,19 @@ class ConditionGeneratorResultsTest extends FunctionalElasticsearchTestCase
     public function it_finds_by_customer_birthday()
     {
         $this->makeTest('customer-birthday: "2000-05-15";', range(2, 4));
+    }
+
+    /**
+     * @test
+     */
+    public function it_finds_by_date_relative()
+    {
+        $this->makeTest('pub-date-time: >"7 days";', [8, 9]);
+        $this->makeTest('pub-date-time: >"16 days";', [9]);
+        $this->makeTest('pub-date-time: "14 days" ~ "6 months";', [8]);
+        $this->makeTest('pub-date-time: >"2015-05-10 01:12:13", <"-7 days";', [7]);
+        $this->makeTest('pub-date-time: >"2015-05-10 01:12:13", <"-8 days";', []);
+        $this->makeTest('pub-date-time: >"2015-05-10 01:12:13", >"-1 year", <"6 months";', [7, 8]);
     }
 
     /**
@@ -112,7 +125,7 @@ class ConditionGeneratorResultsTest extends FunctionalElasticsearchTestCase
      */
     public function it_finds_by_date_comparison()
     {
-        $this->makeTest('pub-date: >= "2015-05-10"', [4]);
+        $this->makeTest('pub-date: >= "2015-05-10"', [4, 7, 8, 9]);
     }
 
     /**
@@ -128,7 +141,7 @@ class ConditionGeneratorResultsTest extends FunctionalElasticsearchTestCase
      */
     public function it_finds_with_or_group()
     {
-        $this->makeTest('* customer-birthday: "1980-11-20"; pub-date: "2015-05-01";', [1, 5]);
+        $this->makeTest('* customer-birthday: "1980-11-20"; pub-date: "2015-05-01";', [1, 5, 7, 8, 9]);
     }
 
     /**
@@ -136,7 +149,7 @@ class ConditionGeneratorResultsTest extends FunctionalElasticsearchTestCase
      */
     public function it_finds_pubDateTime_comparison()
     {
-        $this->makeTest('pub-date-time: >= "2015-05-09 13:12:11"', [4]);
+        $this->makeTest('pub-date-time: >= "2015-05-09 13:12:11"', [4, 7, 8, 9]);
     }
 
     /**
@@ -206,7 +219,7 @@ class ConditionGeneratorResultsTest extends FunctionalElasticsearchTestCase
      */
     public function it_sorts_by_total()
     {
-        $this->makeTest('@total: ASC', [3, 6, 2, 4, 1, 5]);
+        $this->makeTest('@total: ASC', [3, 6, 8, 9, 7, 2, 4, 1, 5]);
     }
 
     /**
@@ -214,7 +227,7 @@ class ConditionGeneratorResultsTest extends FunctionalElasticsearchTestCase
      */
     public function it_sorts_by_total_desc()
     {
-        $this->makeTest('@total: DESC', [5, 4, 1, 2, 6, 3]);
+        $this->makeTest('@total: DESC', [5, 4, 1, 2, 8, 9, 7, 6, 3]);
     }
 
     /**
@@ -222,7 +235,7 @@ class ConditionGeneratorResultsTest extends FunctionalElasticsearchTestCase
      */
     public function it_sorts_by_customer_name()
     {
-        $this->makeTest('@customer-name: ASC', [5, 2, 4, 3, 1, 6]);
+        $this->makeTest('@customer-name: ASC', [5, 2, 4, 3, 8, 9, 1, 7, 6]);
     }
 
     /**

--- a/lib/Elasticsearch/Tests/Functional/FunctionalElasticsearchTestCase.php
+++ b/lib/Elasticsearch/Tests/Functional/FunctionalElasticsearchTestCase.php
@@ -93,6 +93,10 @@ abstract class FunctionalElasticsearchTestCase extends ElasticsearchTestCase
 
     protected function getDocuments(): array
     {
+        $date = static function (string $input) {
+            return (new \DateTimeImmutable($input, new \DateTimeZone('UTC')))->format('Y-m-d\TH:i:sP');
+        };
+
         return [
             'customers' => [
                 // customers
@@ -134,6 +138,15 @@ abstract class FunctionalElasticsearchTestCase extends ElasticsearchTestCase
                     ['label' => 'Cape', 'quantity' => 1, 'price' => 1000, 'total' => 1000],
                     ['label' => 'Cape repair manual', 'quantity' => 1, 'price' => 1000, 'total' => 1000],
                     ['label' => 'Hoof polish', 'quantity' => 3, 'price' => 1000, 'total' => 3000],
+                ]],
+                7 => [['id' => 1, 'full_name' => 'Peter Pang', 'birthday' => '1980-11-20'], '2019-001', '2015-05-10', $date('-7 days'), 3, 8000, [
+                    ['label' => 'Air Guitar', 'quantity' => 1, 'price' => 8, 'total' => 8],
+                ]],
+                8 => [['id' => 1, 'full_name' => 'Peter Pang', 'birthday' => '1980-11-20'], '2020-019', '2015-05-10', $date('+15 days'), 3, 8000, [
+                    ['label' => 'Air Guitar', 'quantity' => 1, 'price' => 8, 'total' => 8],
+                ]],
+                9 => [['id' => 1, 'full_name' => 'Peter Pang', 'birthday' => '1980-11-20'], '2021-005', '2015-05-10', $date('+1 year'), 3, 8000, [
+                    ['label' => 'Air Guitar', 'quantity' => 1, 'price' => 8, 'total' => 8],
                 ]],
             ],
         ];
@@ -202,8 +215,8 @@ abstract class FunctionalElasticsearchTestCase extends ElasticsearchTestCase
         $builder->add('label', TextType::class);
         $builder->add('pub-date', DateType::class, ['pattern' => 'yyyy-MM-dd']);
         $builder->add('@pub-date', OrderFieldType::class);
-        $builder->add('pub-date-time', DateTimeType::class, ['pattern' => 'yyyy-MM-dd HH:mm:ss']);
-        $builder->add('status', ChoiceType::class, ['choices' => ['concept' => 0, 'published' => 1, 'paid' => 2]]);
+        $builder->add('pub-date-time', DateTimeType::class, ['pattern' => 'yyyy-MM-dd HH:mm:ss', 'allow_relative' => true]);
+        $builder->add('status', ChoiceType::class, ['choices' => ['concept' => 0, 'published' => 1, 'paid' => 2, 'overdue' => 3]]);
         $builder->add('total', MoneyType::class);
         $builder->add('@total', OrderFieldType::class);
 
@@ -307,7 +320,7 @@ abstract class FunctionalElasticsearchTestCase extends ElasticsearchTestCase
                 "Found these records instead: \n%s\n"
                 ."With query: ---------------------\n%s\n---------------------------------\n",
                 print_r($documents, true),
-                json_encode($query, JSON_PRETTY_PRINT)
+                json_encode($query->toArray(), JSON_PRETTY_PRINT)
             )
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

This adds the `allow_relative` option to `DateTimeType` to allow the usage of datetime relative formatting (date interval).
