### PR TITLE
PHP 8 compatibility and dropping support for Symfony < 4.4

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -1,3 +1,10 @@
+UPGRADE FROM 2.0-BETA1 to 2.0-BETA2
+===================================
+
+ * Support for PHP 7.1 was dropped, you need at least PHP 7.2 or greater.
+ 
+ * Support for Symfony below 4.4 was dropped.
+
 UPGRADE FROM 2.0-ALPHA23 to 2.0-ALPHA24
 =======================================
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": ">=7.2",
         "nesbot/carbon": "^2.38",
         "psr/container": "^1.0.0",
         "symfony/intl": "^4.4 || ^5.0",

--- a/lib/ApiPlatform/composer.json
+++ b/lib/ApiPlatform/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": ">=7.2",
         "api-platform/core": "^2.0.10",
         "rollerworks/search": "^2.0@dev,>=2.0.0-ALPHA23",
         "rollerworks/uri-encoder": "^1.1.0 || ^2.0",

--- a/lib/ApiPlatform/composer.json
+++ b/lib/ApiPlatform/composer.json
@@ -20,7 +20,7 @@
         "doctrine/orm": "^2.5.6",
         "phpunit/phpunit": "^6.3",
         "rollerworks/search-doctrine-orm": "^2.0@dev,>=2.0.0-BETA1",
-        "symfony/phpunit-bridge": "^4.3 || ^5.0"
+        "symfony/phpunit-bridge": "^4.4 || ^5.0"
     },
     "extra": {
         "branch-alias": {

--- a/lib/ApiPlatform/composer.json
+++ b/lib/ApiPlatform/composer.json
@@ -12,14 +12,14 @@
     "require": {
         "php": ">=7.2",
         "api-platform/core": "^2.0.10",
-        "rollerworks/search": "^2.0@dev,>=2.0.0-ALPHA23",
+        "rollerworks/search": "^2.0@dev,>=2.0.0-BETA1",
         "rollerworks/uri-encoder": "^1.1.0 || ^2.0",
         "symfony/http-foundation": "^4.4 || ^5.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.5.6",
         "phpunit/phpunit": "^6.3",
-        "rollerworks/search-doctrine-orm": "^2.0@dev,>=2.0.0-ALPHA23",
+        "rollerworks/search-doctrine-orm": "^2.0@dev,>=2.0.0-BETA1",
         "symfony/phpunit-bridge": "^4.3 || ^5.0"
     },
     "extra": {

--- a/lib/Core/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
+++ b/lib/Core/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
@@ -135,7 +135,7 @@ final class MoneyToLocalizedStringTransformer extends NumberToLocalizedStringTra
     protected function getNumberFormatter(): \NumberFormatter
     {
         $formatter = new \NumberFormatter(\Locale::getDefault(), \NumberFormatter::CURRENCY);
-        $formatter->setAttribute(\NumberFormatter::GROUPING_USED, $this->grouping);
+        $formatter->setAttribute(\NumberFormatter::GROUPING_USED, $this->grouping ? 1 : 0);
 
         return $formatter;
     }

--- a/lib/Core/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
+++ b/lib/Core/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
@@ -100,7 +100,7 @@ class NumberToLocalizedStringTransformer implements DataTransformer
     /**
      * Transforms a number type into localized number.
      *
-     * @param float|int|null $value Number value
+     * @param float|int|string|null $value Number value
      *
      * @throws TransformationFailedException if the given value is not numeric
      *                                       or if the value can not be transformed
@@ -118,7 +118,7 @@ class NumberToLocalizedStringTransformer implements DataTransformer
         }
 
         $formatter = $this->getNumberFormatter();
-        $value = $formatter->format($value);
+        $value = (string) $formatter->format((float) $value);
 
         if (\intl_is_failure($formatter->getErrorCode())) {
             throw new TransformationFailedException($formatter->getErrorMessage());
@@ -221,7 +221,7 @@ class NumberToLocalizedStringTransformer implements DataTransformer
             $formatter->setAttribute(\NumberFormatter::ROUNDING_MODE, $this->roundingMode);
         }
 
-        $formatter->setAttribute(\NumberFormatter::GROUPING_USED, $this->grouping);
+        $formatter->setAttribute(\NumberFormatter::GROUPING_USED, $this->grouping ? 1 : 0);
 
         return $formatter;
     }

--- a/lib/Core/ParameterBag.php
+++ b/lib/Core/ParameterBag.php
@@ -31,6 +31,6 @@ class ParameterBag
 
     public function injectParameters($template): string
     {
-        return \str_replace(\array_keys($this->parameters), \array_values($this->parameters), $template);
+        return \str_replace(\array_keys($this->parameters), \array_values($this->parameters), (string) $template);
     }
 }

--- a/lib/Core/composer.json
+++ b/lib/Core/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": ">=7.2",
         "nesbot/carbon": "^2.38",
         "psr/container": "^1.0.0",
         "symfony/intl": "^4.3 || ^5.0",

--- a/lib/Core/composer.json
+++ b/lib/Core/composer.json
@@ -23,10 +23,10 @@
         "php": ">=7.2",
         "nesbot/carbon": "^2.38",
         "psr/container": "^1.0.0",
-        "symfony/intl": "^4.3 || ^5.0",
-        "symfony/options-resolver": "^3.4.2 || ^4.0 || ^5.0",
-        "symfony/property-access": "^3.4.2 || ^4.0 || ^5.0",
-        "symfony/string": "^5.1"
+        "symfony/intl": "^4.4 || ^5.0",
+        "symfony/options-resolver": "^4.4 || ^5.0",
+        "symfony/property-access": "^4.4 || ^5.0",
+        "symfony/string": "^4.4 || ^5.0"
     },
     "conflict": {
         "moneyphp/money": "<3.2.0"
@@ -34,8 +34,8 @@
     "require-dev": {
         "moneyphp/money": "^3.2.0",
         "phpunit/phpunit": "^6.5.4",
-        "symfony/phpunit-bridge": "^4.3 || ^5.0",
-        "symfony/var-dumper": "^4.3 || ^5.0"
+        "symfony/phpunit-bridge": "^4.4 || ^5.0",
+        "symfony/var-dumper": "^4.4 || ^5.0"
     },
     "suggest": {
         "moneyphp/money": "To use the MoneyType"

--- a/lib/Doctrine/Dbal/composer.json
+++ b/lib/Doctrine/Dbal/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": ">=7.2",
         "doctrine/dbal": "^2.8",
         "psr/simple-cache": "^1.0.0",
         "rollerworks/search": "^2.0@dev,>=2.0.0-ALPHA23"

--- a/lib/Doctrine/Dbal/composer.json
+++ b/lib/Doctrine/Dbal/composer.json
@@ -23,7 +23,7 @@
         "php": ">=7.2",
         "doctrine/dbal": "^2.8",
         "psr/simple-cache": "^1.0.0",
-        "rollerworks/search": "^2.0@dev,>=2.0.0-ALPHA23"
+        "rollerworks/search": "^2.0@dev,>=2.0.0-BETA1"
     },
     "require-dev": {
         "moneyphp/money": "^3.0.7",

--- a/lib/Doctrine/Dbal/composer.json
+++ b/lib/Doctrine/Dbal/composer.json
@@ -27,8 +27,8 @@
     },
     "require-dev": {
         "moneyphp/money": "^3.0.7",
-        "symfony/phpunit-bridge": "^3.4.2 || ^4.0.2 || ^5.0",
-        "symfony/var-dumper": "^3.4.2 || ^4.0.2 || ^5.0"
+        "symfony/phpunit-bridge": "^4.4 || ^5.0",
+        "symfony/var-dumper": "^4.4 || ^5.0"
     },
     "config": {
         "platform": {

--- a/lib/Doctrine/Orm/composer.json
+++ b/lib/Doctrine/Orm/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": ">=7.2",
         "doctrine/orm": "^2.6",
         "rollerworks/search": "^2.0@dev,>=2.0.0-ALPHA23",
         "rollerworks/search-doctrine-dbal": "^2.0@dev,>=2.0.0-ALPHA23"

--- a/lib/Doctrine/Orm/composer.json
+++ b/lib/Doctrine/Orm/composer.json
@@ -22,8 +22,8 @@
     "require": {
         "php": ">=7.2",
         "doctrine/orm": "^2.6",
-        "rollerworks/search": "^2.0@dev,>=2.0.0-ALPHA23",
-        "rollerworks/search-doctrine-dbal": "^2.0@dev,>=2.0.0-ALPHA23"
+        "rollerworks/search": "^2.0@dev,>=2.0.0-BETA1",
+        "rollerworks/search-doctrine-dbal": "^2.0@dev,>=2.0.0-BETA1"
     },
     "require-dev": {
         "moneyphp/money": "^3.0.7",
@@ -32,9 +32,6 @@
         "symfony/var-dumper": "^3.4.2 || ^4.0.2 || ^5.0"
     },
     "config": {
-        "platform": {
-            "php": "7.1"
-        },
         "preferred-install": {
             "doctrine/dbal": "source",
             "doctrine/orm": "source",

--- a/lib/Doctrine/Orm/composer.json
+++ b/lib/Doctrine/Orm/composer.json
@@ -28,8 +28,8 @@
     "require-dev": {
         "moneyphp/money": "^3.0.7",
         "phpunit/phpunit": "^6.5.4",
-        "symfony/phpunit-bridge": "^4.3 || ^5.0",
-        "symfony/var-dumper": "^3.4.2 || ^4.0.2 || ^5.0"
+        "symfony/phpunit-bridge": "^4.4 || ^5.0",
+        "symfony/var-dumper": "^4.4 || ^5.0"
     },
     "config": {
         "preferred-install": {

--- a/lib/Elasticsearch/composer.json
+++ b/lib/Elasticsearch/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=7.2",
         "psr/simple-cache": "^1.0",
-        "rollerworks/search": "^2.0@dev,>=2.0.0-ALPHA13",
+        "rollerworks/search": "^2.0@dev,>=2.0.0-BETA1",
         "ruflin/elastica": "^4.0 || ^5.0 || ^6.0"
     },
     "require-dev": {

--- a/lib/Elasticsearch/composer.json
+++ b/lib/Elasticsearch/composer.json
@@ -27,8 +27,8 @@
     },
     "require-dev": {
         "moneyphp/money": "^3.0",
-        "symfony/phpunit-bridge": "^4.3 || ^5.0",
-        "symfony/var-dumper": "^3.4.2 || ^4.0.2 || ^5.0"
+        "symfony/phpunit-bridge": "^4.4 || ^5.0",
+        "symfony/var-dumper": "^4.4 || ^5.0"
     },
     "extra": {
         "branch-alias": {

--- a/lib/Elasticsearch/composer.json
+++ b/lib/Elasticsearch/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": ">=7.2",
         "psr/simple-cache": "^1.0",
         "rollerworks/search": "^2.0@dev,>=2.0.0-ALPHA13",
         "ruflin/elastica": "^4.0 || ^5.0 || ^6.0"

--- a/lib/Symfony/SearchBundle/composer.json
+++ b/lib/Symfony/SearchBundle/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": ">=7.2",
         "psr/simple-cache": "^1.0.0",
         "rollerworks/search": "^2.0@dev,>=2.0.0-ALPHA23",
         "symfony/framework-bundle": "^4.4 || ^5.0",

--- a/lib/Symfony/SearchBundle/composer.json
+++ b/lib/Symfony/SearchBundle/composer.json
@@ -34,12 +34,12 @@
         "matthiasnoback/symfony-service-definition-validator": "^1.2.8",
         "phpunit/phpunit": "^6.5.4",
         "rollerworks/search-symfony-validator": "^2.0@dev,>=2.0.0-BETA1",
-        "symfony/asset": "^3.4.2 || ^4.0.2 || ^5.0",
-        "symfony/browser-kit": "^3.4.2 || ^4.0.2 || ^5.0",
-        "symfony/dom-crawler": "^3.4.2 || ^4.0.2 || ^5.0",
-        "symfony/phpunit-bridge": "^4.3 || ^5.0",
-        "symfony/routing": "^3.4.2 || ^4.0.2 || ^5.0",
-        "symfony/templating": "^3.4.2 || ^4.0.2 || ^5.0"
+        "symfony/asset": "^4.4 || ^5.0",
+        "symfony/browser-kit": "^4.4 || ^5.0",
+        "symfony/dom-crawler": "^4.4 || ^5.0",
+        "symfony/phpunit-bridge": "^4.4 || ^5.0",
+        "symfony/routing": "^4.4 || ^5.0",
+        "symfony/templating": "^4.4 || ^5.0"
     },
     "config": {
         "sort-packages": true

--- a/lib/Symfony/SearchBundle/composer.json
+++ b/lib/Symfony/SearchBundle/composer.json
@@ -25,15 +25,15 @@
     },
     "conflict": {
         "doctrine/doctrine-bundle": "<1.1",
-        "rollerworks/search-doctrine-dbal": "<2.0.0-ALPHA23",
-        "rollerworks/search-doctrine-orm": "<2.0.0-ALPHA23",
-        "rollerworks/search-symfony-validator": "<2.0.0-ALPHA23"
+        "rollerworks/search-doctrine-dbal": "<2.0.0-BETA1",
+        "rollerworks/search-doctrine-orm": "<2.0.0-BETA1",
+        "rollerworks/search-symfony-validator": "<2.0.0-BETA1"
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^2.0.0",
         "matthiasnoback/symfony-service-definition-validator": "^1.2.8",
         "phpunit/phpunit": "^6.5.4",
-        "rollerworks/search-symfony-validator": "^2.0@dev,>=2.0.0-ALPHA23",
+        "rollerworks/search-symfony-validator": "^2.0@dev,>=2.0.0-BETA1",
         "symfony/asset": "^3.4.2 || ^4.0.2 || ^5.0",
         "symfony/browser-kit": "^3.4.2 || ^4.0.2 || ^5.0",
         "symfony/dom-crawler": "^3.4.2 || ^4.0.2 || ^5.0",

--- a/lib/Symfony/Validator/composer.json
+++ b/lib/Symfony/Validator/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": ">=7.2",
         "rollerworks/search": "^2.0@dev,>=2.0.0-ALPHA13",
         "symfony/validator": "^4.4 || ^5.0"
     },

--- a/lib/Symfony/Validator/composer.json
+++ b/lib/Symfony/Validator/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=7.2",
-        "rollerworks/search": "^2.0@dev,>=2.0.0-ALPHA13",
+        "rollerworks/search": "^2.0@dev,>=2.0.0-BETA1",
         "symfony/validator": "^4.4 || ^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT

* Add support PHP 8 and, and bump minimum version to PHP 7.2 (which is still rather old).
* All Symfony versions below 4.4 were already not tested in detail, but I feel it's better to drop support for these older versions completely.
