### PR TITLE
[Doctrine ORM] Add support for ordering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-QA_DOCKER_IMAGE=jakzal/phpqa:1.41.0-php7.4-alpine
+QA_DOCKER_IMAGE=jakzal/phpqa:1.58.9-php7.4-alpine
 QA_DOCKER_COMMAND=docker run --init -t --rm --user "$(shell id -u):$(shell id -g)" --volume /tmp/tmp-phpqa-$(shell id -u):/tmp --volume "$(shell pwd):/project" --workdir /project ${QA_DOCKER_IMAGE}
 
 dist: install cs-full phpstan test

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -5,6 +5,37 @@ UPGRADE FROM 2.0-BETA1 to 2.0-BETA2
  
  * Support for Symfony below 4.4 was dropped.
 
+### Doctrine ORM
+
+ * Support for passing a `Doctrine\ORM\Query` object in the generators was removed, 
+   pass a `Doctrine\ORM\QueryBuilder` object instead.
+   
+  _This BC change was required to make applying of result-ordering possible without worrying
+   to much about details and edge-cases._
+
+ * The methods `getWhereClause()` and `getParameters()` on the ConditionGenerators were removed.
+   _It's still possible to generate a stand-alone where-clause by using the `DqlConditionGenerator` directly, 
+    but this is not officially supported nor documented._
+
+ * The `createCachedConditionGenerator` of `DoctrineOrmFactory` now expects a
+   a `QueryBuilder` and `SearchCondition` are provided instead of a ConditionGenerator.
+
+   Before:
+   
+      ```php
+      $generator = $ormFactory->createConditionGenerator($query, $searchCondition);
+      $generator = $ormFactory->createCachedConditionGenerator($generator, 60 * 60);
+      ```
+   
+   Now:
+   
+      ```php
+      $generator = $ormFactory->createCachedConditionGenerator($query, $searchCondition, 60 * 60);
+      ```
+   
+ * The `updateQuery()` method on the ConditionGenerators was renamed to `apply()` and no 
+   longer supports a prepend for the query, as the query must now always be a `QueryBuilder`.
+
 UPGRADE FROM 2.0-ALPHA23 to 2.0-ALPHA24
 =======================================
 

--- a/lib/ApiPlatform/Doctrine/Orm/Extension/SearchExtension.php
+++ b/lib/ApiPlatform/Doctrine/Orm/Extension/SearchExtension.php
@@ -66,12 +66,10 @@ final class SearchExtension implements QueryCollectionExtensionInterface
         ArrayKeysValidator::assertOnlyKeys($configuration, ['relations', 'mappings'], $configPath);
         $this->configureRelations($configPath, $configuration, $queryBuilder);
 
-        $conditionGenerator = $this->ormFactory->createCachedConditionGenerator(
-            $this->ormFactory->createConditionGenerator($queryBuilder, $condition)
-        );
+        $conditionGenerator = $this->ormFactory->createCachedConditionGenerator($queryBuilder, $condition);
 
         $this->configureMappings($resourceClass, $configuration, $configPath, $conditionGenerator);
-        $conditionGenerator->updateQuery();
+        $conditionGenerator->apply();
     }
 
     private function configureRelations(string $configPath, array $configuration, QueryBuilder $queryBuilder): void

--- a/lib/ApiPlatform/Tests/Doctrine/Orm/Extension/SearchExtensionTest.php
+++ b/lib/ApiPlatform/Tests/Doctrine/Orm/Extension/SearchExtensionTest.php
@@ -24,7 +24,6 @@ use Prophecy\Argument;
 use Rollerworks\Component\Search\ApiPlatform\Doctrine\Orm\Extension\SearchExtension;
 use Rollerworks\Component\Search\Doctrine\Orm\CachedDqlConditionGenerator;
 use Rollerworks\Component\Search\Doctrine\Orm\DoctrineOrmFactory;
-use Rollerworks\Component\Search\Doctrine\Orm\DqlConditionGenerator;
 use Rollerworks\Component\Search\FieldSet;
 use Rollerworks\Component\Search\SearchCondition;
 use Rollerworks\Component\Search\Value\ValuesGroup;
@@ -42,17 +41,13 @@ final class SearchExtensionTest extends TestCase
         $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
         $queryBuilder = $queryBuilderProphecy->reveal();
 
-        $conditionGeneratorProphecy = $this->prophesize(DqlConditionGenerator::class);
-        $conditionGenerator = $conditionGeneratorProphecy->reveal();
-
         $cachedConditionGeneratorProphecy = $this->prophesize(CachedDqlConditionGenerator::class);
         $cachedConditionGeneratorProphecy->setField('dummy-id', 'id', 'o', Dummy::class, null)->shouldBeCalled();
         $cachedConditionGeneratorProphecy->setField('dummy-name', 'name', 'o', Dummy::class, null)->shouldBeCalled();
-        $cachedConditionGeneratorProphecy->updateQuery()->shouldBeCalled();
+        $cachedConditionGeneratorProphecy->apply()->shouldBeCalled();
 
         $ormFactoryProphecy = $this->prophesize(DoctrineOrmFactory::class);
-        $ormFactoryProphecy->createConditionGenerator($queryBuilder, $searchCondition)->willReturn($conditionGenerator);
-        $ormFactoryProphecy->createCachedConditionGenerator($conditionGenerator)->willReturn($cachedConditionGeneratorProphecy->reveal());
+        $ormFactoryProphecy->createCachedConditionGenerator($queryBuilder, $searchCondition)->willReturn($cachedConditionGeneratorProphecy->reveal());
 
         $request = new Request([], [], [
             '_api_search_condition' => $searchCondition,
@@ -84,20 +79,16 @@ final class SearchExtensionTest extends TestCase
         $queryBuilderProphecy->leftJoin('o.thirdLevel', 't', 'WITH', 't.id = o.id', 'o.id')->shouldBeCalled();
         $queryBuilder = $queryBuilderProphecy->reveal();
 
-        $conditionGeneratorProphecy = $this->prophesize(DqlConditionGenerator::class);
-        $conditionGenerator = $conditionGeneratorProphecy->reveal();
-
         $cachedConditionGeneratorProphecy = $this->prophesize(CachedDqlConditionGenerator::class);
         $cachedConditionGeneratorProphecy->setField('dummy-id', 'id', 'o', RelatedDummy::class, null)->shouldBeCalled();
         $cachedConditionGeneratorProphecy->setField('dummy-name', 'name', 'o', RelatedDummy::class, null)->shouldBeCalled();
         $cachedConditionGeneratorProphecy->setField('fiend-name', 'name', 'r', RelatedDummy::class, null)->shouldBeCalled();
         $cachedConditionGeneratorProphecy->setField('level', 'level', 't', ThirdLevel::class, 'integer')->shouldBeCalled();
 
-        $cachedConditionGeneratorProphecy->updateQuery()->shouldBeCalled();
+        $cachedConditionGeneratorProphecy->apply()->shouldBeCalled();
 
         $ormFactoryProphecy = $this->prophesize(DoctrineOrmFactory::class);
-        $ormFactoryProphecy->createConditionGenerator($queryBuilder, $searchCondition)->willReturn($conditionGenerator);
-        $ormFactoryProphecy->createCachedConditionGenerator($conditionGenerator)->willReturn($cachedConditionGeneratorProphecy->reveal());
+        $ormFactoryProphecy->createCachedConditionGenerator($queryBuilder, $searchCondition)->willReturn($cachedConditionGeneratorProphecy->reveal());
 
         $request = new Request([], [], [
             '_api_search_condition' => $searchCondition,
@@ -143,13 +134,10 @@ final class SearchExtensionTest extends TestCase
         $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
         $queryBuilder = $queryBuilderProphecy->reveal();
 
-        $conditionGeneratorProphecy = $this->prophesize(DqlConditionGenerator::class);
-        $conditionGenerator = $conditionGeneratorProphecy->reveal();
         $cachedConditionGeneratorProphecy = $this->prophesize(CachedDqlConditionGenerator::class);
 
         $ormFactoryProphecy = $this->prophesize(DoctrineOrmFactory::class);
-        $ormFactoryProphecy->createConditionGenerator($queryBuilder, $searchCondition)->willReturn($conditionGenerator);
-        $ormFactoryProphecy->createCachedConditionGenerator($conditionGenerator)->willReturn($cachedConditionGeneratorProphecy->reveal());
+        $ormFactoryProphecy->createCachedConditionGenerator($queryBuilder, $searchCondition)->willReturn($cachedConditionGeneratorProphecy->reveal());
 
         $request = new Request([], [], [
             '_api_search_condition' => $searchCondition,
@@ -244,7 +232,7 @@ final class SearchExtensionTest extends TestCase
     public function apply_to_collection_without_condition(): void
     {
         $ormFactoryProphecy = $this->prophesize(DoctrineOrmFactory::class);
-        $ormFactoryProphecy->createCachedConditionGenerator(Argument::any())->shouldNotBeCalled();
+        $ormFactoryProphecy->createCachedConditionGenerator(Argument::any(), Argument::any())->shouldNotBeCalled();
 
         $queryBuilderProphecy = $this->prophesize(QueryBuilder::class);
         $queryBuilder = $queryBuilderProphecy->reveal();

--- a/lib/ApiPlatform/composer.json
+++ b/lib/ApiPlatform/composer.json
@@ -12,14 +12,14 @@
     "require": {
         "php": ">=7.2",
         "api-platform/core": "^2.0.10",
-        "rollerworks/search": "^2.0@dev,>=2.0.0-BETA1",
+        "rollerworks/search": "^2.0@dev,>=2.0.0-BETA2",
         "rollerworks/uri-encoder": "^1.1.0 || ^2.0",
         "symfony/http-foundation": "^4.4 || ^5.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.5.6",
         "phpunit/phpunit": "^6.3",
-        "rollerworks/search-doctrine-orm": "^2.0@dev,>=2.0.0-BETA1",
+        "rollerworks/search-doctrine-orm": "^2.0@dev,>=2.0.0-BETA2",
         "symfony/phpunit-bridge": "^4.4 || ^5.0"
     },
     "extra": {

--- a/lib/Core/Extension/Core/DataTransformer/MultiTypeDataTransformer.php
+++ b/lib/Core/Extension/Core/DataTransformer/MultiTypeDataTransformer.php
@@ -44,7 +44,7 @@ final class MultiTypeDataTransformer implements DataTransformer
             return '';
         }
 
-        $type = \get_debug_type($value);
+        $type = get_debug_type($value);
 
         if (! isset($this->transformers[$type])) {
             throw new TransformationFailedException(\sprintf('Unsupported type "%s".', $type));

--- a/lib/Core/SearchOrder.php
+++ b/lib/Core/SearchOrder.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search;
 
+use Rollerworks\Component\Search\Exception\InvalidArgumentException;
 use Rollerworks\Component\Search\Value\ValuesGroup;
 
 /**
@@ -24,11 +25,32 @@ final class SearchOrder
 
     public function __construct(ValuesGroup $valuesGroup)
     {
+        if ($valuesGroup->hasGroups()) {
+            throw new InvalidArgumentException('A SearchOrder must have a single-level structure. Only fields with single values are accepted.');
+        }
+
         $this->values = $valuesGroup;
     }
 
     public function getValuesGroup(): ValuesGroup
     {
         return $this->values;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getFields(): array
+    {
+        $fields = [];
+
+        foreach ($this->values->getFields() as $fieldName => $valuesBag) {
+            $direction = \strtolower(\current($valuesBag->getSimpleValues()));
+            \assert($direction === 'desc' || $direction === 'asc');
+
+            $fields[$fieldName] = $direction;
+        }
+
+        return $fields;
     }
 }

--- a/lib/Doctrine/Dbal/Tests/DbalTestCase.php
+++ b/lib/Doctrine/Dbal/Tests/DbalTestCase.php
@@ -20,6 +20,7 @@ use Rollerworks\Component\Search\Extension\Core\Type\DateTimeType;
 use Rollerworks\Component\Search\Extension\Core\Type\IntegerType;
 use Rollerworks\Component\Search\Extension\Core\Type\TextType;
 use Rollerworks\Component\Search\Extension\Doctrine\Dbal\DoctrineDbalExtension;
+use Rollerworks\Component\Search\Field\OrderFieldType;
 use Rollerworks\Component\Search\Test\SearchIntegrationTestCase;
 use Rollerworks\Component\Search\Tests\Doctrine\Dbal\Mocks\ConnectionMock;
 use Rollerworks\Component\Search\Tests\Doctrine\Dbal\Stub\Type\InvoiceLabelType;
@@ -32,10 +33,12 @@ abstract class DbalTestCase extends SearchIntegrationTestCase
         $fieldSet = $this->getFactory()->createFieldSetBuilder();
 
         $fieldSet->add('id', IntegerType::class);
+        $fieldSet->add('@id', OrderFieldType::class);
         $fieldSet->add('label', InvoiceLabelType::class);
         $fieldSet->add('status', InvoiceStatusType::class);
 
         $fieldSet->add('customer', IntegerType::class);
+        $fieldSet->add('@customer', OrderFieldType::class);
         $fieldSet->add('customer_name', TextType::class);
         $fieldSet->add('customer_birthday', DateTimeType::class, ['allow_relative' => true]);
 

--- a/lib/Doctrine/Dbal/Tests/Functional/FunctionalDbalTestCase.php
+++ b/lib/Doctrine/Dbal/Tests/Functional/FunctionalDbalTestCase.php
@@ -158,7 +158,7 @@ abstract class FunctionalDbalTestCase extends DbalTestCase
         foreach ($conditionGenerator->getParameters() as $name => [$value, $type]) {
             $statement->bindValue($name, $value, $type);
 
-            $paramsString .= \sprintf("%s = '%s'\n", $name, $type === null ? (\is_scalar($value) ? (string) $value : \get_debug_type($value)) : $type->convertToDatabaseValue($value, $platform));
+            $paramsString .= \sprintf("%s = '%s'\n", $name, $type === null ? (\is_scalar($value) ? (string) $value : get_debug_type($value)) : $type->convertToDatabaseValue($value, $platform));
         }
 
         $statement->execute();

--- a/lib/Doctrine/Orm/ConditionGenerator.php
+++ b/lib/Doctrine/Orm/ConditionGenerator.php
@@ -13,9 +13,8 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Doctrine\Orm;
 
-use Doctrine\Common\Collections\ArrayCollection;
-use Rollerworks\Component\Search\Exception\BadMethodCallException;
-use Rollerworks\Component\Search\Exception\UnknownFieldException;
+use Doctrine\ORM\QueryBuilder;
+use Rollerworks\Component\Search\SearchCondition;
 
 /**
  * A Doctrine ORM ConditionGenerator generates an DQL/SQL WHERE-clause
@@ -39,9 +38,7 @@ interface ConditionGenerator
      * @param string $entity Entity name (FQCN)
      * @param string $alias  Table alias as used in the query "u" for `FROM Acme:Users AS u`
      *
-     * @throws BadMethodCallException When the where-clause is already generated
-     *
-     * @return static
+     * @return $this
      */
     public function setDefaultEntity(string $entity, string $alias);
 
@@ -74,37 +71,18 @@ interface ConditionGenerator
      * @param string $fieldName Name of the search field as registered in the FieldSet or
      *                          `field-name#mapping-name` to configure a secondary mapping
      * @param string $property  Entity field name
-     * @param string $alias     Table alias as used in the query "u" for `FROM Acme:Users AS u`
+     * @param string $alias     Table alias as used in the query "u" for `FROM Acme\Entity\User AS u`
      * @param string $entity    Entity name (FQCN or Doctrine aliased)
      * @param string $dbType    Doctrine DBAL supported type, eg. string (not text)
      *
-     * @throws UnknownFieldException  When the field is not registered in the fieldset
-     * @throws BadMethodCallException When the where-clause is already generated
-     *
-     * @return static
+     * @return $this
      */
     public function setField(string $fieldName, string $property, string $alias = null, string $entity = null, string $dbType = null);
 
     /**
-     * Returns the generated where-clause.
-     *
-     * The Where-clause is wrapped inside a group so it can be safely used
-     * with other conditions.
-     *
-     * @param string $prependQuery Prepend before the generated WHERE clause
-     *                             Eg. " WHERE " or " AND ", ignored when WHERE
-     *                             clause is empty.
+     * Apply the SearchCondition to the QueryBuilder (as an AND-WHERE).
      */
-    public function getWhereClause(string $prependQuery = ''): string;
+    public function apply();
 
-    /**
-     * Updates the configured query object with the where-clause.
-     *
-     * @param string $prependQuery Prepend before the generated WHERE clause
-     *                             Eg. " WHERE " or " AND ", ignored when WHERE
-     *                             clause is empty. Default is ' WHERE '
-     */
-    public function updateQuery(string $prependQuery = ' WHERE ');
-
-    public function getParameters(): ArrayCollection;
+    public function getQueryBuilder(): QueryBuilder;
 }

--- a/lib/Doctrine/Orm/DoctrineOrmFactory.php
+++ b/lib/Doctrine/Orm/DoctrineOrmFactory.php
@@ -13,14 +13,11 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Doctrine\Orm;
 
-use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Psr\SimpleCache\CacheInterface as Cache;
 use Rollerworks\Component\Search\SearchCondition;
 
 /**
- * @author Sebastiaan Stok <s.stok@rollerscapes.net>
- *
  * @final
  */
 class DoctrineOrmFactory
@@ -39,27 +36,25 @@ class DoctrineOrmFactory
      * Creates a new ConditionGenerator for the SearchCondition.
      *
      * Conversions are applied using the 'doctrine_dbal_conversion' option (when present).
-     *
-     * @param Query|QueryBuilder $query
      */
-    public function createConditionGenerator($query, SearchCondition $searchCondition): DqlConditionGenerator
+    public function createConditionGenerator(QueryBuilder $query, SearchCondition $searchCondition): QueryBuilderConditionGenerator
     {
-        return new DqlConditionGenerator($query, $searchCondition);
+        return new QueryBuilderConditionGenerator($query, $searchCondition);
     }
 
     /**
-     * Creates a new CachedConditionGenerator instance for the ConditionGenerator.
+     * Creates a new CachedConditionGenerator for the SearchCondition.
      *
      * @param \DateInterval|int|null $ttl Optional. The TTL value of this item. If no value is sent and
      *                                    the driver supports TTL then the library may set a default value
      *                                    for it or let the driver take care of that.
      */
-    public function createCachedConditionGenerator(ConditionGenerator $conditionGenerator, $ttl = null): ConditionGenerator
+    public function createCachedConditionGenerator(QueryBuilder $query, SearchCondition $searchCondition, $ttl = null): ConditionGenerator
     {
         if ($this->cacheDriver === null) {
-            return $conditionGenerator;
+            return $this->createConditionGenerator($query, $searchCondition);
         }
 
-        return new CachedDqlConditionGenerator($conditionGenerator, $this->cacheDriver, $ttl);
+        return new CachedDqlConditionGenerator($query, $searchCondition, $this->cacheDriver, $ttl);
     }
 }

--- a/lib/Doctrine/Orm/DqlConditionGenerator.php
+++ b/lib/Doctrine/Orm/DqlConditionGenerator.php
@@ -15,13 +15,12 @@ namespace Rollerworks\Component\Search\Doctrine\Orm;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Query as DqlQuery;
 use Doctrine\ORM\QueryBuilder;
 use Rollerworks\Component\Search\Doctrine\Dbal\Query\QueryGenerator;
 use Rollerworks\Component\Search\Doctrine\Orm\QueryPlatform\DqlQueryPlatform;
 use Rollerworks\Component\Search\Exception\BadMethodCallException;
-use Rollerworks\Component\Search\Exception\UnexpectedTypeException;
 use Rollerworks\Component\Search\SearchCondition;
+use Rollerworks\Component\Search\SearchOrder;
 
 /**
  * SearchCondition Doctrine ORM DQL ConditionGenerator.
@@ -29,22 +28,9 @@ use Rollerworks\Component\Search\SearchCondition;
  * This class provides the functionality for creating a DQL
  * WHERE-clause based on the provided SearchCondition.
  *
- * Note that only fields that have been configured with `setField()`
- * will be actually used in the generated query.
- *
- * Keep the following in mind when using conversions.
- *
- *  * Conversions are performed per search field and must be stateless, they receive the db-type
- *    and connection information for the conversion process.
- *  * Unlike DBAL conversions the conversion must be DQL (not SQL)
- *  * Values must be registered as parameters (using the ConversionHints)
- *  * Conversion results must be properly escaped to prevent DQL injections.
- *
- * @author Sebastiaan Stok <s.stok@rollerscapes.net>
- *
- * @final
+ * Note: This class should not be used directly, use the provided ConditionGenerators instead.
  */
-class DqlConditionGenerator implements ConditionGenerator
+final class DqlConditionGenerator
 {
     /**
      * @var SearchCondition
@@ -71,128 +57,53 @@ class DqlConditionGenerator implements ConditionGenerator
      */
     private $parameters;
 
-    /**
-     * @var DqlQuery|QueryBuilder
-     */
-    private $query;
-
-    public function __construct($query, SearchCondition $searchCondition)
+    public function __construct(EntityManagerInterface $entityManager, SearchCondition $searchCondition, FieldConfigBuilder $configBuilder)
     {
-        if (! $query instanceof DqlQuery && ! $query instanceof QueryBuilder) {
-            throw new UnexpectedTypeException($query, [DqlQuery::class, QueryBuilder::class]);
-        }
-
-        $this->entityManager = $query->getEntityManager();
-        $this->fieldsConfig = new FieldConfigBuilder($this->entityManager, $searchCondition->getFieldSet());
+        $this->entityManager = $entityManager;
         $this->searchCondition = $searchCondition;
-        $this->parameters = new ArrayCollection();
-        $this->query = $query;
+        $this->fieldsConfig = $configBuilder;
     }
 
-    public function setDefaultEntity(string $entity, string $alias)
+    public function getWhereClause(): string
     {
-        $this->guardNotGenerated();
-        $this->fieldsConfig->setDefaultEntity($entity, $alias);
+        $fields = $this->fieldsConfig->getFields();
+        $connection = $this->entityManager->getConnection();
+        $platform = new DqlQueryPlatform($connection);
+        $queryGenerator = new QueryGenerator($connection, $platform, $fields);
 
-        return $this;
-    }
+        $this->whereClause = $queryGenerator->getWhereClause($this->searchCondition);
+        $this->parameters = $platform->getParameters();
 
-    /**
-     * @throws BadMethodCallException When the where-clause is already generated
-     */
-    protected function guardNotGenerated(): void
-    {
-        if ($this->whereClause !== null) {
-            throw new BadMethodCallException(
-                'ConditionGenerator configuration methods cannot be accessed anymore once the where-clause is generated.'
-            );
-        }
-    }
-
-    public function setField(string $fieldName, string $property, string $alias = null, string $entity = null, string $dbType = null)
-    {
-        $this->guardNotGenerated();
-        $this->fieldsConfig->setField($fieldName, $property, $alias, $entity, $dbType);
-
-        return $this;
-    }
-
-    public function getWhereClause(string $prependQuery = ''): string
-    {
-        if ($this->whereClause === null) {
-            $fields = $this->fieldsConfig->getFields();
-            $connection = $this->entityManager->getConnection();
-            $platform = new DqlQueryPlatform($connection);
-            $queryGenerator = new QueryGenerator($connection, $platform, $fields);
-
-            $this->whereClause = $queryGenerator->getWhereClause($this->searchCondition);
-            $this->parameters = $platform->getParameters();
-        }
-
-        if ($this->whereClause !== '') {
-            return $prependQuery . $this->whereClause;
-        }
-
-        return '';
-    }
-
-    public function updateQuery(string $prependQuery = ' WHERE '): self
-    {
-        $whereCase = $this->getWhereClause($prependQuery);
-
-        if ($whereCase === '') {
-            return $this;
-        }
-
-        if ($this->query instanceof QueryBuilder) {
-            $this->query->andWhere($this->getWhereClause());
-        } else {
-            $this->query->setDQL($this->query->getDQL() . $whereCase);
-        }
-
-        foreach ($this->parameters as $name => [$value, $type]) {
-            $this->query->setParameter($name, $value, $type);
-        }
-
-        return $this;
+        return $this->whereClause;
     }
 
     public function getParameters(): ArrayCollection
     {
+        if (! isset($this->parameters)) {
+            throw new BadMethodCallException('getParameters() cannot be called before getWhereClause()');
+        }
+
         return $this->parameters;
     }
 
-    /**
-     * @internal
-     */
-    public function getSearchCondition(): SearchCondition
+    public static function applySortingTo(?SearchOrder $order, QueryBuilder $qb, FieldConfigBuilder $configBuilder): void
     {
-        return $this->searchCondition;
-    }
+        if ($order === null) {
+            return;
+        }
 
-    /**
-     * @internal
-     */
-    public function getEntityManager(): EntityManagerInterface
-    {
-        return $this->entityManager;
-    }
+        $fields = $configBuilder->getFields();
 
-    /**
-     * @internal
-     */
-    public function getFieldsConfig(): FieldConfigBuilder
-    {
-        return $this->fieldsConfig;
-    }
+        foreach ($order->getFields() as $fieldName => $direction) {
+            if (! isset($fields[$fieldName])) {
+                continue;
+            }
 
-    /**
-     * @internal
-     *
-     * @return DqlQuery|QueryBuilder
-     */
-    public function getQuery()
-    {
-        return $this->query;
+            if (\count($fields[$fieldName]) > 1) {
+                throw new BadMethodCallException(\sprintf('Field "%s" is registered as multiple mapping and cannot be used for sorting.', $fieldName));
+            }
+
+            $qb->addOrderBy($fields[$fieldName][null]->column, \strtoupper($direction));
+        }
     }
 }

--- a/lib/Doctrine/Orm/QueryBuilderConditionGenerator.php
+++ b/lib/Doctrine/Orm/QueryBuilderConditionGenerator.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Doctrine\Orm;
+
+use Doctrine\ORM\QueryBuilder;
+use Rollerworks\Component\Search\Exception\BadMethodCallException;
+use Rollerworks\Component\Search\SearchCondition;
+
+/**
+ * SearchCondition Doctrine ORM DQL ConditionGenerator.
+ *
+ * Note that only fields that have been configured with `setField()`
+ * will be actually used in the generated query.
+ *
+ * Keep the following in mind when using conversions.
+ *
+ *  * Conversions are performed per search field and must be stateless, they receive the db-type
+ *    and connection information for the conversion process.
+ *  * Unlike DBAL conversions the conversion must be DQL (not SQL)
+ *  * Values must be registered as parameters (using the ConversionHints)
+ *  * Conversion results must be properly escaped to prevent DQL injections.
+ *
+ * After the fields are configured call `apply()` to apply
+ * the condition on the QueryBuilder.
+ */
+final class QueryBuilderConditionGenerator implements ConditionGenerator
+{
+    /**
+     * @var FieldConfigBuilder
+     */
+    private $fieldsConfig;
+
+    /**
+     * @var SearchCondition
+     */
+    private $searchCondition;
+
+    /**
+     * @var QueryBuilder
+     */
+    private $qb;
+
+    private $isApplied = false;
+
+    public function __construct(QueryBuilder $query, SearchCondition $searchCondition)
+    {
+        $this->fieldsConfig = new FieldConfigBuilder($query->getEntityManager(), $searchCondition->getFieldSet());
+        $this->searchCondition = $searchCondition;
+        $this->qb = $query;
+    }
+
+    public function setDefaultEntity(string $entity, string $alias)
+    {
+        $this->guardNotGenerated();
+        $this->fieldsConfig->setDefaultEntity($entity, $alias);
+
+        return $this;
+    }
+
+    /**
+     * @throws BadMethodCallException When the where-clause is already generated
+     */
+    private function guardNotGenerated(): void
+    {
+        if ($this->isApplied) {
+            throw new BadMethodCallException('ConditionGenerator configuration cannot be changed once the query is applied.');
+        }
+    }
+
+    public function setField(string $fieldName, string $property, string $alias = null, string $entity = null, string $dbType = null)
+    {
+        $this->guardNotGenerated();
+        $this->fieldsConfig->setField($fieldName, $property, $alias, $entity, $dbType);
+
+        return $this;
+    }
+
+    public function apply(): self
+    {
+        if ($this->isApplied) {
+            \trigger_error('SearchCondition was already applied. Ignoring operation.', \E_USER_WARNING);
+
+            return $this;
+        }
+
+        $this->isApplied = true;
+        $generator = new DqlConditionGenerator($this->qb->getEntityManager(), $this->searchCondition, $this->fieldsConfig);
+        $whereClause = $generator->getWhereClause();
+
+        if (null !== $primaryCondition = $this->searchCondition->getPrimaryCondition()) {
+            DqlConditionGenerator::applySortingTo($primaryCondition->getOrder(), $this->qb, $this->fieldsConfig);
+        }
+
+        DqlConditionGenerator::applySortingTo($this->searchCondition->getOrder(), $this->qb, $this->fieldsConfig);
+
+        if ($whereClause === '') {
+            return $this;
+        }
+
+        $this->qb->andWhere($whereClause);
+
+        foreach ($generator->getParameters() as $name => [$value, $type]) {
+            $this->qb->setParameter($name, $value, $type);
+        }
+
+        return $this;
+    }
+
+    public function getQueryBuilder(): QueryBuilder
+    {
+        return $this->qb;
+    }
+}

--- a/lib/Doctrine/Orm/Tests/ConditionGeneratorResultsTestCase.php
+++ b/lib/Doctrine/Orm/Tests/ConditionGeneratorResultsTestCase.php
@@ -13,13 +13,14 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Tests\Doctrine\Orm;
 
-use Rollerworks\Component\Search\Doctrine\Orm\ConditionGenerator;
+use Rollerworks\Component\Search\Doctrine\Orm\FieldConfigBuilder;
 use Rollerworks\Component\Search\Extension\Core\Type\BirthdayType;
 use Rollerworks\Component\Search\Extension\Core\Type\ChoiceType;
 use Rollerworks\Component\Search\Extension\Core\Type\DateTimeType;
 use Rollerworks\Component\Search\Extension\Core\Type\IntegerType;
 use Rollerworks\Component\Search\Extension\Core\Type\MoneyType;
 use Rollerworks\Component\Search\Extension\Core\Type\TextType;
+use Rollerworks\Component\Search\Field\OrderFieldType;
 use Rollerworks\Component\Search\Input\ProcessorConfig;
 use Rollerworks\Component\Search\Input\StringQueryInput;
 use Rollerworks\Component\Search\SearchPrimaryCondition;
@@ -150,10 +151,11 @@ abstract class ConditionGeneratorResultsTestCase extends OrmTestCase
         ];
     }
 
-    protected function configureConditionGenerator(ConditionGenerator $conditionGenerator): void
+    protected function configureConditionGenerator(FieldConfigBuilder $conditionGenerator): void
     {
         $conditionGenerator->setDefaultEntity(self::INVOICE_CLASS, 'I');
         $conditionGenerator->setField('id', 'id');
+        $conditionGenerator->setField('@id', 'id');
         $conditionGenerator->setField('label', 'label');
         $conditionGenerator->setField('pub-date', 'date');
         $conditionGenerator->setField('status', 'status');
@@ -184,6 +186,7 @@ abstract class ConditionGeneratorResultsTestCase extends OrmTestCase
 
         // Invoice
         $fieldSet->add('id', IntegerType::class);
+        $fieldSet->add('@id', OrderFieldType::class);
         $fieldSet->add('customer', IntegerType::class);
         $fieldSet->add('label', TextType::class);
         $fieldSet->add('pub-date', DateTimeType::class, ['pattern' => 'yyyy-MM-dd', 'allow_relative' => true]);
@@ -203,6 +206,13 @@ abstract class ConditionGeneratorResultsTestCase extends OrmTestCase
     public function it_finds_with_id(): void
     {
         $this->makeTest('id: 1, 5;', [1, 5]);
+    }
+
+    /** @test */
+    public function it_orders(): void
+    {
+        $this->makeTest('@id: ASC; id: 1, 5;', [1, 5]);
+        $this->makeTest('@id: DESC; id: 1, 5;', [5, 1]);
     }
 
     /** @test */

--- a/lib/Doctrine/Orm/Tests/DoctrineOrmFactoryTest.php
+++ b/lib/Doctrine/Orm/Tests/DoctrineOrmFactoryTest.php
@@ -16,9 +16,10 @@ namespace Rollerworks\Component\Search\Tests\Doctrine\Orm;
 use Psr\SimpleCache\CacheInterface;
 use Rollerworks\Component\Search\Doctrine\Orm\CachedDqlConditionGenerator;
 use Rollerworks\Component\Search\Doctrine\Orm\DoctrineOrmFactory;
-use Rollerworks\Component\Search\Doctrine\Orm\DqlConditionGenerator;
+use Rollerworks\Component\Search\Doctrine\Orm\QueryBuilderConditionGenerator;
 use Rollerworks\Component\Search\GenericFieldSet;
 use Rollerworks\Component\Search\SearchCondition;
+use Rollerworks\Component\Search\Tests\Doctrine\Orm\Fixtures\Entity\ECommerceInvoice;
 use Rollerworks\Component\Search\Value\ValuesGroup;
 
 /**
@@ -37,20 +38,24 @@ final class DoctrineOrmFactoryTest extends OrmTestCase
     public function create_condition_generator(): void
     {
         $condition = new SearchCondition(new GenericFieldSet([]), new ValuesGroup());
-        $query = $this->em->createQuery('SELECT I FROM Rollerworks\Component\Search\Tests\Fixtures\Entity\ECommerceInvoice I JOIN I.customer C WHERE ');
+        $qb = $this->em->createQueryBuilder()
+            ->select('I')
+            ->from(ECommerceInvoice::class, 'I')
+            ->join('I.customer', 'C');
 
-        $conditionGenerator = $this->factory->createConditionGenerator($query, $condition);
-        self::assertInstanceOf(DqlConditionGenerator::class, $conditionGenerator);
+        $conditionGenerator = $this->factory->createConditionGenerator($qb, $condition);
+        self::assertInstanceOf(QueryBuilderConditionGenerator::class, $conditionGenerator);
     }
 
     /** @test */
     public function cached_dql_condition_generator(): void
     {
-        $query = $this->em->createQuery('SELECT I FROM Rollerworks\Component\Search\Tests\Fixtures\Entity\ECommerceInvoice I JOIN I.customer C WHERE ');
+        $qb = $this->em->createQueryBuilder()
+            ->select('I')
+            ->from(ECommerceInvoice::class, 'I')
+            ->join('I.customer', 'C');
         $searchCondition = new SearchCondition(new GenericFieldSet([]), new ValuesGroup());
-
-        $conditionGenerator = $this->factory->createConditionGenerator($query, $searchCondition);
-        $cachedConditionGenerator = $this->factory->createCachedConditionGenerator($conditionGenerator);
+        $cachedConditionGenerator = $this->factory->createCachedConditionGenerator($qb, $searchCondition);
 
         self::assertInstanceOf(CachedDqlConditionGenerator::class, $cachedConditionGenerator);
     }

--- a/lib/Doctrine/Orm/Tests/DqlConditionGeneratorResultsTest.php
+++ b/lib/Doctrine/Orm/Tests/DqlConditionGeneratorResultsTest.php
@@ -13,26 +13,21 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Tests\Doctrine\Orm;
 
+use Doctrine\ORM\QueryBuilder;
+use Rollerworks\Component\Search\Tests\Doctrine\Orm\Fixtures\Entity\ECommerceInvoice;
+
 /**
  * @internal
  */
 final class DqlConditionGeneratorResultsTest extends ConditionGeneratorResultsTestCase
 {
-    protected function getQuery()
+    protected function getQuery(): QueryBuilder
     {
-        $query = <<<'DQL'
-SELECT
-    I
-FROM
-    Rollerworks\Component\Search\Tests\Doctrine\Orm\Fixtures\Entity\ECommerceInvoice AS I
-JOIN
-    I.customer AS C
-LEFT JOIN
-    I.children AS IP
-LEFT JOIN
-    I.rows AS R
-DQL;
-
-        return $this->em->createQuery($query);
+        return $this->em->createQueryBuilder()
+            ->select('I')
+            ->from(ECommerceInvoice::class, 'I')
+            ->join('I.customer', 'C')
+            ->leftJoin('I.children', 'IP')
+            ->leftJoin('I.rows', 'R');
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -29,7 +29,3 @@ parameters:
         ## Symony Config
         - '# Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition given#'
         - '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition\:\:#'
-
-        ## Doctrine
-        - '#Call to an undefined method Rollerworks\\Component\\Search\\Doctrine\\Orm\\ConditionGenerator\:\:get[a-zA-Z]+#'
-        - '#Instanceof between Doctrine\\ORM\\Query and Doctrine\\ORM\\QueryBuilder will always evaluate to false#'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,7 @@
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"
          convertErrorsToExceptions="false"
-         convertWarningsToExceptions="false"
+         convertWarningsToExceptions="true"
          convertNoticesToExceptions="false"
 >
     <php>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tickets       | Fix #289, related to #290
| License       | MIT

To make ordering with Doctrine ORM work you need need to pass a QueryBuilder now, using a "loose" Query object is no longer possible. It's still possible to generate the where-clause, but it's not officially documented.
