### PR TITLE
[Core] Make SearchConditionBuilder easier to use

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-versions: ['7.2', '7.3', '7.4', '8.0']
+                php-versions: ['7.4', '8.0']
 
         services:
             # https://docs.docker.com/samples/library/postgres/

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "friendsofsymfony/elastica-bundle": "^5.0 || ^5.2@dev",
         "matthiasnoback/symfony-dependency-injection-test": "^3.0 || ^4.1.1",
         "moneyphp/money": "^3.2.0",
-        "phpunit/phpunit": "^7.5.20 || ^8.0",
+        "phpunit/phpunit": "^7.5.20 || ^8.0 || ^9.5.7",
         "psr/simple-cache": "^1.0.0",
         "ruflin/elastica": "^3.2 || ^6.0.0",
         "symfony/asset": "^4.4 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.4",
         "nesbot/carbon": "^2.38",
         "psr/container": "^1.0.0",
         "symfony/intl": "^4.4 || ^5.0",

--- a/lib/Core/Value/ValuesBag.php
+++ b/lib/Core/Value/ValuesBag.php
@@ -45,28 +45,34 @@ class ValuesBag implements \Countable, \Serializable
         }
     }
 
-    public function serialize(): string
+    public function __serialize(): array
     {
-        return \serialize(
-            [
-                $this->simpleValues,
-                $this->simpleExcludedValues,
-                $this->values,
-                $this->valuesCount,
-            ]
-        );
+        return [
+            'simpleValues' => $this->simpleValues,
+            'simpleExcludedValues' => $this->simpleExcludedValues,
+            'values' => $this->values,
+            'valuesCount' => $this->valuesCount,
+        ];
     }
 
-    public function unserialize($serialized): void
+    public function __unserialize(array $data): void
     {
-        $data = \unserialize($serialized);
-
         [
-            $this->simpleValues,
-            $this->simpleExcludedValues,
-            $this->values,
-            $this->valuesCount
+            'simpleValues' => $this->simpleValues,
+            'simpleExcludedValues' => $this->simpleExcludedValues,
+            'values' => $this->values,
+            'valuesCount' => $this->valuesCount,
         ] = $data;
+    }
+
+    public function serialize(): string
+    {
+        return \serialize($this->__serialize());
+    }
+
+    public function unserialize($data): void
+    {
+        $this->__unserialize(\unserialize($data));
     }
 
     public function getSimpleValues(): array

--- a/lib/Core/Value/ValuesGroup.php
+++ b/lib/Core/Value/ValuesGroup.php
@@ -188,24 +188,31 @@ class ValuesGroup implements \Serializable
         return $this;
     }
 
-    public function serialize(): string
+    public function __serialize(): array
     {
-        return \serialize(
-            [
-                $this->groupLogical,
-                $this->groups,
-                $this->fields,
-            ]
-        );
+        return [
+            'groupLogical' => $this->groupLogical,
+            'groups' => $this->groups,
+            'fields' => $this->fields,
+        ];
     }
 
-    public function unserialize($serialized): void
+    public function __unserialize(array $data): void
     {
-        $data = \unserialize($serialized);
-
         [
-            $this->groupLogical,
-            $this->groups,
-            $this->fields] = $data;
+            'groupLogical' => $this->groupLogical,
+            'groups' => $this->groups,
+            'fields' => $this->fields,
+        ] = $data;
+    }
+
+    public function serialize(): string
+    {
+        return \serialize($this->__serialize());
+    }
+
+    public function unserialize($data): void
+    {
+        $this->__unserialize(\unserialize($data));
     }
 }

--- a/lib/Core/ValuesBagBuilder.php
+++ b/lib/Core/ValuesBagBuilder.php
@@ -17,8 +17,6 @@ use Rollerworks\Component\Search\Value\ValuesBag;
 
 /**
  * Helper class for the SearchConditionBuilder.
- *
- * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
 class ValuesBagBuilder extends ValuesBag
 {
@@ -34,10 +32,13 @@ class ValuesBagBuilder extends ValuesBag
         return $this->parent;
     }
 
+    /**
+     * @internal
+     */
     public function toValuesBag(): ValuesBag
     {
         $valuesBag = new ValuesBag();
-        $valuesBag->unserialize($this->serialize());
+        $valuesBag->__unserialize($this->__serialize());
 
         return $valuesBag;
     }

--- a/lib/Doctrine/Dbal/Query/QueryField.php
+++ b/lib/Doctrine/Dbal/Query/QueryField.php
@@ -97,6 +97,20 @@ class QueryField implements \Serializable
         // noop
     }
 
+    public function __serialize(): array
+    {
+        return [
+            'mapping_name' => $this->mappingName,
+            'field' => $this->fieldConfig->getName(),
+            'db_type' => $this->dbType->getName(),
+        ];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        // noop
+    }
+
     protected function initConversions(FieldConfig $fieldConfig): void
     {
         $converter = $fieldConfig->getOption('doctrine_dbal_conversion');

--- a/lib/Doctrine/Dbal/Tests/CachedConditionGeneratorTest.php
+++ b/lib/Doctrine/Dbal/Tests/CachedConditionGeneratorTest.php
@@ -141,7 +141,7 @@ final class CachedConditionGeneratorTest extends DbalTestCase
         $this->cacheDriver
             ->expects(self::once())
             ->method('get')
-            ->with('7bdf48ca3ce581f79fe43359148b2b4f91934d3f2a7b542b1da034c5fdd057af')
+            ->with('62e186fb1789cc8fd59315f3453808771910dae798440eee8b85d83889d5e88a')
             ->willReturn(["me = 'foo'", [':search' => [1, 'integer']]]);
 
         $this->conditionGenerator
@@ -166,7 +166,7 @@ final class CachedConditionGeneratorTest extends DbalTestCase
         $this->cacheDriver
             ->expects(self::once())
             ->method('get')
-            ->with('7bdf48ca3ce581f79fe43359148b2b4f91934d3f2a7b542b1da034c5fdd057af')
+            ->with('62e186fb1789cc8fd59315f3453808771910dae798440eee8b85d83889d5e88a')
             ->willReturn(["me = 'foo'", [':search' => [1, 'integer']]]);
 
         $this->conditionGenerator
@@ -190,7 +190,7 @@ final class CachedConditionGeneratorTest extends DbalTestCase
         $this->cacheDriver
             ->expects(self::once())
             ->method('get')
-            ->with('7bdf48ca3ce581f79fe43359148b2b4f91934d3f2a7b542b1da034c5fdd057af')
+            ->with('62e186fb1789cc8fd59315f3453808771910dae798440eee8b85d83889d5e88a')
             ->willReturn(['', []]);
 
         $this->conditionGenerator
@@ -260,8 +260,8 @@ final class CachedConditionGeneratorTest extends DbalTestCase
         $fieldSet = $this->getFieldSet();
 
         $cacheDriver = $this->prophesize(Cache::class);
-        $cacheDriver->get('7503457faa505a978544359616a2b503638538170931ce460b69fcf35566f771')->willReturn(["me = 'foo'", [':search' => [1, 'integer']]]);
-        $cacheDriver->get('65dc24cc06603327105d067e431b024f9dc0f7573db68fe839b6e244a821c4bb')->willReturn(["you = 'me' AND me = 'foo'", [':search' => [5, 'integer']]]);
+        $cacheDriver->get('cb991a892faabc87fd36502af520e0e1fad70617cf4d11a5dc8ca8feb9417235')->willReturn(["me = 'foo'", [':search' => [1, 'integer']]]);
+        $cacheDriver->get('aac1029ef411d16c316398274bb01cdad21999c91d6552f6a5afa2a399094415')->willReturn(["you = 'me' AND me = 'foo'", [':search' => [5, 'integer']]]);
 
         $cachedConditionGenerator = $this->createCachedConditionGenerator(
             $cacheDriver->reveal(),

--- a/lib/Doctrine/Orm/Tests/CachedDqlConditionGeneratorTest.php
+++ b/lib/Doctrine/Orm/Tests/CachedDqlConditionGeneratorTest.php
@@ -46,7 +46,7 @@ final class CachedDqlConditionGeneratorTest extends OrmTestCase
      */
     protected $cacheDriver;
 
-    public const CACHE_KEY = '4f85bf50a4dc325f31c15b800e4a6d63a44583c9ce44f850d5a217bf5eefc51a';
+    public const CACHE_KEY = 'a862f6cc2c2273dd537ef9404a5cf3f6bc8c9fa8183492d13d1559339c8235bf';
 
     /** @test */
     public function get_where_clause_no_cache(): void
@@ -131,7 +131,7 @@ final class CachedDqlConditionGeneratorTest extends OrmTestCase
         $this->cacheDriver
             ->expects(self::any())
             ->method('get')
-            ->with(self::matchesRegularExpression('/^' . self::CACHE_KEY . '|7442bffaecd972dbcdfef565acbc7d27688f505df8e6fb02be901179afc561b8$/'))
+            ->with(self::matchesRegularExpression('/^' . self::CACHE_KEY . '|2572233a315f25e5bc6603ae17db405863603c0a61b9d780bf9f6d62a37350ce/'))
             ->willReturn(["me = 'foo'", [':search' => [1, 'integer']]]);
 
         $this->cacheDriver
@@ -199,7 +199,7 @@ final class CachedDqlConditionGeneratorTest extends OrmTestCase
         $this->cacheDriver
             ->expects(self::once())
             ->method('get')
-            ->with('e3d953d9d0eb7cdfb41e73ddadbdd9454bc460df1d6732e89cef4c054fb66691')
+            ->with('0bd93612c80eb441a04867c5963104aa1b4dd33cf0afa555e958bf696c14e0b0')
             ->willReturn(null);
 
         $this->cacheDriver
@@ -226,8 +226,8 @@ final class CachedDqlConditionGeneratorTest extends OrmTestCase
     public function with_existing_caches_and_primary_cond(): void
     {
         $cacheDriverProphecy = $this->prophesize(CacheInterface::class);
-        $cacheDriverProphecy->get('d2340566dbc6d23ef4d5897c6c668c0d50161e9f6ced9cf6f85f5a098fe61664')->willReturn(["me = 'foo'", [':search_1' => ['duck', 'text']]])->shouldBeCalled();
-        $cacheDriverProphecy->get('6bde38a81c5065acb3ef6b2f3139b2d0b14daca6991b92316f37516f6f151c91')->willReturn(["you = 'me' AND me = 'foo'", [':search_2' => ['roll', 'text']]])->shouldBeCalled();
+        $cacheDriverProphecy->get('94006677e4dd617091945f6f4210a5cefb9e78d84fa3292c126f501523b17b10')->willReturn(["me = 'foo'", [':search_1' => ['duck', 'text']]])->shouldBeCalled();
+        $cacheDriverProphecy->get('d86dcae4d3eca451c2364158a3b0acf40b07402df80bdb42f4ed1b64c8621c67')->willReturn(["you = 'me' AND me = 'foo'", [':search_2' => ['roll', 'text']]])->shouldBeCalled();
         $cacheDriver = $cacheDriverProphecy->reveal();
 
         $searchCondition = SearchConditionBuilder::create($this->getFieldSet())

--- a/lib/Doctrine/Orm/Tests/DqlConditionGeneratorTest.php
+++ b/lib/Doctrine/Orm/Tests/DqlConditionGeneratorTest.php
@@ -42,6 +42,7 @@ final class DqlConditionGeneratorTest extends OrmTestCase
     protected function getFieldSet(bool $build = true)
     {
         $fieldSet = parent::getFieldSet(false);
+        $fieldSet->add('id2', IntegerType::class);
         $fieldSet->add('status', ChoiceType::class, ['choices' => ['concept' => 0, 'published' => 1, 'paid' => 2]]);
         $fieldSet->add('customer_first_name', TextType::class);
 

--- a/lib/Symfony/SearchBundle/Tests/SearchConditionBuilderTest.php
+++ b/lib/Symfony/SearchBundle/Tests/SearchConditionBuilderTest.php
@@ -1,0 +1,442 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\SearchBundle\Tests;
+
+use BadMethodCallException;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+use Rollerworks\Component\Search\Extension\Core\Type\IntegerType;
+use Rollerworks\Component\Search\Extension\Core\Type\TextType;
+use Rollerworks\Component\Search\Field\OrderFieldType;
+use Rollerworks\Component\Search\FieldSet;
+use Rollerworks\Component\Search\SearchCondition;
+use Rollerworks\Component\Search\SearchConditionBuilder;
+use Rollerworks\Component\Search\Searches;
+use Rollerworks\Component\Search\SearchOrder;
+use Rollerworks\Component\Search\SearchPrimaryCondition;
+use Rollerworks\Component\Search\Tests\Mock\FieldSetStub;
+use Rollerworks\Component\Search\Value\ValuesBag;
+use Rollerworks\Component\Search\Value\ValuesGroup;
+
+/**
+ * @internal
+ */
+final class SearchConditionBuilderTest extends TestCase
+{
+    /** @test */
+    public function it_produces_an_empty_condition(): void
+    {
+        $fieldSet = new FieldSetStub();
+
+        $builder = SearchConditionBuilder::create($fieldSet);
+        self::assertEquals(new SearchCondition($fieldSet, new ValuesGroup()), $builder->getSearchCondition());
+
+        $builder = SearchConditionBuilder::create($fieldSet, ValuesGroup::GROUP_LOGICAL_OR);
+        self::assertEquals(new SearchCondition($fieldSet, new ValuesGroup(ValuesGroup::GROUP_LOGICAL_OR)), $builder->getSearchCondition());
+    }
+
+    /** @test */
+    public function it_disallows_serialization(): void
+    {
+        $fieldSet = new FieldSetStub();
+        $builder = SearchConditionBuilder::create($fieldSet);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Unable serialize a SearchConditionBuilder. Call getSearchCondition() and serialize the SearchCondition itself.');
+
+        \serialize($builder);
+    }
+
+    /** @test */
+    public function it_sorting_at_nested_levels(): void
+    {
+        $searchFactory = Searches::createSearchFactory();
+
+        $fieldSetBuilder = $searchFactory->createFieldSetBuilder();
+        $fieldSetBuilder
+            ->add('id', IntegerType::class)
+            ->add('@id', OrderFieldType::class);
+        $fieldSet = $fieldSetBuilder->getFieldSet('users');
+        $condBuilder = SearchConditionBuilder::create($fieldSet);
+
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('Cannot add ordering at nested levels.');
+
+        $condBuilder->group()
+            ->order('@id');
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider provideBuilderExpectations
+     */
+    public function it_produces_a_condition_with_expected_structure(callable $conditionProvider, callable $builder): void
+    {
+        $searchFactory = Searches::createSearchFactory();
+
+        $fieldSetBuilder = $searchFactory->createFieldSetBuilder();
+        $fieldSetBuilder
+            ->add('id', IntegerType::class)
+            ->add('fist-name', TextType::class)
+            ->add('last-name', TextType::class)
+
+            ->add('_user', IntegerType::class)
+            ->add('@id', OrderFieldType::class)
+            ->add('@date', OrderFieldType::class);
+        $fieldSet = $fieldSetBuilder->getFieldSet('users');
+        $condBuilder = SearchConditionBuilder::create($fieldSet);
+
+        $builder($condBuilder);
+
+        self::assertEquals($conditionProvider($fieldSet), $condBuilder->getSearchCondition());
+    }
+
+    public function provideBuilderExpectations(): iterable
+    {
+        yield 'root (AND)' => [
+            static function (FieldSet $fieldSet): SearchCondition {
+                $idValues = (new ValuesBag())
+                    ->addSimpleValue(10)
+                    ->addSimpleValue(30);
+
+                $root = new ValuesGroup();
+                $root->addField('id', $idValues);
+
+                return new SearchCondition($fieldSet, $root);
+            },
+            static function (SearchConditionBuilder $builder): void {
+                $builder
+                    ->field('id')
+                        ->addSimpleValue(10)
+                        ->addSimpleValue(30)
+                    ->end();
+            },
+        ];
+
+        yield 'root (OR)' => [
+            static function (FieldSet $fieldSet): SearchCondition {
+                $idValues = (new ValuesBag())
+                    ->addSimpleValue(10)
+                    ->addSimpleValue(30);
+
+                $root = new ValuesGroup(ValuesGroup::GROUP_LOGICAL_OR);
+                $root->addField('id', $idValues);
+
+                return new SearchCondition($fieldSet, $root);
+            },
+            static function (SearchConditionBuilder $builder): void {
+                $builder
+                    ->setGroupLogical(ValuesGroup::GROUP_LOGICAL_OR)
+                    ->field('id')
+                        ->addSimpleValue(10)
+                        ->addSimpleValue(30)
+                    ->end();
+            },
+        ];
+
+        yield 'nested group (AND)' => [
+            static function (FieldSet $fieldSet): SearchCondition {
+                $idValues = (new ValuesBag())
+                    ->addSimpleValue(10)
+                    ->addSimpleValue(30);
+
+                $root = new ValuesGroup();
+                $root->addGroup(
+                    (new ValuesGroup())
+                        ->addField('id', $idValues)
+                );
+
+                return new SearchCondition($fieldSet, $root);
+            },
+            static function (SearchConditionBuilder $builder): void {
+                $builder
+                    ->group()
+                        ->field('id')
+                            ->addSimpleValue(10)
+                            ->addSimpleValue(30)
+                        ->end()
+                    ->end();
+            },
+        ];
+
+        yield 'nested group (OR)' => [
+            static function (FieldSet $fieldSet): SearchCondition {
+                $idValues = (new ValuesBag())
+                    ->addSimpleValue(10)
+                    ->addSimpleValue(30);
+
+                $root = new ValuesGroup();
+                $root->addGroup(
+                    (new ValuesGroup(ValuesGroup::GROUP_LOGICAL_OR))
+                        ->addField('id', $idValues)
+                );
+
+                return new SearchCondition($fieldSet, $root);
+            },
+            static function (SearchConditionBuilder $builder): void {
+                $builder
+                    ->group(ValuesGroup::GROUP_LOGICAL_OR)
+                        ->field('id')
+                            ->addSimpleValue(10)
+                            ->addSimpleValue(30)
+                        ->end()
+                    ->end();
+            },
+        ];
+
+        yield 'expend field' => [
+            static function (FieldSet $fieldSet): SearchCondition {
+                $idValues = (new ValuesBag())
+                    ->addSimpleValue(10)
+                    ->addSimpleValue(30)
+                    ->addSimpleValue(20)
+                    ->addSimpleValue(50);
+
+                $root = new ValuesGroup();
+                $root->addField('id', $idValues);
+
+                return new SearchCondition($fieldSet, $root);
+            },
+            static function (SearchConditionBuilder $builder): void {
+                $builder
+                    ->field('id')
+                        ->addSimpleValue(10)
+                        ->addSimpleValue(30)
+                    ->end()
+                    ->field('id')
+                        ->addSimpleValue(20)
+                        ->addSimpleValue(50)
+                    ->end();
+            },
+        ];
+
+        yield 'overwrite field' => [
+            static function (FieldSet $fieldSet): SearchCondition {
+                $idValues = (new ValuesBag())
+                    ->addSimpleValue(20)
+                    ->addSimpleValue(50);
+
+                $root = new ValuesGroup();
+                $root->addField('id', $idValues);
+
+                return new SearchCondition($fieldSet, $root);
+            },
+            static function (SearchConditionBuilder $builder): void {
+                $builder
+                    ->field('id')
+                        ->addSimpleValue(10)
+                        ->addSimpleValue(30)
+                    ->end()
+                    ->overwriteField('id')
+                        ->addSimpleValue(20)
+                        ->addSimpleValue(50)
+                    ->end();
+            },
+        ];
+
+        yield 'result order' => [
+            static function (FieldSet $fieldSet): SearchCondition {
+                $idValues = (new ValuesBag())
+                    ->addSimpleValue(10)
+                    ->addSimpleValue(30);
+
+                $root = new ValuesGroup();
+                $root->addField('id', $idValues);
+
+                $sortGroup = new ValuesGroup();
+                $sortGroup->addField('@id', (new ValuesBag())->addSimpleValue('DESC'));
+                $sortGroup->addField('@date', (new ValuesBag())->addSimpleValue('ASC'));
+
+                $condition = new SearchCondition($fieldSet, $root);
+                $condition->setOrder(new SearchOrder($sortGroup));
+
+                return $condition;
+            },
+            static function (SearchConditionBuilder $builder): void {
+                $builder
+                    ->field('id')
+                        ->addSimpleValue(10)
+                        ->addSimpleValue(30)
+                    ->end()
+                    ->order('@id', 'DESC')
+                    ->order('@date');
+            },
+        ];
+
+        yield 'reset previous orders' => [
+            static function (FieldSet $fieldSet): SearchCondition {
+                $idValues = (new ValuesBag())
+                    ->addSimpleValue(10)
+                    ->addSimpleValue(30);
+
+                $root = new ValuesGroup();
+                $root->addField('id', $idValues);
+
+                $sortGroup = new ValuesGroup();
+                $sortGroup->addField('@date', (new ValuesBag())->addSimpleValue('ASC'));
+
+                $condition = new SearchCondition($fieldSet, $root);
+                $condition->setOrder(new SearchOrder($sortGroup));
+
+                return $condition;
+            },
+            static function (SearchConditionBuilder $builder): void {
+                $builder
+                    ->field('id')
+                        ->addSimpleValue(10)
+                        ->addSimpleValue(30)
+                    ->end()
+                    ->order('@id', 'DESC')
+                    ->clearOrder()
+                    ->order('@date');
+            },
+        ];
+
+        yield 'only primary-condition' => [
+            static function (FieldSet $fieldSet): SearchCondition {
+                $idValuesPrimary = (new ValuesBag())
+                    ->addSimpleValue(10)
+                    ->addSimpleValue(30);
+
+                $rootPrimary = new ValuesGroup();
+                $rootPrimary->addField('id', $idValuesPrimary);
+
+                $searchCondition = new SearchCondition($fieldSet, new ValuesGroup());
+                $searchCondition->setPrimaryCondition(new SearchPrimaryCondition($rootPrimary));
+
+                return $searchCondition;
+            },
+            static function (SearchConditionBuilder $builder): void {
+                $builder
+                    ->primaryCondition()
+                        ->field('id')
+                            ->addSimpleValue(10)
+                            ->addSimpleValue(30)
+                        ->end()
+                    ->end();
+            },
+        ];
+
+        yield 'with primary-condition' => [
+            static function (FieldSet $fieldSet): SearchCondition {
+                $primaryIdValues = (new ValuesBag())
+                    ->addSimpleValue(10)
+                    ->addSimpleValue(30);
+                $primaryRoot = new ValuesGroup();
+                $primaryRoot->addField('id', $primaryIdValues);
+
+                $idValues = (new ValuesBag())
+                    ->addSimpleValue(20)
+                    ->addSimpleValue(50);
+                $root = new ValuesGroup();
+                $root->addField('id', $idValues);
+
+                $searchCondition = new SearchCondition($fieldSet, $root);
+                $searchCondition->setPrimaryCondition(new SearchPrimaryCondition($primaryRoot));
+
+                return $searchCondition;
+            },
+            static function (SearchConditionBuilder $builder): void {
+                $builder
+                    ->primaryCondition()
+                        ->field('id')
+                            ->addSimpleValue(10)
+                            ->addSimpleValue(30)
+                        ->end()
+                    ->end()
+                    ->field('id')
+                        ->addSimpleValue(20)
+                        ->addSimpleValue(50)
+                    ->end();
+            },
+        ];
+
+        yield 'with primary-condition (sorting)' => [
+            static function (FieldSet $fieldSet): SearchCondition {
+                $primaryIdValues = (new ValuesBag())
+                    ->addSimpleValue(10)
+                    ->addSimpleValue(30);
+                $primaryRoot = new ValuesGroup();
+                $primaryRoot->addField('id', $primaryIdValues);
+
+                $idValues = (new ValuesBag())
+                    ->addSimpleValue(20)
+                    ->addSimpleValue(50);
+                $root = new ValuesGroup();
+                $root->addField('id', $idValues);
+
+                $primaryCondition = new SearchPrimaryCondition($primaryRoot);
+                $primaryCondition->setOrder(
+                    new SearchOrder((new ValuesGroup())
+                        ->addField('@id', (new ValuesBag())
+                            ->addSimpleValue('DESC')))
+                );
+
+                $searchCondition = new SearchCondition($fieldSet, $root);
+                $searchCondition->setPrimaryCondition($primaryCondition);
+
+                return $searchCondition;
+            },
+            static function (SearchConditionBuilder $builder): void {
+                $builder
+                    ->primaryCondition()
+                        ->order('@id', 'DESC')
+                        ->field('id')
+                            ->addSimpleValue(10)
+                            ->addSimpleValue(30)
+                        ->end()
+                    ->end()
+                    ->field('id')
+                        ->addSimpleValue(20)
+                        ->addSimpleValue(50)
+                    ->end();
+            },
+        ];
+
+        yield 'with primary-condition (private field)' => [
+            static function (FieldSet $fieldSet): SearchCondition {
+                $primaryIdValues = (new ValuesBag())
+                    ->addSimpleValue(10)
+                    ->addSimpleValue(30);
+                $primaryRoot = new ValuesGroup();
+                $primaryRoot->addField('_user', $primaryIdValues);
+
+                $idValues = (new ValuesBag())
+                    ->addSimpleValue(20)
+                    ->addSimpleValue(50);
+                $root = new ValuesGroup();
+                $root->addField('id', $idValues);
+
+                $searchCondition = new SearchCondition($fieldSet, $root);
+                $searchCondition->setPrimaryCondition(new SearchPrimaryCondition($primaryRoot));
+
+                return $searchCondition;
+            },
+            static function (SearchConditionBuilder $builder): void {
+                $builder
+                    ->primaryCondition()
+                        ->field('_user')
+                            ->addSimpleValue(10)
+                            ->addSimpleValue(30)
+                        ->end()
+                    ->end()
+                    ->field('id')
+                        ->addSimpleValue(20)
+                        ->addSimpleValue(50)
+                    ->end();
+            },
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

- Check if a field is registered rather than silently failing
- Add more PHPDoc with explanations
- Add tests for SearchConditionBuilder

Note: this removes the `$forceNew` parameter for the `field` method that was already deprecated previously, wasn't removed in the announced version yet.