### PR TITLE
[DBAL] Require QueryBuilder for generating

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,7 +80,6 @@ jobs:
                 name: Install Composer dependencies
                 run: |
                     rm -f composer.lock
-                    composer global require symfony/flex
                     composer install --no-progress --no-interaction --no-suggest --optimize-autoloader --ansi
 
             ## —— Tests ✅ ———————————————————————————————————————————————————————————
@@ -118,7 +117,6 @@ jobs:
                 name: Install Composer dependencies
                 run: |
                     rm -f composer.lock
-                    composer global require symfony/flex
                     composer install --no-progress --no-interaction --no-suggest --optimize-autoloader --ansi
 
             -

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-QA_DOCKER_IMAGE=jakzal/phpqa:1.59.1-php7.4-alpine
+QA_DOCKER_IMAGE=jakzal/phpqa:1.77-php8.1-alpine
 QA_DOCKER_COMMAND=docker run --init -t --rm --user "$(shell id -u):$(shell id -g)" --volume /tmp/tmp-phpqa-$(shell id -u):/tmp --volume "$(shell pwd):/project" --workdir /project ${QA_DOCKER_IMAGE}
 
 dist: install cs-full phpstan test
@@ -31,10 +31,10 @@ cs: ensure
 	sh -c "${QA_DOCKER_COMMAND} php-cs-fixer fix -vvv --diff"
 
 cs-full: ensure
-	sh -c "${QA_DOCKER_COMMAND} php-cs-fixer fix -vvv --using-cache=false --diff"
+	sh -c "${QA_DOCKER_COMMAND} php-cs-fixer fix -vvv --using-cache=no --diff"
 
 cs-full-check: ensure
-	sh -c "${QA_DOCKER_COMMAND} php-cs-fixer fix -vvv --using-cache=false --diff --dry-run"
+	sh -c "${QA_DOCKER_COMMAND} php-cs-fixer fix -vvv --using-cache=no --diff --dry-run"
 
 ##
 # Special operations

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -5,6 +5,38 @@ UPGRADE FROM 2.0-BETA2 to 2.0-BETA3
  
  * Support for Symfony 5 was dropped.
 
+### Doctrine DBAL 
+
+  * Support for using a query as string was removed, a DBAL QueryBuilder
+    is now required to be passed to the generator.
+
+  * The `DoctrineDbalFactory::createCachedConditionGenerator()` method now 
+    requires a DBAL QueryBuilder and SearchCondition is provided instead
+    of a ``ConditionGenerator`` instance.
+ 
+  * The `ConditionGenerator` now longer provides access to the generated
+    condition and parameters. These are applied automatically when calling `apply()`.
+
+    ```php
+    // Doctrine\DBAL\Query\QueryBuilder object
+    $qb = $connection->createQueryBuilder();
+
+    // Rollerworks\Component\Search\SearchCondition object
+    $searchCondition = ...;
+
+    $conditionGenerator = $doctrineDbalFactory->createConditionGenerator($qb, $searchCondition);
+
+    // Set fields mapping
+    // ....
+
+    // Apply the condition (with ordering, if any) to the QueryBuilder
+    $conditionGenerator->apply();
+
+    // Get all the records
+    // See http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/data-retrieval-and-manipulation.html#data-retrieval
+    $result = $qb->execute();
+    ````
+
 UPGRADE FROM 2.0-BETA1 to 2.0-BETA2
 ===================================
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
-FROM php:7.4-cli
+FROM php:8.0-cli
 
 ENV BUILD_DEPS="autoconf file g++ gcc libc-dev pkg-config re2c"
-ENV LIB_DEPS="git make unzip ca-certificates zlib1g-dev libzip-dev libpq5 postgresql-server-dev-11"
-ENV ICU_RELEASE=60.1
+ENV LIB_DEPS="git make unzip ca-certificates zlib1g-dev libzip-dev libpq5 postgresql-server-dev-13"
+ENV ICU_RELEASE=70.1
 ENV CXXFLAGS "--std=c++0x"
 
 RUN apt-get update && apt-get install -y --no-install-recommends $BUILD_DEPS $LIB_DEPS && rm -rf /var/lib/apt/lists/*
@@ -21,10 +21,6 @@ RUN ln -s /usr/bin/composer /usr/bin/composer.phar
 
 # https://getcomposer.org/doc/03-cli.md#composer-allow-superuser
 ENV COMPOSER_ALLOW_SUPERUSER 1
-# install Symfony Flex globally to speed up download of Composer packages (parallelized prefetching)
-RUN set -eux; \
-	composer global require "symfony/flex" --prefer-dist --no-progress --no-suggest --classmap-authoritative; \
-	composer clear-cache
 ENV PATH="${PATH}:/root/.composer/vendor/bin"
 
 WORKDIR /srv/www

--- a/lib/Doctrine/Dbal/ConditionGenerator.php
+++ b/lib/Doctrine/Dbal/ConditionGenerator.php
@@ -13,8 +13,7 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Doctrine\Dbal;
 
-use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\DBAL\Statement;
+use Doctrine\DBAL\Query\QueryBuilder;
 use Rollerworks\Component\Search\Exception\BadMethodCallException;
 use Rollerworks\Component\Search\Exception\UnknownFieldException;
 use Rollerworks\Component\Search\SearchCondition;
@@ -31,29 +30,9 @@ use Rollerworks\Component\Search\SearchCondition;
 interface ConditionGenerator
 {
     /**
-     * Returns the generated where-clause.
-     *
-     * The Where-clause is wrapped inside a group so it can be safely used
-     * with other conditions.
-     *
-     * @param string $prependQuery Prepend before the generated WHERE clause
-     *                             Eg. " WHERE " or " AND ", ignored when WHERE
-     *                             clause is empty.
+     * Apply the SearchCondition to the QueryBuilder (as an AND-WHERE).
      */
-    public function getWhereClause(string $prependQuery = ''): string;
-
-    /**
-     * Binds the WHERE-statement parameters at the Doctrine DBAL Statement.
-     *
-     * Note: PDO directly is not supported due to a limitation in how
-     * types are handled.
-     */
-    public function bindParameters(Statement $statement): void;
-
-    /**
-     * Returns the value-parameters (to be used when executing).
-     */
-    public function getParameters(): ArrayCollection;
+    public function apply(): void;
 
     /**
      * Set the search field to database table-column mapping configuration.
@@ -86,15 +65,7 @@ interface ConditionGenerator
      */
     public function setField(string $fieldName, string $column, string $alias = null, string $type = 'string');
 
-    /**
-     * Returns the assigned SearchCondition.
-     */
     public function getSearchCondition(): SearchCondition;
 
-    /**
-     * Returns the configured field to columns mapping.
-     *
-     * @return array[] [field-name][mapping-name] => {QueryField}
-     */
-    public function getFieldsMapping(): array;
+    public function getQueryBuilder(): QueryBuilder;
 }

--- a/lib/Doctrine/Dbal/DoctrineDbalFactory.php
+++ b/lib/Doctrine/Dbal/DoctrineDbalFactory.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Doctrine\Dbal;
 
-use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
 use Psr\SimpleCache\CacheInterface as Cache;
 use Rollerworks\Component\Search\SearchCondition;
 
@@ -36,16 +36,14 @@ final class DoctrineDbalFactory
      * Creates a new SqlConditionGenerator for the SearchCondition.
      *
      * Conversions are applied using the 'doctrine_dbal_conversion' option.
-     *
-     * @param Connection $connection Doctrine DBAL Connection
      */
-    public function createConditionGenerator(Connection $connection, SearchCondition $searchCondition): ConditionGenerator
+    public function createConditionGenerator(QueryBuilder $queryBuilder, SearchCondition $searchCondition): ConditionGenerator
     {
-        return new SqlConditionGenerator($connection, $searchCondition);
+        return new SqlConditionGenerator($queryBuilder, $searchCondition);
     }
 
     /**
-     * Creates a new CachedConditionGenerator instance for the given ConditionGenerator.
+     * Creates a new CachedConditionGenerator for the SearchCondition.
      *
      * Note: When no cache driver was configured the original ConditionGenerator
      * is returned instead.
@@ -54,12 +52,12 @@ final class DoctrineDbalFactory
      *                                    the driver supports TTL then the library may set a default value
      *                                    for it or let the driver take care of that.
      */
-    public function createCachedConditionGenerator(ConditionGenerator $conditionGenerator, $ttl = 0): ConditionGenerator
+    public function createCachedConditionGenerator(QueryBuilder $queryBuilder, SearchCondition $searchCondition, $ttl = 0): ConditionGenerator
     {
         if ($this->cacheDriver === null) {
-            return $conditionGenerator;
+            return new SqlConditionGenerator($queryBuilder, $searchCondition);
         }
 
-        return new CachedConditionGenerator($conditionGenerator, $this->cacheDriver, $ttl);
+        return new CachedConditionGenerator($queryBuilder, $searchCondition, $this->cacheDriver, $ttl);
     }
 }

--- a/lib/Doctrine/Dbal/FieldConfigurationSet.php
+++ b/lib/Doctrine/Dbal/FieldConfigurationSet.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Doctrine\Dbal;
+
+use Doctrine\DBAL\Types\Type as MappingType;
+use Rollerworks\Component\Search\Doctrine\Dbal\Query\QueryField;
+use Rollerworks\Component\Search\FieldSet;
+
+/**
+ * @internal
+ */
+final class FieldConfigurationSet
+{
+    private FieldSet $fieldSet;
+    /** @var array<string, QueryField> */
+    public $fields = [];
+
+    public function __construct(FieldSet $fieldSet)
+    {
+        $this->fieldSet = $fieldSet;
+    }
+
+    public function setField(string $fieldName, string $column, string $alias = null, string $type = 'string'): void
+    {
+        $mappingIdx = null;
+
+        if (mb_strpos($fieldName, '#') !== false) {
+            [$fieldName, $mappingIdx] = explode('#', $fieldName, 2);
+            unset($this->fields[$fieldName][null]);
+        } else {
+            $this->fields[$fieldName] = [];
+        }
+
+        $this->fields[$fieldName][$mappingIdx] = new QueryField(
+            $fieldName . ($mappingIdx !== null ? "#{$mappingIdx}" : ''),
+            $this->fieldSet->get($fieldName),
+            MappingType::getType($type),
+            $column,
+            $alias
+        );
+    }
+}

--- a/lib/Doctrine/Dbal/Test/QueryBuilderAssertion.php
+++ b/lib/Doctrine/Dbal/Test/QueryBuilderAssertion.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Doctrine\Dbal\Test;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use PHPUnit\Framework\Assert;
+use Rollerworks\Component\Search\Doctrine\Dbal\ConditionGenerator;
+
+final class QueryBuilderAssertion
+{
+    /**
+     * @phpstan-param array<string, mixed|array{0: mixed, 1: string}}> $parameters by name with value or [value, type name)]
+     */
+    public static function assertQueryBuilderEquals(ConditionGenerator $generator, string $where, ?array $parameters = []): void
+    {
+        $queryBuilder = $generator->getQueryBuilder();
+        $baseDql = $queryBuilder->getSQL();
+
+        $generator->apply();
+
+        $finalDql = $queryBuilder->getSQL();
+
+        Assert::assertEquals($baseDql . $where, $finalDql);
+
+        if ($parameters !== null) {
+            self::assertQueryParametersEquals($parameters, $queryBuilder);
+        }
+    }
+
+    public static function assertQueryParametersEquals(?array $parameters, QueryBuilder $qb): void
+    {
+        if ($parameters === null) {
+            return;
+        }
+
+        $actualParameters = $qb->getParameters();
+
+        foreach ($actualParameters as $name => $value) {
+            $type = $qb->getParameterType($name);
+
+            if ($type !== null) {
+                $actualParameters[$name] = [$value, \is_object($type) ? $type->getName() : $type];
+            } else {
+                $actualParameters[$name] = $value;
+            }
+        }
+
+        Assert::assertEquals($parameters, $actualParameters);
+    }
+}

--- a/lib/Doctrine/Dbal/Tests/DoctrineDbalFactoryTest.php
+++ b/lib/Doctrine/Dbal/Tests/DoctrineDbalFactoryTest.php
@@ -34,25 +34,27 @@ final class DoctrineDbalFactoryTest extends DbalTestCase
     /** @test */
     public function create_condition_generator(): void
     {
-        $connection = $this->getConnectionMock();
+        $queryBuilder = $this->getConnectionMock()->createQueryBuilder();
         $searchCondition = new SearchCondition(new GenericFieldSet([], 'invoice'), new ValuesGroup());
 
-        $conditionGenerator = $this->factory->createConditionGenerator($connection, $searchCondition);
+        $conditionGenerator = $this->factory->createConditionGenerator($queryBuilder, $searchCondition);
+        self::assertInstanceOf(SqlConditionGenerator::class, $conditionGenerator);
 
         self::assertSame($searchCondition, $conditionGenerator->getSearchCondition());
+        self::assertSame($queryBuilder, $conditionGenerator->getQueryBuilder());
     }
 
     /** @test */
     public function create_cache_condition_generator(): void
     {
-        $connection = $this->getConnectionMock();
+        $queryBuilder = $this->getConnectionMock()->createQueryBuilder();
         $searchCondition = new SearchCondition(new GenericFieldSet([], 'invoice'), new ValuesGroup());
 
-        $conditionGenerator = $this->factory->createConditionGenerator($connection, $searchCondition);
-        self::assertInstanceOf(SqlConditionGenerator::class, $conditionGenerator);
+        $conditionGenerator = $this->factory->createCachedConditionGenerator($queryBuilder, $searchCondition);
+        self::assertInstanceOf(CachedConditionGenerator::class, $conditionGenerator);
 
-        $cacheConditionGenerator = $this->factory->createCachedConditionGenerator($conditionGenerator);
-        self::assertInstanceOf(CachedConditionGenerator::class, $cacheConditionGenerator);
+        self::assertSame($searchCondition, $conditionGenerator->getSearchCondition());
+        self::assertSame($queryBuilder, $conditionGenerator->getQueryBuilder());
     }
 
     protected function setUp(): void

--- a/lib/Doctrine/Dbal/Tests/Functional/Extension/Conversion/AgeConversionTest.php
+++ b/lib/Doctrine/Dbal/Tests/Functional/Extension/Conversion/AgeConversionTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Tests\Doctrine\Dbal\Functional\Extension\Conversion;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Schema\Schema as DbSchema;
 use Rollerworks\Component\Search\Doctrine\Dbal\ConditionGenerator;
 use Rollerworks\Component\Search\Extension\Core\Type\BirthdayType;
@@ -50,9 +51,12 @@ final class AgeConversionTest extends FunctionalDbalTestCase
         ];
     }
 
-    protected function getQuery()
+    protected function getQuery(): QueryBuilder
     {
-        return 'SELECT id FROM site_user AS u WHERE ';
+        return $this->conn->createQueryBuilder()
+            ->select('id')
+            ->from('site_user', 'u')
+        ;
     }
 
     protected function configureConditionGenerator(ConditionGenerator $conditionGenerator): void

--- a/lib/Doctrine/Dbal/Tests/Functional/Extension/Conversion/ChildCountTypeTest.php
+++ b/lib/Doctrine/Dbal/Tests/Functional/Extension/Conversion/ChildCountTypeTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Tests\Doctrine\Dbal\Functional\Extension\Conversion;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Schema\Schema as DbSchema;
 use Rollerworks\Component\Search\Doctrine\Dbal\ConditionGenerator;
 use Rollerworks\Component\Search\Extension\Core\Type\IntegerType;
@@ -60,9 +61,12 @@ final class ChildCountTypeTest extends FunctionalDbalTestCase
         ];
     }
 
-    protected function getQuery()
+    protected function getQuery(): QueryBuilder
     {
-        return 'SELECT id FROM site_user AS u WHERE ';
+        return $this->conn->createQueryBuilder()
+            ->select('id')
+            ->from('site_user', 'u')
+        ;
     }
 
     protected function configureConditionGenerator(ConditionGenerator $conditionGenerator): void

--- a/lib/Doctrine/Dbal/Tests/Functional/Extension/Conversion/MoneyValueConversionTest.php
+++ b/lib/Doctrine/Dbal/Tests/Functional/Extension/Conversion/MoneyValueConversionTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Tests\Doctrine\Dbal\Functional\Extension\Conversion;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Schema\Schema as DbSchema;
 use Money\Money;
 use Rollerworks\Component\Search\Doctrine\Dbal\ConditionGenerator;
@@ -55,9 +56,12 @@ final class MoneyValueConversionTest extends FunctionalDbalTestCase
         ];
     }
 
-    protected function getQuery()
+    protected function getQuery(): QueryBuilder
     {
-        return 'SELECT id FROM product AS p WHERE ';
+        return $this->conn->createQueryBuilder()
+            ->select('id')
+            ->from('product', 'p')
+        ;
     }
 
     protected function configureConditionGenerator(ConditionGenerator $conditionGenerator): void

--- a/lib/Doctrine/Dbal/Tests/Functional/SqlConditionGeneratorResultsTest.php
+++ b/lib/Doctrine/Dbal/Tests/Functional/SqlConditionGeneratorResultsTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Tests\Doctrine\Dbal\Functional;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Schema\Schema as DbSchema;
 use Rollerworks\Component\Search\Doctrine\Dbal\ConditionGenerator;
 use Rollerworks\Component\Search\Extension\Core\Type\BirthdayType;
@@ -184,20 +185,14 @@ final class SqlConditionGeneratorResultsTest extends FunctionalDbalTestCase
         ];
     }
 
-    protected function getQuery()
+    protected function getQuery(): QueryBuilder
     {
-        return <<<'SQL'
-            SELECT
-                *, i.id AS id
-            FROM
-                invoice AS i
-            JOIN
-                customer AS c ON i.customer = c.id
-            LEFT JOIN
-                invoice_details AS ir ON ir.invoice = i.id
-            WHERE
-
-            SQL;
+        return $this->conn->createQueryBuilder()
+            ->select('*', 'i.id AS id')
+            ->from('invoice', 'i')
+            ->join('i', 'customer', 'c', 'i.customer = c.id')
+            ->leftJoin('i', 'invoice_details', 'ir', 'ir.invoice = i.id')
+        ;
     }
 
     protected function configureConditionGenerator(ConditionGenerator $conditionGenerator): void
@@ -366,7 +361,7 @@ final class SqlConditionGeneratorResultsTest extends FunctionalDbalTestCase
                 echo 'Please install symfony/var-dumper as dev-requirement to get a readable structure.' . \PHP_EOL;
 
                 // Don't use var-dump or print-r as this crashes php...
-                echo \get_class($e) . '::' . (string) $e;
+                echo \get_class($e) . '::' . $e;
             }
 
             self::fail('Condition contains errors.');
@@ -390,7 +385,7 @@ final class SqlConditionGeneratorResultsTest extends FunctionalDbalTestCase
                 echo 'Please install symfony/var-dumper as dev-requirement to get a readable structure.' . \PHP_EOL;
 
                 // Don't use var-dump or print-r as this crashes php...
-                echo \get_class($e) . '::' . (string) $e;
+                echo \get_class($e) . '::' . $e;
             }
 
             self::fail('Condition contains errors.');

--- a/lib/Doctrine/Orm/composer.json
+++ b/lib/Doctrine/Orm/composer.json
@@ -23,7 +23,7 @@
         "php": ">=8.0",
         "doctrine/orm": "^2.6",
         "rollerworks/search": "^2.0@dev,>=2.0.0-BETA1",
-        "rollerworks/search-doctrine-dbal": "^2.0@dev,>=2.0.0-BETA1"
+        "rollerworks/search-doctrine-dbal": "^2.0@dev,>=2.0.0-BETA2"
     },
     "require-dev": {
         "moneyphp/money": "^3.0.7 || ^4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | 
| Tickets       | Closes #290 
| License       | MIT

Require a QueryBuilder is used for Doctrine DBAL, which also ensures ordering is applied correctly.
Due too some technical details it's no longer possible to retrieve the generated where-condition, this is now made all internal.

However I do plan to make a few test-helper classes to make testing of conversions much easier.