### PR TITLE
Fix tests for PHP 8.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,11 +15,11 @@ env:
 jobs:
     test:
         name: PHP ${{ matrix.php-versions }}
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-latest
         strategy:
             fail-fast: false
             matrix:
-                php-versions: ['8.0', '8.1']
+                php-versions: ['8.1', '8.2']
 
         services:
             # https://docs.docker.com/samples/library/postgres/

--- a/lib/Core/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
+++ b/lib/Core/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
@@ -89,7 +89,8 @@ final class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
             throw new TransformationFailedException(intl_get_error_message());
         }
 
-        return $value;
+        // Convert non-breaking and narrow non-breaking spaces to normal ones
+        return str_replace(["\xc2\xa0", "\xe2\x80\xaf"], ' ', $value);
     }
 
     /**
@@ -110,13 +111,16 @@ final class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
             return null;
         }
 
+        // Non-breaking lines are required instead of spaces.
+        $value = str_replace(' ', "\xe2\x80\xaf", $value);
+
         // date-only patterns require parsing to be done in UTC, as midnight might not exist in the local timezone due
         // to DST changes
         $dateOnly = $this->isPatternDateOnly();
 
         $timestamp = $this->getIntlDateFormatter($dateOnly)->parse($value);
 
-        if (intl_get_error_code() != 0) {
+        if (intl_get_error_code() !== 0) {
             throw new TransformationFailedException(intl_get_error_message());
         }
 

--- a/lib/Core/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
+++ b/lib/Core/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
@@ -115,7 +115,7 @@ final class DateTimeToStringTransformer extends BaseDateTimeTransformer
 
         $lastErrors = \DateTimeImmutable::getLastErrors();
 
-        if (0 < $lastErrors['warning_count'] || 0 < $lastErrors['error_count']) {
+        if ($lastErrors !== false && (0 < $lastErrors['warning_count'] || 0 < $lastErrors['error_count'])) {
             throw new TransformationFailedException(implode(', ', array_merge(array_values($lastErrors['warnings']), array_values($lastErrors['errors']))));
         }
 

--- a/lib/Core/Extension/Core/Type/DateTimeType.php
+++ b/lib/Core/Extension/Core/Type/DateTimeType.php
@@ -125,7 +125,7 @@ final class DateTimeType extends BaseDateTimeType
 
         $view->vars['timezone'] = $options['view_timezone'] ?: date_default_timezone_get();
         $view->vars['allow_relative'] = $options['allow_relative'];
-        $view->vars['pattern'] = $pattern;
+        $view->vars['pattern'] = str_replace(' ', ' ', $pattern);
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/lib/Core/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/lib/Core/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -18,6 +18,8 @@ use Rollerworks\Component\Search\Extension\Core\Type\DateTimeType;
 use Rollerworks\Component\Search\FieldSetView;
 use Rollerworks\Component\Search\Test\FieldTransformationAssertion;
 use Rollerworks\Component\Search\Test\SearchIntegrationTestCase;
+use Symfony\Component\Intl\Intl;
+use Symfony\Component\Intl\Util\IcuVersion;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 /**
@@ -194,7 +196,7 @@ final class DateTimeTypeTest extends SearchIntegrationTestCase
         FieldTransformationAssertion::assertThat($field)
             ->withInput('2 Juni 2010 3:04', '2010-06-02T03:04:00Z')
             ->successfullyTransformsTo($outputTime)
-            ->andReverseTransformsTo('2 jun. 2010 03:04', '2010-06-02T03:04:00Z')
+            ->andReverseTransformsTo(IcuVersion::compare(Intl::getIcuVersion(), '73.2', '>', 1) ? '2 jun 2010 03:04' : '2 jun. 2010 03:04', '2010-06-02T03:04:00Z')
         ;
 
         FieldTransformationAssertion::assertThat($field)
@@ -227,6 +229,6 @@ final class DateTimeTypeTest extends SearchIntegrationTestCase
         parent::setUp();
 
         // we test against "nl", so we need the full implementation
-        IntlTestHelper::requireFullIntl($this, '58.1');
+        IntlTestHelper::requireFullIntl($this, '66.1');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       |  
| License       | MIT

ICU data changed and was breaking the tests and parsing of localized date(time).