### PR TITLE
[Core] Fix ordering not properly handled

### DIFF
--- a/lib/Core/Exporter/JsonExporter.php
+++ b/lib/Core/Exporter/JsonExporter.php
@@ -32,7 +32,32 @@ final class JsonExporter extends AbstractExporter
 {
     public function exportCondition(SearchCondition $condition): string
     {
-        return (string) json_encode($this->exportGroup($condition->getValuesGroup(), $condition->getFieldSet(), true));
+        $fieldSet = $condition->getFieldSet();
+
+        return (string) json_encode(
+            array_merge(
+                $this->exportOrder($condition, $fieldSet),
+                $this->exportGroup($condition->getValuesGroup(), $fieldSet, true)
+            ),
+            \JSON_THROW_ON_ERROR
+        );
+    }
+
+    protected function exportOrder(SearchCondition $condition, FieldSet $fieldSet): array
+    {
+        $order = $condition->getOrder();
+
+        if ($order === null) {
+            return [];
+        }
+
+        $result = [];
+
+        foreach ($order->getFields() as $name => $direction) {
+            $result[mb_substr($name, 1)] = $this->modelToNorm($direction, $fieldSet->get($name));
+        }
+
+        return $result ? ['order' => $result] : [];
     }
 
     protected function exportGroup(ValuesGroup $valuesGroup, FieldSet $fieldSet, bool $isRoot = false): array

--- a/lib/Core/Exporter/StringExporter.php
+++ b/lib/Core/Exporter/StringExporter.php
@@ -37,12 +37,30 @@ abstract class StringExporter extends AbstractExporter
 
     public function exportCondition(SearchCondition $condition): string
     {
-        $this->fields = $this->resolveLabels($condition->getFieldSet());
+        $this->fields = $this->resolveLabels($fieldSet = $condition->getFieldSet());
 
-        return $this->exportGroup($condition->getValuesGroup(), $condition->getFieldSet(), true);
+        return $this->exportOrder($condition, $fieldSet) . $this->exportGroup($condition->getValuesGroup(), $fieldSet, true);
     }
 
     abstract protected function resolveLabels(FieldSet $fieldSet): array;
+
+    protected function exportOrder(SearchCondition $condition, FieldSet $fieldSet): string
+    {
+        $order = $condition->getOrder();
+
+        if ($order === null) {
+            return '';
+        }
+
+        $result = '';
+
+        foreach ($order->getFields() as $name => $direction) {
+            $result .= $this->getFieldLabel($name);
+            $result .= ': ' . $this->modelToExported($direction, $fieldSet->get($name)) . '; ';
+        }
+
+        return trim($result);
+    }
 
     protected function exportGroup(ValuesGroup $valuesGroup, FieldSet $fieldSet, bool $isRoot = false): string
     {

--- a/lib/Core/Extension/Core/DataTransformer/OrderToLocalizedTransformer.php
+++ b/lib/Core/Extension/Core/DataTransformer/OrderToLocalizedTransformer.php
@@ -16,41 +16,46 @@ namespace Rollerworks\Component\Search\Extension\Core\DataTransformer;
 use Rollerworks\Component\Search\DataTransformer;
 use Rollerworks\Component\Search\Exception\TransformationFailedException;
 
-/**
- * @author Dalibor Karlović <dalibor@flexolabs.io>
- */
-final class OrderTransformer implements DataTransformer
+final class OrderToLocalizedTransformer implements DataTransformer
 {
-    public const CASE_LOWERCASE = 'LOWERCASE';
-    public const CASE_UPPERCASE = 'UPPERCASE';
+    private array $alias;
+    private array $viewLabel;
+    private string $case;
 
-    /**
-     * @var array
-     */
-    private $alias;
-
-    /**
-     * @var string
-     */
-    private $case;
-
-    public function __construct(array $alias, string $case = self::CASE_UPPERCASE)
+    public function __construct(array $alias, array $viewLabel, string $case = OrderTransformer::CASE_UPPERCASE)
     {
-        $this->alias = $alias;
         $this->case = $case;
+        $this->alias = $alias;
+        $this->viewLabel = $viewLabel;
     }
 
     public function transform($value)
     {
-        if ($value !== null && ! \is_string($value)) {
-            throw new TransformationFailedException('Expected a string or null.');
-        }
-
         if ($value === null) {
             return '';
         }
 
-        return $value;
+        if (! \is_string($value)) {
+            throw new TransformationFailedException('Expected a string or null.');
+        }
+
+        switch ($this->case) {
+            case OrderTransformer::CASE_LOWERCASE:
+                $value = mb_strtolower($value);
+
+                break;
+
+            case OrderTransformer::CASE_UPPERCASE:
+                $value = mb_strtoupper($value);
+
+                break;
+        }
+
+        if (! isset($this->viewLabel[$value])) {
+            throw new TransformationFailedException(sprintf('No localized label configured for "%s".', $value));
+        }
+
+        return $this->viewLabel[$value];
     }
 
     public function reverseTransform($value)
@@ -64,12 +69,12 @@ final class OrderTransformer implements DataTransformer
         }
 
         switch ($this->case) {
-            case self::CASE_LOWERCASE:
+            case OrderTransformer::CASE_LOWERCASE:
                 $value = mb_strtolower($value);
 
                 break;
 
-            case self::CASE_UPPERCASE:
+            case OrderTransformer::CASE_UPPERCASE:
                 $value = mb_strtoupper($value);
 
                 break;

--- a/lib/Core/Field/OrderFieldType.php
+++ b/lib/Core/Field/OrderFieldType.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Field;
 
+use Rollerworks\Component\Search\Extension\Core\DataTransformer\OrderToLocalizedTransformer;
 use Rollerworks\Component\Search\Extension\Core\DataTransformer\OrderTransformer;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -32,6 +34,7 @@ final class OrderFieldType implements FieldType
             'default' => null,
             'case' => OrderTransformer::CASE_UPPERCASE,
             'alias' => ['ASC' => 'ASC', 'DESC' => 'DESC'],
+            'view_label' => ['ASC' => 'asc', 'DESC' => 'desc'],
             'type' => null,
             'type_options' => [],
         ]);
@@ -41,17 +44,46 @@ final class OrderFieldType implements FieldType
             OrderTransformer::CASE_UPPERCASE,
         ]);
         $resolver->setAllowedTypes('alias', 'array');
+        $resolver->setAllowedTypes('view_label', ['array']);
         $resolver->setAllowedTypes('default', ['null', 'string']);
         $resolver->setAllowedTypes('type', ['string', 'null']);
         $resolver->setAllowedTypes('type_options', ['array']);
+
+        // Ensure view-labels are part of the alias list.
+        $resolver->addNormalizer('alias', static function (Options $options, array $value): mixed {
+            // Must always exist for interoperability, but it's still possible to overwrite.
+            $value = array_merge($value,
+                $options['case'] === OrderTransformer::CASE_LOWERCASE ? ['asc' => 'ASC', 'desc' => 'DESC'] : ['ASC' => 'ASC', 'DESC' => 'DESC']
+            );
+
+            foreach ($options['view_label'] as $direction => $label) {
+                switch ($options['case']) {
+                    case OrderTransformer::CASE_LOWERCASE:
+                        $label = mb_strtolower($label);
+
+                        break;
+
+                    case OrderTransformer::CASE_UPPERCASE:
+                        $label = mb_strtoupper($label);
+
+                        break;
+                }
+
+                if (isset($value[$label])) {
+                    continue;
+                }
+
+                $value[$label] = $direction;
+            }
+
+            return $value;
+        });
     }
 
     public function buildType(FieldConfig $config, array $options): void
     {
-        $transformer = new OrderTransformer($options['alias'], $options['case'], $options['default']);
-
-        $config->setNormTransformer($transformer);
-        $config->setViewTransformer($transformer);
+        $config->setNormTransformer(new OrderTransformer($options['alias'], $options['case']));
+        $config->setViewTransformer(new OrderToLocalizedTransformer($options['alias'], $options['view_label'], $options['case']));
     }
 
     public function buildView(SearchFieldView $view, FieldConfig $config, array $options): void

--- a/lib/Core/Input/JsonInput.php
+++ b/lib/Core/Input/JsonInput.php
@@ -35,6 +35,8 @@ use Rollerworks\Component\Search\Value\ValuesGroup;
  * Each entry must contain an array with 'fields' and/or 'groups' structures.
  * Optionally the array can contain 'logical-case' => 'OR' to make it OR-cased.
  *
+ * The 'order' setting can only be applied at root level, and must NOT begin with the @-sign.
+ *
  * The 'groups' array contains groups with the keys as described above ('fields' and/or 'groups').
  *
  * The fields array is an hash-map where each key is the field-name

--- a/lib/Core/Input/OrderStructureBuilder.php
+++ b/lib/Core/Input/OrderStructureBuilder.php
@@ -59,13 +59,16 @@ final class OrderStructureBuilder implements StructureBuilder
      */
     private $inputTransformer;
 
-    public function __construct(ProcessorConfig $config, Validator $validator, ErrorList $errorList, string $path = '')
+    private bool $viewFormat;
+
+    public function __construct(ProcessorConfig $config, Validator $validator, ErrorList $errorList, string $path = '', bool $viewFormat = false)
     {
         $this->fieldSet = $config->getFieldSet();
         $this->validator = $validator;
         $this->path = $path ?: 'order';
         $this->errorList = $errorList;
         $this->valuesGroup = new ValuesGroup();
+        $this->viewFormat = $viewFormat;
     }
 
     public function getErrors(): ErrorList
@@ -100,6 +103,7 @@ final class OrderStructureBuilder implements StructureBuilder
         }
 
         $this->fieldConfig = $this->fieldSet->get($name);
+        $this->inputTransformer = ($this->viewFormat ? $this->fieldConfig->getViewTransformer() : $this->fieldConfig->getNormTransformer()) ?? false;
 
         $this->valuesBag = $this->valuesGroup->getField($name);
 
@@ -182,10 +186,6 @@ final class OrderStructureBuilder implements StructureBuilder
      */
     private function inputToNorm($value, string $path)
     {
-        if ($this->inputTransformer === null) {
-            $this->inputTransformer = $this->fieldConfig->getNormTransformer() ?? false;
-        }
-
         if ($this->inputTransformer === false) {
             if ($value !== null && ! \is_scalar($value)) {
                 $e = new \RuntimeException(

--- a/lib/Core/Input/ProcessorConfig.php
+++ b/lib/Core/Input/ProcessorConfig.php
@@ -134,7 +134,6 @@ class ProcessorConfig
         return $this->cacheTTL;
     }
 
-
     public function getDefaultField(bool $error = false): ?string
     {
         if ($this->defaultField === null && $error) {

--- a/lib/Core/Input/StringQueryInput.php
+++ b/lib/Core/Input/StringQueryInput.php
@@ -71,7 +71,9 @@ final class StringQueryInput extends StringInput
         $this->orderStructureBuilder = new OrderStructureBuilder(
             $this->config,
             $this->validator,
-            $this->errors
+            $this->errors,
+            '',
+            true
         );
     }
 }

--- a/lib/Core/Resources/translations/validators.en.xlf
+++ b/lib/Core/Resources/translations/validators.en.xlf
@@ -42,6 +42,10 @@
                 <source>This value is not a valid datetime.</source>
                 <target>This value is not a valid datetime.</target>
             </trans-unit>
+            <trans-unit id="11">
+                <source>This value is not a valid sorting direction. Accepted directions are "{{ directions }}".</source>
+                <target>This value is not a valid sorting direction. Accepted directions are "{{ directions }}".</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/lib/Core/Resources/translations/validators.nl.xlf
+++ b/lib/Core/Resources/translations/validators.nl.xlf
@@ -43,6 +43,10 @@
                 <source>This value is not a valid datetime.</source>
                 <target>Deze waarde is geen geldige datum en tijd.</target>
             </trans-unit>
+            <trans-unit id="11">
+                <source>This value is not a valid sorting direction. Accepted directions are "{{ directions }}".</source>
+                <target>Deze waarde is geen geldige sorteer richting. De geaccepteerde richtingen zijn : "{{ directions }}".</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/lib/Core/Tests/Exporter/JsonExporterTest.php
+++ b/lib/Core/Tests/Exporter/JsonExporterTest.php
@@ -236,6 +236,11 @@ final class JsonExporterTest extends SearchConditionExporterTestCase
         return json_encode(['groups' => [[]]]);
     }
 
+    public function provideOrderTest()
+    {
+        return json_encode(['order' => ['id' => 'desc', 'status' => 'asc']], \JSON_THROW_ON_ERROR);
+    }
+
     protected function getExporter(): ConditionExporter
     {
         return new JsonExporter();

--- a/lib/Core/Tests/Exporter/NormStringQueryExporterTest.php
+++ b/lib/Core/Tests/Exporter/NormStringQueryExporterTest.php
@@ -115,6 +115,11 @@ final class NormStringQueryExporterTest extends SearchConditionExporterTestCase
         return '(  );';
     }
 
+    public function provideOrderTest()
+    {
+        return '@id: desc; @status: asc;';
+    }
+
     protected function getExporter(): ConditionExporter
     {
         return new NormStringQueryExporter();

--- a/lib/Core/Tests/Field/OrderFieldTest.php
+++ b/lib/Core/Tests/Field/OrderFieldTest.php
@@ -136,13 +136,13 @@ final class OrderFieldTest extends TestCase
     }
 
     /** @test */
-    public function it_has_no__norm_transformer_by_default(): void
+    public function it_has_no_norm_transformer_by_default(): void
     {
         self::assertNull($this->field->getNormTransformer());
     }
 
     /** @test */
-    public function it_allows_setting_a__norm_transformer(): void
+    public function it_allows_setting_a_norm_transformer(): void
     {
         $normTransformer = $this->getMockBuilder(DataTransformer::class)->getMock();
         $this->field->setNormTransformer($normTransformer);

--- a/lib/Core/Tests/Field/OrderFieldTypeTest.php
+++ b/lib/Core/Tests/Field/OrderFieldTypeTest.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Tests\Field;
+
+use Rollerworks\Component\Search\Exception\TransformationFailedException;
+use Rollerworks\Component\Search\Extension\Core\DataTransformer\OrderTransformer;
+use Rollerworks\Component\Search\Field\OrderField;
+use Rollerworks\Component\Search\Field\OrderFieldType;
+use Rollerworks\Component\Search\Test\FieldTransformationAssertion;
+use Rollerworks\Component\Search\Test\SearchIntegrationTestCase;
+
+/**
+ * @internal
+ */
+final class OrderFieldTypeTest extends SearchIntegrationTestCase
+{
+    /** @test */
+    public function it_transforms_with_default_configuration(): void
+    {
+        /** @var OrderField $field */
+        $field = $this->getFactory()->createField('@id', OrderFieldType::class);
+
+        FieldTransformationAssertion::assertThat($field)
+            ->withInput('DESC')
+            ->successfullyTransformsTo('DESC')
+            ->andReverseTransformsTo('desc', 'DESC')
+        ;
+
+        FieldTransformationAssertion::assertThat($field)
+            ->withInput('desc')
+            ->successfullyTransformsTo('DESC')
+            ->andReverseTransformsTo('desc', 'DESC')
+        ;
+
+        FieldTransformationAssertion::assertThat($field)
+            ->withInput('ASC')
+            ->successfullyTransformsTo('ASC')
+            ->andReverseTransformsTo('asc', 'ASC')
+        ;
+    }
+
+    /** @test */
+    public function it_transforms_with_alias(): void
+    {
+        /** @var OrderField $field */
+        $field = $this->getFactory()->createField('@id', OrderFieldType::class, ['alias' => [
+            'UP' => 'ASC',
+            'DOWN' => 'DESC',
+
+            'OMHOOR' => 'ASC',
+            'NEER' => 'DESC',
+        ]]);
+
+        FieldTransformationAssertion::assertThat($field)
+            ->withInput('down')
+            ->successfullyTransformsTo('DESC')
+            ->andReverseTransformsTo('desc', 'DESC')
+        ;
+
+        FieldTransformationAssertion::assertThat($field)
+            ->withInput('NEER')
+            ->successfullyTransformsTo('DESC')
+            ->andReverseTransformsTo('desc', 'DESC')
+        ;
+
+        FieldTransformationAssertion::assertThat($field)
+            ->withInput('desc')
+            ->successfullyTransformsTo('DESC')
+            ->andReverseTransformsTo('desc', 'DESC')
+        ;
+    }
+
+    /** @test */
+    public function it_transforms_with_view_label(): void
+    {
+        /** @var OrderField $field */
+        $field = $this->getFactory()->createField('@id', OrderFieldType::class, ['view_label' => [
+            'ASC' => 'up',
+            'DESC' => 'down',
+        ]]);
+
+        FieldTransformationAssertion::assertThat($field)
+            ->withInput('down')
+            ->successfullyTransformsTo('DESC')
+            ->andReverseTransformsTo('down', 'DESC')
+        ;
+
+        FieldTransformationAssertion::assertThat($field)
+            ->withInput('Up')
+            ->successfullyTransformsTo('ASC')
+            ->andReverseTransformsTo('up', 'ASC')
+        ;
+
+        FieldTransformationAssertion::assertThat($field)
+            ->withInput('desc')
+            ->successfullyTransformsTo('DESC')
+            ->andReverseTransformsTo('down', 'DESC')
+        ;
+    }
+
+    /** @test */
+    public function it_transforms_with_alias_and_view_label(): void
+    {
+        /** @var OrderField $field */
+        $field = $this->getFactory()->createField('@id', OrderFieldType::class, [
+            'view_label' => [
+                'ASC' => 'up',
+                'DESC' => 'down',
+            ],
+            'alias' => [
+                'UP' => 'ASC',
+                'DOWN' => 'DESC',
+                'OMHOOR' => 'ASC',
+                'NEER' => 'DESC',
+            ],
+        ]);
+
+        FieldTransformationAssertion::assertThat($field)
+            ->withInput('down')
+            ->successfullyTransformsTo('DESC')
+            ->andReverseTransformsTo('down', 'DESC')
+        ;
+
+        FieldTransformationAssertion::assertThat($field)
+            ->withInput('Up')
+            ->successfullyTransformsTo('ASC')
+            ->andReverseTransformsTo('up', 'ASC')
+        ;
+
+        FieldTransformationAssertion::assertThat($field)
+            ->withInput('desc')
+            ->successfullyTransformsTo('DESC')
+            ->andReverseTransformsTo('down', 'DESC')
+        ;
+
+        FieldTransformationAssertion::assertThat($field)
+            ->withInput('down')
+            ->successfullyTransformsTo('DESC')
+            ->andReverseTransformsTo('down', 'DESC')
+        ;
+
+        FieldTransformationAssertion::assertThat($field)
+            ->withInput('NEER')
+            ->successfullyTransformsTo('DESC')
+            ->andReverseTransformsTo('down', 'DESC')
+        ;
+
+        FieldTransformationAssertion::assertThat($field)
+            ->withInput('desc')
+            ->successfullyTransformsTo('DESC')
+            ->andReverseTransformsTo('down', 'DESC')
+        ;
+    }
+
+    /** @test */
+    public function it_transforms_with_alias_and_view_label_and_lowercase(): void
+    {
+        /** @var OrderField $field */
+        $field = $this->getFactory()->createField('@id', OrderFieldType::class, [
+            'view_label' => [
+                'asc' => 'up',
+                'desc' => 'down',
+            ],
+            'alias' => [
+                'up' => 'ASC',
+                'down' => 'DESC',
+                'omhoor' => 'ASC',
+                'neer' => 'DESC',
+            ],
+            'case' => OrderTransformer::CASE_LOWERCASE,
+        ]);
+
+        FieldTransformationAssertion::assertThat($field)
+            ->withInput('down')
+            ->successfullyTransformsTo('DESC')
+            ->andReverseTransformsTo('down', 'DESC')
+        ;
+
+        FieldTransformationAssertion::assertThat($field)
+            ->withInput('Up')
+            ->successfullyTransformsTo('ASC')
+            ->andReverseTransformsTo('up', 'ASC')
+        ;
+
+        FieldTransformationAssertion::assertThat($field)
+            ->withInput('desc')
+            ->successfullyTransformsTo('DESC')
+            ->andReverseTransformsTo('down', 'DESC')
+        ;
+
+        FieldTransformationAssertion::assertThat($field)
+            ->withInput('down')
+            ->successfullyTransformsTo('DESC')
+            ->andReverseTransformsTo('down', 'DESC')
+        ;
+
+        FieldTransformationAssertion::assertThat($field)
+            ->withInput('NEER')
+            ->successfullyTransformsTo('DESC')
+            ->andReverseTransformsTo('down', 'DESC');
+
+        FieldTransformationAssertion::assertThat($field)
+            ->withInput('desc')
+            ->successfullyTransformsTo('DESC')
+            ->andReverseTransformsTo('down', 'DESC');
+    }
+
+    /** @test */
+    public function it_fails_to_transform_with_invalid_direction(): void
+    {
+        /** @var OrderField $field */
+        $field = $this->getFactory()->createField('@id', OrderFieldType::class, [
+            'view_label' => [
+                'asc' => 'up',
+                'desc' => 'down',
+            ],
+        ]);
+
+        FieldTransformationAssertion::assertThat($field)
+            ->withInput('neer')
+            ->failsToTransforms(
+                new TransformationFailedException(
+                    'Invalid sort direction "NEER" specified, expected one of: "ASC", "DESC", "UP", "DOWN"',
+                    0,
+                    null,
+                    'This value is not a valid sorting direction. Accepted directions are "{{ directions }}".',
+                    ['{{ directions }}' => 'asc", "desc", "up", "down']
+                )
+            )
+        ;
+    }
+}

--- a/lib/Core/Tests/Input/InputProcessorTestCase.php
+++ b/lib/Core/Tests/Input/InputProcessorTestCase.php
@@ -60,8 +60,8 @@ abstract class InputProcessorTestCase extends SearchIntegrationTestCase
         $fieldSet->add('date', DateType::class, ['pattern' => 'MM-dd-yyyy']);
 
         if ($order) {
-            $fieldSet->add('@date', OrderFieldType::class, ['case' => OrderTransformer::CASE_LOWERCASE,  'alias' => ['up' => 'ASC', 'down' => 'DESC'], 'default' => 'down']);
-            $fieldSet->add('@id', OrderFieldType::class, ['default' => 'up']);
+            $fieldSet->add('@date', OrderFieldType::class, ['case' => OrderTransformer::CASE_LOWERCASE, 'alias' => ['up' => 'ASC', 'down' => 'DESC'], 'default' => 'down']);
+            $fieldSet->add('@id', OrderFieldType::class, ['default' => 'ASC']);
         }
         $fieldSet->set(
             $this->getFactory()->createField('no-range-field', IntegerType::class)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,11 +11,6 @@ parameters:
 			path: lib/Core/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
 
 		-
-			message: "#^Property Rollerworks\\\\Component\\\\Search\\\\Extension\\\\Core\\\\DataTransformer\\\\OrderTransformer\\:\\:\\$default is never read, only written\\.$#"
-			count: 1
-			path: lib/Core/Extension/Core/DataTransformer/OrderTransformer.php
-
-		-
 			message: "#^Property Rollerworks\\\\Component\\\\Search\\\\Field\\\\OrderField\\:\\:\\$valueComparator is never written, only read\\.$#"
 			count: 1
 			path: lib/Core/Field/OrderField.php


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

- Ordering direction was not included in exported conditions
- String (view format) didn't support localized labels
- The OrderStructureBuilder didn't use the correct transformer when changing fields; as this is configurable per field

**IMPORTANT**

```PHP
            $fieldSet->add('@date', OrderFieldType::class, ['case' => OrderTransformer::CASE_LOWERCASE, 'alias' => ['up' => 'ASC', 'down' => 'DESC'], 'default' => 'down']);
            $fieldSet->add('@id', OrderFieldType::class, ['default' => 'ASC']);
```

Previously the `@id` would contain the same transformer as the `@date` field (due to a bug in the `OrderStructureBuilder`), but this is incorrect behavior as each field has it's own configuration. 
If your current configuration stops working this is why.