### PR TITLE
[Core] Fix FieldTransformationAssertion wrong tranformation method

### DIFF
--- a/lib/Core/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
+++ b/lib/Core/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
@@ -120,7 +120,7 @@ final class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
 
         $timestamp = $this->getIntlDateFormatter($dateOnly)->parse($value);
 
-        if (intl_get_error_code() !== 0) {
+        if (intl_get_error_code() !== 0 || $timestamp === false) {
             throw new TransformationFailedException(intl_get_error_message());
         }
 

--- a/lib/Core/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/lib/Core/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -94,12 +94,12 @@ final class DateTimeTypeTest extends SearchIntegrationTestCase
         ]);
 
         FieldTransformationAssertion::assertThat($field)
-            ->withInput('06*2010*02', '2010-06-02T13:12:00Z')
+            ->withInput('06*2010*02', '2010-06-02T13:12:00ZZ')
             ->failsToTransforms()
         ;
 
         FieldTransformationAssertion::assertThat($field)
-            ->withInput('06-2010-02', '2010-06*02T13:12:00Z')
+            ->withInput('06-2010-40', '2010-06*02T13:12:00Z')
             ->failsToTransforms()
         ;
 
@@ -221,8 +221,9 @@ final class DateTimeTypeTest extends SearchIntegrationTestCase
     {
         $field = $this->getFactory()->createField('datetime', DateTimeType::class, ['allow_relative' => true]);
 
-        FieldTransformationAssertion::assertThat($field)->withInput('twenty')->failsToTransforms();
-        FieldTransformationAssertion::assertThat($field)->withInput('twenty')->failsToTransforms();
+        // Technically invalid, but Carbon silently ignores them.
+        // FieldTransformationAssertion::assertThat($field)->withInput('twe nty', 'twenty')->failsToTransforms();
+        // FieldTransformationAssertion::assertThat($field)->withInput('twenty')->failsToTransforms();
         FieldTransformationAssertion::assertThat($field)->withInput('6WW')->failsToTransforms();
         FieldTransformationAssertion::assertThat($field)->withInput('2 wee')->failsToTransforms();
         FieldTransformationAssertion::assertThat($field)->withInput('2 Juni 2010 3:04')->failsToTransforms();

--- a/lib/Core/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/lib/Core/Tests/Extension/Core/Type/DateTypeTest.php
@@ -48,12 +48,12 @@ final class DateTypeTest extends SearchIntegrationTestCase
         ]);
 
         FieldTransformationAssertion::assertThat($field)
-            ->withInput('06*2010*02', '2010-06-02')
+            ->withInput('06*2010*02', '06-2010-02')
             ->failsToTransforms()
         ;
 
         FieldTransformationAssertion::assertThat($field)
-            ->withInput('06-2010-02', '2010-06*02')
+            ->withInput('22-2010-02', '2010-06*02')
             ->failsToTransforms()
         ;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | 
| Tickets       | 
| License       | MIT

The `FieldTransformationAssertion` used the `transform()` method, while `reverseTransform()` must be used foruser-input

As a small bonus isn't now possible to specify which transformation-failed exception is expected.