### PR TITLE
[Core] Fix order-clause with in StringInput

### DIFF
--- a/lib/Core/Exception/OrderStructureException.php
+++ b/lib/Core/Exception/OrderStructureException.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search\Exception;
+
+final class OrderStructureException extends InputProcessorException
+{
+    public static function invalidValue(string $fieldName): self
+    {
+        return new self('', 'Field {{ field }} only accepts a single simple-value.', ['{{ field }}' => $fieldName]);
+    }
+
+    public static function noGrouping(): self
+    {
+        return new self('', 'Order clauses cannot be placed in a group.');
+    }
+}

--- a/lib/Core/Input/NormStringQueryInput.php
+++ b/lib/Core/Input/NormStringQueryInput.php
@@ -40,6 +40,6 @@ final class NormStringQueryInput extends StringInput
 
         $this->fields = $names;
         $this->structureBuilder = new ConditionStructureBuilder($this->config, $this->validator, $this->errors);
-        $this->orderStructureBuilder = new ConditionStructureBuilder($this->config, $this->validator, $this->errors);
+        $this->orderStructureBuilder = new OrderStructureBuilder($this->config, $this->validator, $this->errors);
     }
 }

--- a/lib/Core/Input/OrderStructureBuilder.php
+++ b/lib/Core/Input/OrderStructureBuilder.php
@@ -16,10 +16,8 @@ namespace Rollerworks\Component\Search\Input;
 use Rollerworks\Component\Search\ConditionErrorMessage;
 use Rollerworks\Component\Search\DataTransformer;
 use Rollerworks\Component\Search\ErrorList;
-use Rollerworks\Component\Search\Exception\InvalidArgumentException;
+use Rollerworks\Component\Search\Exception\OrderStructureException;
 use Rollerworks\Component\Search\Exception\TransformationFailedException;
-use Rollerworks\Component\Search\Exception\UnexpectedTypeException;
-use Rollerworks\Component\Search\Exception\ValuesOverflowException;
 use Rollerworks\Component\Search\Field\FieldConfig;
 use Rollerworks\Component\Search\FieldSet;
 use Rollerworks\Component\Search\StructureBuilder;
@@ -88,12 +86,12 @@ final class OrderStructureBuilder implements StructureBuilder
 
     public function enterGroup(string $groupLocal = 'AND', string $path = '[%d]'): void
     {
-        throw new InvalidArgumentException('Order clauses do not support nesting');
+        throw OrderStructureException::noGrouping();
     }
 
     public function leaveGroup(): void
     {
-        throw new InvalidArgumentException('Order clauses do not support nesting');
+        throw OrderStructureException::noGrouping();
     }
 
     public function field(string $name, string $path): void
@@ -117,7 +115,7 @@ final class OrderStructureBuilder implements StructureBuilder
         }
 
         if ($this->valuesBag->count()) {
-            throw new ValuesOverflowException($this->fieldConfig->getName(), 1, $path);
+            throw OrderStructureException::invalidValue($this->fieldConfig->getName());
         }
 
         if (($modelVal = $this->inputToNorm($value, $path)) !== null) {
@@ -129,7 +127,7 @@ final class OrderStructureBuilder implements StructureBuilder
 
     public function excludedSimpleValue($value, string $path): void
     {
-        throw new UnexpectedTypeException($this->fieldConfig->getName(), $path);
+        throw OrderStructureException::invalidValue($this->fieldConfig->getName());
     }
 
     /**
@@ -137,7 +135,7 @@ final class OrderStructureBuilder implements StructureBuilder
      */
     public function rangeValue($lower, $upper, bool $lowerInclusive, bool $upperInclusive, array $path): void
     {
-        throw new UnexpectedTypeException($this->fieldConfig->getName(), $path);
+        throw OrderStructureException::invalidValue($this->fieldConfig->getName());
     }
 
     /**
@@ -145,7 +143,7 @@ final class OrderStructureBuilder implements StructureBuilder
      */
     public function excludedRangeValue($lower, $upper, bool $lowerInclusive, bool $upperInclusive, array $path): void
     {
-        throw new UnexpectedTypeException($this->fieldConfig->getName(), $path);
+        throw OrderStructureException::invalidValue($this->fieldConfig->getName());
     }
 
     /**
@@ -154,7 +152,7 @@ final class OrderStructureBuilder implements StructureBuilder
      */
     public function comparisonValue($operator, $value, array $path): void
     {
-        throw new UnexpectedTypeException($this->fieldConfig->getName(), $path);
+        throw OrderStructureException::invalidValue($this->fieldConfig->getName());
     }
 
     /**
@@ -164,7 +162,7 @@ final class OrderStructureBuilder implements StructureBuilder
      */
     public function patterMatchValue($type, $value, bool $caseInsensitive, array $path): void
     {
-        throw new UnexpectedTypeException($this->fieldConfig->getName(), $path);
+        throw OrderStructureException::invalidValue($this->fieldConfig->getName());
     }
 
     public function endValues(): void

--- a/lib/Core/Input/StringInput.php
+++ b/lib/Core/Input/StringInput.php
@@ -16,6 +16,7 @@ namespace Rollerworks\Component\Search\Input;
 use Rollerworks\Component\Search\ErrorList;
 use Rollerworks\Component\Search\Exception\InputProcessorException;
 use Rollerworks\Component\Search\Exception\InvalidSearchConditionException;
+use Rollerworks\Component\Search\Exception\OrderStructureException;
 use Rollerworks\Component\Search\Exception\StringLexerException;
 use Rollerworks\Component\Search\Exception\UnexpectedTypeException;
 use Rollerworks\Component\Search\Exception\UnknownFieldException;
@@ -276,6 +277,10 @@ abstract class StringInput extends AbstractInput
                 $fieldName = $this->getFieldName($this->lexer->fieldIdentification());
             } else {
                 $fieldName = $this->config->getDefaultField(true);
+            }
+
+            if (OrderField::isOrder($fieldName) && $inGroup ) {
+                throw OrderStructureException::noGrouping();
             }
 
             $this->lexer->skipEmptyLines();

--- a/lib/Core/Tests/Input/InputProcessorTestCase.php
+++ b/lib/Core/Tests/Input/InputProcessorTestCase.php
@@ -18,6 +18,7 @@ use Rollerworks\Component\Search\DataTransformer;
 use Rollerworks\Component\Search\Exception\GroupsNestingException;
 use Rollerworks\Component\Search\Exception\GroupsOverflowException;
 use Rollerworks\Component\Search\Exception\InvalidSearchConditionException;
+use Rollerworks\Component\Search\Exception\OrderStructureException;
 use Rollerworks\Component\Search\Exception\TransformationFailedException;
 use Rollerworks\Component\Search\Exception\UnknownFieldException;
 use Rollerworks\Component\Search\Exception\UnsupportedValueTypeException;
@@ -672,54 +673,4 @@ abstract class InputProcessorTestCase extends SearchIntegrationTestCase
      * @return array[]
      */
     abstract public static function provideNestedErrorsTests();
-
-    /**
-     * @param ConditionErrorMessage[] $errors
-     */
-    protected function assertConditionContainsErrorsWithoutCause($input, ProcessorConfig $config, array $errors): void
-    {
-        $processor = $this->getProcessor();
-
-        try {
-            $processor->process($config, $input);
-
-            self::fail('Condition should be invalid.');
-        } catch (\Exception $e) {
-            /* @var InvalidSearchConditionException $e */
-            self::detectSystemException($e);
-            self::assertInstanceOf(InvalidSearchConditionException::class, $e);
-
-            $errorsList = $e->getErrors();
-
-            foreach ($errorsList as $error) {
-                // Remove cause to make assertion possible.
-                $error->cause = null;
-            }
-
-            foreach ($errors as $error) {
-                $error->cause = null;
-            }
-
-            self::assertEquals($errors, $errorsList);
-        }
-    }
-
-    /**
-     * @param ConditionErrorMessage[] $errors
-     */
-    protected function assertConditionContainsErrors($input, ProcessorConfig $config, array $errors): void
-    {
-        $processor = $this->getProcessor();
-
-        try {
-            $processor->process($config, $input);
-
-            self::fail('Condition should be invalid.');
-        } catch (\Exception $e) {
-            /* @var InvalidSearchConditionException $e */
-            self::detectSystemException($e);
-            self::assertInstanceOf(InvalidSearchConditionException::class, $e);
-            self::assertEquals($errors, $e->getErrors());
-        }
-    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

- Order field allowed invalid value types
- Order field in group did not error
- NormStringQueryInput didn't use the correct structure builder
- Use proper error messages (translations will be added later)

Note: Translations will be added later, there are some other problems with this which need to be resolved separate.
