### PR TITLE
[Doctrine] Fix wrong query for pattern matches

### DIFF
--- a/lib/Doctrine/Dbal/QueryPlatform/AbstractQueryPlatform.php
+++ b/lib/Doctrine/Dbal/QueryPlatform/AbstractQueryPlatform.php
@@ -93,12 +93,12 @@ abstract class AbstractQueryPlatform
         }
 
         $patternMap = [
-            PatternMatch::PATTERN_STARTS_WITH => ["'%%'", '%s'],
-            PatternMatch::PATTERN_NOT_STARTS_WITH => ["'%%'", '%s'],
+            PatternMatch::PATTERN_STARTS_WITH => ['%s', "'%%'"],
+            PatternMatch::PATTERN_NOT_STARTS_WITH => ['%s', "'%%'"],
             PatternMatch::PATTERN_CONTAINS => ["'%%'", '%s', "'%%'"],
             PatternMatch::PATTERN_NOT_CONTAINS => ["'%%'", '%s', "'%%'"],
-            PatternMatch::PATTERN_ENDS_WITH => ['%s', "'%%'"],
-            PatternMatch::PATTERN_NOT_ENDS_WITH => ['%s', "'%%'"],
+            PatternMatch::PATTERN_ENDS_WITH => ["'%%'", '%s'],
+            PatternMatch::PATTERN_NOT_ENDS_WITH => ["'%%'", '%s'],
         ];
 
         $value = addcslashes($patternMatch->getValue(), $this->getLikeEscapeChars());

--- a/lib/Doctrine/Dbal/Tests/SqlConditionGeneratorTest.php
+++ b/lib/Doctrine/Dbal/Tests/SqlConditionGeneratorTest.php
@@ -517,7 +517,7 @@ final class SqlConditionGeneratorTest extends DbalTestCase
 
         QueryBuilderAssertion::assertQueryBuilderEquals(
             $conditionGenerator,
-            " WHERE (((c.name LIKE '%' || :search_0 OR c.name LIKE '%' || :search_1 OR c.name = :search_2 OR LOWER(c.name) = LOWER(:search_3)) AND (LOWER(c.name) NOT LIKE LOWER(:search_4 || '%') AND c.name <> :search_5 AND LOWER(c.name) <> LOWER(:search_6))))",
+            " WHERE (((c.name LIKE :search_0 || '%' OR c.name LIKE :search_1 || '%' OR c.name = :search_2 OR LOWER(c.name) = LOWER(:search_3)) AND (LOWER(c.name) NOT LIKE LOWER('%' || :search_4) AND c.name <> :search_5 AND LOWER(c.name) <> LOWER(:search_6))))",
             [
                 'search_0' => ['foo', 'text'],
                 'search_1' => ['fo\\\'o', 'text'],
@@ -574,7 +574,7 @@ final class SqlConditionGeneratorTest extends DbalTestCase
 
         QueryBuilderAssertion::assertQueryBuilderEquals(
             $conditionGenerator,
-            " WHERE (((i.customer = :search_0)) AND (((c.name LIKE '%' || :search_1))))",
+            " WHERE (((i.customer = :search_0)) AND (((c.name LIKE :search_1 || '%'))))",
             [
                 'search_0' => [2, 'integer'],
                 'search_1' => ['foo', 'text'],
@@ -599,7 +599,7 @@ final class SqlConditionGeneratorTest extends DbalTestCase
 
         QueryBuilderAssertion::assertQueryBuilderEquals(
             $conditionGenerator,
-            " WHERE ((i.customer = :search_0) OR (c.name LIKE '%' || :search_1))",
+            " WHERE ((i.customer = :search_0) OR (c.name LIKE :search_1 || '%'))",
             [
                 'search_0' => [2, 'integer'],
                 'search_1' => ['foo', 'text'],
@@ -628,7 +628,7 @@ final class SqlConditionGeneratorTest extends DbalTestCase
 
         QueryBuilderAssertion::assertQueryBuilderEquals(
             $conditionGenerator,
-            " WHERE ((((i.customer = :search_0) OR (c.name LIKE '%' || :search_1))))",
+            " WHERE ((((i.customer = :search_0) OR (c.name LIKE :search_1 || '%'))))",
             [
                 'search_0' => [2, 'integer'],
                 'search_1' => ['foo', 'text'],

--- a/lib/Doctrine/Orm/QueryPlatform/DqlQueryPlatform.php
+++ b/lib/Doctrine/Orm/QueryPlatform/DqlQueryPlatform.php
@@ -32,12 +32,12 @@ final class DqlQueryPlatform extends AbstractQueryPlatform
         }
 
         $patternMap = [
-            PatternMatch::PATTERN_STARTS_WITH => "CONCAT('%%', %s)",
-            PatternMatch::PATTERN_NOT_STARTS_WITH => "CONCAT('%%', %s)",
+            PatternMatch::PATTERN_STARTS_WITH => "CONCAT(%s, '%%')",
+            PatternMatch::PATTERN_NOT_STARTS_WITH => "CONCAT(%s, '%%')",
             PatternMatch::PATTERN_CONTAINS => "CONCAT('%%', %s, '%%')",
             PatternMatch::PATTERN_NOT_CONTAINS => "CONCAT('%%', %s, '%%')",
-            PatternMatch::PATTERN_ENDS_WITH => "CONCAT(%s, '%%')",
-            PatternMatch::PATTERN_NOT_ENDS_WITH => "CONCAT(%s, '%%')",
+            PatternMatch::PATTERN_ENDS_WITH => "CONCAT('%%', %s)",
+            PatternMatch::PATTERN_NOT_ENDS_WITH => "CONCAT('%%', %s)",
         ];
 
         $value = addcslashes($patternMatch->getValue(), $this->getLikeEscapeChars());

--- a/lib/Doctrine/Orm/Tests/OrmTestCase.php
+++ b/lib/Doctrine/Orm/Tests/OrmTestCase.php
@@ -170,7 +170,7 @@ abstract class OrmTestCase extends DbalTestCase
     /**
      * @throws \Doctrine\DBAL\Exception
      */
-    protected function assertRecordsAreFound(SearchCondition $condition, array $ids): void
+    protected function assertRecordsAreFound(SearchCondition $condition, array $ids, string $input): void
     {
         $qb = $this->getQuery();
 
@@ -219,7 +219,8 @@ abstract class OrmTestCase extends DbalTestCase
             $ids,
             array_merge([], array_unique($idRows)),
             sprintf(
-                "Found these records instead: \n%s\nWith WHERE-clause: %s\nSQL: %s\nAnd params: %s",
+                "With condition: `%s`\nFound these records instead: \n%s\nWith WHERE-clause: %s\nSQL: %s\nAnd params: %s",
+                $input,
                 print_r($rows, true),
                 $whereClause,
                 $query->getSQL(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

The pattern matches for BEGINS with, and ENDS with were reversed. 
Add some tests to ensure correct behavior.