### PR TITLE
[Core] Fix wrong exported StringQuery with order

### DIFF
--- a/lib/Core/Exporter/StringExporter.php
+++ b/lib/Core/Exporter/StringExporter.php
@@ -39,7 +39,16 @@ abstract class StringExporter extends AbstractExporter
     {
         $this->fields = $this->resolveLabels($fieldSet = $condition->getFieldSet());
 
-        return $this->exportOrder($condition, $fieldSet) . $this->exportGroup($condition->getValuesGroup(), $fieldSet, true);
+        $valuesGroup = $condition->getValuesGroup();
+        $result = '';
+
+        if ($valuesGroup->countValues() > 0 && $valuesGroup->getGroupLogical() === ValuesGroup::GROUP_LOGICAL_OR) {
+            $result .= '* ';
+        }
+
+        $result .= $this->exportOrder($condition, $fieldSet);
+
+        return trim($result . $this->exportGroup($valuesGroup, $fieldSet, true));
     }
 
     abstract protected function resolveLabels(FieldSet $fieldSet): array;
@@ -59,17 +68,13 @@ abstract class StringExporter extends AbstractExporter
             $result .= ': ' . $this->modelToExported($direction, $fieldSet->get($name)) . '; ';
         }
 
-        return trim($result);
+        return ltrim($result);
     }
 
     protected function exportGroup(ValuesGroup $valuesGroup, FieldSet $fieldSet, bool $isRoot = false): string
     {
         $result = '';
         $exportedGroups = '';
-
-        if ($isRoot && $valuesGroup->countValues() > 0 && $valuesGroup->getGroupLogical() === ValuesGroup::GROUP_LOGICAL_OR) {
-            $result .= '*';
-        }
 
         foreach ($valuesGroup->getFields() as $name => $values) {
             if ($fieldSet->isPrivate($name) || $values->count() === 0) {

--- a/lib/Core/Exporter/StringQueryExporter.php
+++ b/lib/Core/Exporter/StringQueryExporter.php
@@ -15,7 +15,6 @@ namespace Rollerworks\Component\Search\Exporter;
 
 use Rollerworks\Component\Search\Field\FieldConfig;
 use Rollerworks\Component\Search\FieldSet;
-use Rollerworks\Component\Search\SearchCondition;
 
 /**
  * Exports the SearchCondition as StringQuery string.

--- a/lib/Core/Test/SearchConditionExporterTestCase.php
+++ b/lib/Core/Test/SearchConditionExporterTestCase.php
@@ -35,6 +35,8 @@ use Rollerworks\Component\Search\Value\ValuesGroup;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * @internal This class is not covered by the BC promise.
  */
 abstract class SearchConditionExporterTestCase extends SearchIntegrationTestCase
 {

--- a/lib/Core/Tests/Exporter/StringQueryExporterTest.php
+++ b/lib/Core/Tests/Exporter/StringQueryExporterTest.php
@@ -124,6 +124,33 @@ final class StringQueryExporterTest extends SearchConditionExporterTestCase
         $this->assertConditionEquals('@id: desc; @status: asc;', $condition, $processor, $config);
     }
 
+    /** @test */
+    public function it_exports_with_ordering_and_root_group_logical(): void
+    {
+        $exporter = $this->getExporter();
+        $fieldSet = $this->getFieldSet(false)
+            ->add('@id', OrderFieldType::class)
+            ->add('@status', OrderFieldType::class)
+            ->getFieldSet()
+        ;
+
+        $config = new ProcessorConfig($fieldSet);
+
+        $condition = new SearchCondition(
+            $config->getFieldSet(),
+            (new ValuesGroup(ValuesGroup::GROUP_LOGICAL_OR))->addField('name', (new ValuesBag())->addSimpleValue('value '))
+        );
+
+        $orderGroup = (new ValuesGroup())
+            ->addField('@id', (new ValuesBag())->addSimpleValue('DESC'))
+            ->addField('@status', (new ValuesBag())->addSimpleValue('ASC'))
+        ;
+        $condition->setOrder(new SearchOrder($orderGroup));
+
+        $this->assertExportEquals('* @id: desc; @status: asc; name: "value ";', $exporter->exportCondition($condition));
+        $this->assertConditionEquals('* @id: desc; @status: asc; name: "value ";', $condition, $this->getInputProcessor(), $config);
+    }
+
     public function provideSingleValuePairTest()
     {
         return 'name: "value ", -value2, value2-, 10.00, "10,00", hÌ, ٤٤٤٦٥٤٦٠٠, "doctor""who""""", !value3; price: € 12.00, "12,00 $", $ 12.00;';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | Related to #310
| License       | MIT

When the root `ValuesGroup` of the condition is a logical `OR`, with values, *and* the condition has order fields, the exporter would place the order fields prior to the root-group logical, which produces a syntax error.

"A group logical operator can only be used at the start of the input or before a group opening"
