### PR TITLE
[Core] Fix wrong col pos in StringLexer exception

### DIFF
--- a/lib/Core/Tests/Input/StringLexerTest.php
+++ b/lib/Core/Tests/Input/StringLexerTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Rollerworks\Component\Search\Tests\Input;
 
 use PHPUnit\Framework\TestCase;
+use Rollerworks\Component\Search\Exception\StringLexerException;
 use Rollerworks\Component\Search\Input\StringLexer;
 
 /**
@@ -47,5 +48,42 @@ final class StringLexerTest extends TestCase
         $this->lexer->skipWhitespace();
 
         self::assertTrue($this->lexer->isGlimpse("/\n/A"));
+    }
+
+    /** @test */
+    public function it_reports_the_correct_col(): void
+    {
+        $this->lexer->parse("he:");
+        $this->lexer->fieldIdentification();
+
+        $this->expectExceptionObject(StringLexerException::syntaxErrorUnexpectedEnd(3, 1, 'StringValue', 'end of string'));
+
+        $this->lexer->stringValue();
+    }
+
+    /** @test */
+    public function it_reports_the_correct_col_with_multiline(): void
+    {
+        $this->lexer->parse("he:\nid:");
+        $this->lexer->fieldIdentification();
+        $this->lexer->skipEmptyLines();
+
+        $this->lexer->fieldIdentification();
+
+        $this->expectExceptionObject(StringLexerException::syntaxErrorUnexpectedEnd(4, 2, 'StringValue', 'end of string'));
+
+        $this->lexer->stringValue();
+    }
+
+    /** @test */
+    public function it_reports_the_correct_col_when_start_at_newline(): void
+    {
+        $this->lexer->parse("he:\n");
+        $this->lexer->fieldIdentification();
+        $this->lexer->skipEmptyLines();
+
+        $this->expectExceptionObject(StringLexerException::syntaxErrorUnexpectedEnd(1, 2, 'StringValue', 'end of string'));
+
+        $this->lexer->stringValue();
     }
 }

--- a/lib/Core/Tests/Input/StringQueryInputTest.php
+++ b/lib/Core/Tests/Input/StringQueryInputTest.php
@@ -256,7 +256,7 @@ final class StringQueryInputTest extends InputProcessorTestCase
             ],
             [
                 "(field1: value, value2, value3, value4, value5; ); \n&",
-                StringLexerException::formatError(52, 2, 'A group logical operator can only be used at the start of the input or before a group opening'),
+                StringLexerException::formatError(1, 2, 'A group logical operator can only be used at the start of the input or before a group opening'),
             ],
             [
                 'field1: value value2)',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

The error message would inform the character position in relation to the whole input, but not the col relative to the line the error was encountered.

And addition this also fixes a bug where the snapshot of char, lineno, and cursor postion weren't reset before parsing.