### PR TITLE
[SF Validator] Handle PatternMatch separate

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -1,3 +1,13 @@
+UPGRADE FROM 2.0-BETA5 to 2.0-BETA6
+===================================
+
+ * The Symfony Input Validator no longer validates a `PatternMatch` value type.
+   Set the `pattern_match_constraints` option to validate this specific type, with
+   it's own constraints.
+
+   **Note:** A PatternMatch will likely not contain a full value, for more advanced
+   validating it's best to create your own input validator.
+
 UPGRADE FROM 2.0-BETA4 to 2.0-BETA5
 ===================================
 

--- a/docs/integration/symfony_validator.rst
+++ b/docs/integration/symfony_validator.rst
@@ -78,4 +78,13 @@ part of the field type using the ``configureOptions`` method of the field type. 
         );
     }
 
+.. note::
+
+    For a field that expects an email it's not possible to use a ``PatternMatch``
+    with a constraint that enforces a valid email address.
+
+    Since RollerworksSearch v2.0-BETA6 the ``PatternMatch`` is no longer validated as
+    part of the the ``constraints`` option, use the ``pattern_match_constraints`` for
+    this specific type.
+
 .. _`Symfony Validator component`: http://symfony.com/doc/current/validation.html

--- a/lib/Symfony/Validator/Tests/InputValidatorTest.php
+++ b/lib/Symfony/Validator/Tests/InputValidatorTest.php
@@ -74,6 +74,37 @@ final class InputValidatorTest extends SearchIntegrationTestCase
     }
 
     /** @test */
+    public function it_works_without_constraints(): void
+    {
+        $fieldSet = $this->getFactory()->createFieldSetBuilder()
+            ->add('id', IntegerType::class)
+            ->add('date', DateType::class)
+            ->add('type', TextType::class)
+            ->getFieldSet()
+        ;
+
+        $errorList = new ErrorList();
+        $this->validator->initializeContext($fieldSet->get('id'), $errorList);
+        $this->validator->validate(10, 'simple', 10, 'simpleValues[0]');
+        $this->validator->validate(3, 'simple', 3, 'simpleValues[1]');
+        $this->validator->validate(4, 'simple', 4, 'simpleValues[2]');
+
+        $errorList2 = new ErrorList();
+        $this->validator->initializeContext($fieldSet->get('date'), $errorList2);
+        $this->validator->validate(new \DateTimeImmutable('2014-12-13 14:35:05 UTC'), 'simple', '2014-12-13 14:35:05', 'simpleValues[0]');
+        $this->validator->validate(new \DateTimeImmutable('2014-12-21 14:35:05 UTC'), 'simple', '2014-12-17 14:35:05', 'simpleValues[1]');
+        $this->validator->validate(new \DateTimeImmutable('2014-12-10 14:35:05 UTC'), 'simple', '2014-12-10 14:35:05', 'simpleValues[2]');
+
+        $errorList3 = new ErrorList();
+        $this->validator->initializeContext($fieldSet->get('type'), $errorList3);
+        $this->validator->validate('something', PatternMatch::class, 'something', 'simpleValues[0]');
+
+        self::assertEmpty($errorList);
+        self::assertEmpty($errorList2);
+        self::assertEmpty($errorList3);
+    }
+
+    /** @test */
     public function it_validates_fields_with_constraints(): void
     {
         $fieldSet = $this->getFieldSet();
@@ -94,7 +125,6 @@ final class InputValidatorTest extends SearchIntegrationTestCase
 
         $errorList3 = new ErrorList();
         $this->validator->initializeContext($fieldSet->get('type'), $errorList3);
-
         $this->validator->validate('something', 'simple', 'something', 'simpleValues[0]');
 
         $this->assertContainsErrors(
@@ -122,7 +152,7 @@ final class InputValidatorTest extends SearchIntegrationTestCase
     public function it_validates_matchers(): void
     {
         $fieldSet = $this->getFieldSet(false);
-        $fieldSet->add('username', TextType::class, ['constraints' => new Assert\NotBlank()]);
+        $fieldSet->add('username', TextType::class, ['constraints' => new Assert\Url(), 'pattern_match_constraints' => new Assert\NotBlank()]);
         $fieldSet = $fieldSet->getFieldSet();
 
         $errorList = new ErrorList();

--- a/lib/Symfony/Validator/Type/FieldTypeValidatorExtension.php
+++ b/lib/Symfony/Validator/Type/FieldTypeValidatorExtension.php
@@ -34,6 +34,8 @@ final class FieldTypeValidatorExtension extends AbstractFieldTypeExtension
         $constraintsNormalizer = static fn (Options $options, $constraints) => \is_object($constraints) ? [$constraints] : (array) $constraints;
 
         $resolver->setDefault('constraints', []);
+        $resolver->setDefault('pattern_match_constraints', []);
         $resolver->setNormalizer('constraints', $constraintsNormalizer);
+        $resolver->setNormalizer('pattern_match_constraints', $constraintsNormalizer);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | 
| Tickets       | 
| License       | MIT

Don't validate PatternMatch by default, use a separate constraints option as a PatternMatch is cannot use full values for constraints.

_For a field that expects an email it's not possible to use a PatternMatch with a constraint that enforces a valid email address._