### PR TITLE
Fix Field label configuration

### DIFF
--- a/docs/integration/symfony_bundle.rst
+++ b/docs/integration/symfony_bundle.rst
@@ -150,6 +150,27 @@ Search Query
 That's it. You can now process search requests! See the reference section
 below to learn more about application wide cache configuring.
 
+Translating labels (StringQuery only)
+-------------------------------------
+
+The :class:`Rollerworks\\Component\\Search\\Input\\StringQueryInput`
+allows to use localized names by setting a :class:`Symfony\\Contracts\\Translation\\TranslatableInterface`
+as the fields label.
+
+.. code-block:: php
+    :linenos:
+
+    use Symfony\Component\Translation\TranslatableMessage;
+
+    $userFieldSet = $searchFactory->createFieldSetBuilder()
+        ->add('id', IntegerType::class, ['label' => new TranslatableMessage('label.id', [], 'search')]
+        ->add('username', TextType::class, ['label' => new TranslatableMessage('label.username', [], 'search'))
+        ->getFieldSet('users')
+    ;
+
+Now in the StringQuery can use a localized label like 'gebruikersnaam' (in Dutch)
+instead of username. This option works the same for order fields.
+
 Registering types and type extensions
 -------------------------------------
 

--- a/lib/Core/Exporter/StringQueryExporter.php
+++ b/lib/Core/Exporter/StringQueryExporter.php
@@ -33,7 +33,7 @@ final class StringQueryExporter extends StringExporter
      */
     public function __construct(?callable $labelResolver = null)
     {
-        $this->labelResolver = $labelResolver ?? static fn (FieldConfig $field) => $field->getOption('label', $field->getName());
+        $this->labelResolver = $labelResolver ?? static fn (FieldConfig $field) => $field->getOption('label') ?? $field->getName();
     }
 
     protected function resolveLabels(FieldSet $fieldSet): array

--- a/lib/Core/Extension/Core/Type/SearchFieldType.php
+++ b/lib/Core/Extension/Core/Type/SearchFieldType.php
@@ -46,6 +46,7 @@ final class SearchFieldType extends AbstractFieldType
     {
         $resolver->setDefaults(
             [
+                'label' => null,
                 'translation_domain' => 'messages',
                 'invalid_message' => 'This value is not valid.',
                 'invalid_message_parameters' => [],
@@ -56,6 +57,7 @@ final class SearchFieldType extends AbstractFieldType
             ]
         );
 
+        $resolver->setAllowedTypes('label', ['null', 'string']);
         $resolver->setAllowedTypes('invalid_message', ['string']);
         $resolver->setAllowedTypes('invalid_message_parameters', ['array']);
         $resolver->setAllowedTypes(StringQueryInput::FIELD_LEXER_OPTION_NAME, ['null', \Closure::class]);

--- a/lib/Core/Field/OrderFieldType.php
+++ b/lib/Core/Field/OrderFieldType.php
@@ -37,6 +37,7 @@ final class OrderFieldType implements FieldType
             'view_label' => ['ASC' => 'asc', 'DESC' => 'desc'],
             'type' => null,
             'type_options' => [],
+            'label' => null,
         ]);
 
         $resolver->setAllowedValues('case', [
@@ -48,6 +49,7 @@ final class OrderFieldType implements FieldType
         $resolver->setAllowedTypes('default', ['null', 'string']);
         $resolver->setAllowedTypes('type', ['string', 'null']);
         $resolver->setAllowedTypes('type_options', ['array']);
+        $resolver->setAllowedTypes('label', ['null', 'string']);
 
         // Ensure view-labels are part of the alias list.
         $resolver->addNormalizer('alias', static function (Options $options, array $value): mixed {

--- a/lib/Core/Input/StringQueryInput.php
+++ b/lib/Core/Input/StringQueryInput.php
@@ -38,7 +38,7 @@ final class StringQueryInput extends StringInput
     public function __construct(?Validator $validator = null, ?callable $labelResolver = null)
     {
         parent::__construct($validator);
-        $this->labelResolver = $labelResolver ?? static fn (FieldConfig $field) => $field->getOption('label', $field->getName());
+        $this->labelResolver = $labelResolver ?? static fn (FieldConfig $field) => $field->getOption('label') ?? $field->getName();
     }
 
     protected function initForProcess(ProcessorConfig $config): void

--- a/lib/Symfony/SearchBundle/Resources/config/translator_alias_resolver.xml
+++ b/lib/Symfony/SearchBundle/Resources/config/translator_alias_resolver.xml
@@ -9,5 +9,13 @@
             <argument id="translator" type="service" />
         </service>
 
+        <service id="Rollerworks\Bundle\SearchBundle\Type\TranslatableFieldTypeExtension">
+            <tag name="rollerworks_search.type_extension" extended-type="Rollerworks\Component\Search\Extension\Core\Type\SearchFieldType" />
+        </service>
+
+        <service id="Rollerworks\Bundle\SearchBundle\Type\TranslatableOrderFieldTypeExtension">
+            <tag name="rollerworks_search.type_extension" extended-type="Rollerworks\Component\Search\Field\OrderFieldType" />
+        </service>
+
     </services>
 </container>

--- a/lib/Symfony/SearchBundle/TranslatorBasedAliasResolver.php
+++ b/lib/Symfony/SearchBundle/TranslatorBasedAliasResolver.php
@@ -14,14 +14,12 @@ declare(strict_types=1);
 namespace Rollerworks\Bundle\SearchBundle;
 
 use Rollerworks\Component\Search\Field\FieldConfig;
+use Symfony\Contracts\Translation\TranslatableInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class TranslatorBasedAliasResolver
 {
-    /**
-     * @var TranslatorInterface
-     */
-    private $translator;
+    private TranslatorInterface $translator;
 
     public function __construct(TranslatorInterface $translator)
     {
@@ -30,14 +28,16 @@ final class TranslatorBasedAliasResolver
 
     public function __invoke(FieldConfig $field)
     {
-        if (null !== $label = $field->getOption('label')) {
-            return $label;
+        $label = $field->getOption('label');
+
+        if ($label === null) {
+            return $field->getName();
         }
 
-        return $this->translator->trans(
-            $field->getOption('label_template', $field->getName()),
-            $field->getOption('label_parameters', []),
-            $field->getOption('label_domain', 'search')
-        );
+        if ($label instanceof TranslatableInterface) {
+            return $label->trans($this->translator);
+        }
+
+        return $label;
     }
 }

--- a/lib/Symfony/SearchBundle/Type/TranslatableFieldTypeExtension.php
+++ b/lib/Symfony/SearchBundle/Type/TranslatableFieldTypeExtension.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\SearchBundle\Type;
+
+use Rollerworks\Component\Search\Extension\Core\Type\SearchFieldType;
+use Rollerworks\Component\Search\Field\AbstractFieldTypeExtension;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Contracts\Translation\TranslatableInterface;
+
+final class TranslatableFieldTypeExtension extends AbstractFieldTypeExtension
+{
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->addAllowedTypes('label', TranslatableInterface::class);
+    }
+
+    public function getExtendedType(): string
+    {
+        return SearchFieldType::class;
+    }
+}

--- a/lib/Symfony/SearchBundle/Type/TranslatableOrderFieldTypeExtension.php
+++ b/lib/Symfony/SearchBundle/Type/TranslatableOrderFieldTypeExtension.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\SearchBundle\Type;
+
+use Rollerworks\Component\Search\Field\AbstractFieldTypeExtension;
+use Rollerworks\Component\Search\Field\OrderFieldType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Contracts\Translation\TranslatableInterface;
+
+final class TranslatableOrderFieldTypeExtension extends AbstractFieldTypeExtension
+{
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->addAllowedTypes('label', TranslatableInterface::class);
+    }
+
+    public function getExtendedType(): string
+    {
+        return OrderFieldType::class;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

The 'field' option wasn't defined so it was never possible to even use a label for localized input (in StringQuery).

Secondly the labels can now be translated using a TranslatableInterface value (for the Symfony bundle).
