### PR TITLE
Fix wrong message-id and error-path for groups

### DIFF
--- a/lib/Core/Exception/GroupsNestingException.php
+++ b/lib/Core/Exception/GroupsNestingException.php
@@ -20,6 +20,6 @@ final class GroupsNestingException extends InputProcessorException
 {
     public function __construct(int $max, string $path)
     {
-        parent::__construct($path, 'Group exceeds maximum nesting level of {{ max }}.', ['{{ max }}' => $max]);
+        parent::__construct($path, 'This group exceeds maximum nesting level of {{ max }}.', ['{{ max }}' => $max]);
     }
 }

--- a/lib/Core/Exception/GroupsOverflowException.php
+++ b/lib/Core/Exception/GroupsOverflowException.php
@@ -20,6 +20,6 @@ final class GroupsOverflowException extends InputProcessorException
 {
     public function __construct(int $max, string $path)
     {
-        parent::__construct($path, 'Group exceeds maximum number of groups {{ max }}.', ['{{ max }}' => $max]);
+        parent::__construct($path, 'This group exceeds maximum number of groups {{ max }}.', ['{{ max }}' => $max]);
     }
 }

--- a/lib/Core/Input/ConditionStructureBuilder.php
+++ b/lib/Core/Input/ConditionStructureBuilder.php
@@ -131,12 +131,12 @@ class ConditionStructureBuilder implements StructureBuilder
 
         $groupCount = $this->groupsCount[$this->nestingLevel];
 
+        // The new group is relative to it's current level (the group is declared at level x); and zero-indexed
+        $this->path[] = \sprintf($path, $groupCount - 1);
+
         if ($groupCount > $this->maxGroups) {
             throw new GroupsOverflowException($this->maxGroups, implode('', $this->path));
         }
-
-        // The new group is relative to it's current level (the group is declared at level x); and zero-indexed
-        $this->path[] = \sprintf($path, $groupCount - 1);
 
         ++$this->nestingLevel;
 

--- a/lib/Core/Resources/translations/RollerworksSearch.en.xlf
+++ b/lib/Core/Resources/translations/RollerworksSearch.en.xlf
@@ -45,10 +45,6 @@
             </trans-unit>
             <!-- // -->
 
-            <trans-unit id="ORDER_CLAUSE_NOT_IN_GROUP">
-                <source>Order clauses cannot be placed in a group.</source>
-                <target>Order clauses cannot be placed in a group.</target>
-            </trans-unit>
             <trans-unit id="STRING_SYNTAX_ERROR_EXPECTED">
                 <source>[Syntax Error] line {{ line }} col {{ column }}: Expected {{ expected }}, got {{ got }}.</source>
                 <target>[Syntax Error] line {{ line }} col {{ column }}: Expected {{ expected }}, got {{ got }}.</target>

--- a/lib/Core/Resources/translations/RollerworksSearch.nl.xlf
+++ b/lib/Core/Resources/translations/RollerworksSearch.nl.xlf
@@ -45,10 +45,6 @@
             </trans-unit>
             <!-- // -->
 
-            <trans-unit id="ORDER_CLAUSE_NOT_IN_GROUP">
-                <source>Order clauses cannot be placed in a group.</source>
-                <target>Volgorde clausules kunnen niet in een groep worden geplaatst.</target>
-            </trans-unit>
             <trans-unit id="STRING_SYNTAX_ERROR_EXPECTED">
                 <source>[Syntax Error] line {{ line }} col {{ column }}: Expected {{ expected }}, got {{ got }}.</source>
                 <target>[Syntaxisfout] regel {{ line }} kolom {{ column }}: Verwacht {{ expected }}, kreeg {{ got }}.</target>

--- a/lib/Core/Resources/translations/validators.en.xlf
+++ b/lib/Core/Resources/translations/validators.en.xlf
@@ -54,6 +54,11 @@
                 <source>This value is not a valid sorting direction. Accepted directions are: {{ directions }}.</source>
                 <target>This value is not a valid sorting direction. Accepted directions are: {{ directions }}.</target>
             </trans-unit>
+
+            <trans-unit id="ORDER_CLAUSE_NOT_IN_GROUP">
+                <source>Order clauses cannot be placed in a group.</source>
+                <target>Order clauses cannot be placed in a group.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/lib/Core/Resources/translations/validators.nl.xlf
+++ b/lib/Core/Resources/translations/validators.nl.xlf
@@ -54,6 +54,11 @@
                 <source>This value is not a valid sorting direction. Accepted directions are: {{ directions }}.</source>
                 <target>Deze waarde is geen geldige sorteer richting. De geaccepteerde richtingen zijn: {{ directions }}.</target>
             </trans-unit>
+
+            <trans-unit id="ORDER_CLAUSE_NOT_IN_GROUP">
+                <source>Order clauses cannot be placed in a group.</source>
+                <target>Volgorde clausules kunnen niet in een groep worden geplaatst.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/lib/Core/Tests/Input/JsonInputTest.php
+++ b/lib/Core/Tests/Input/JsonInputTest.php
@@ -450,7 +450,7 @@ final class JsonInputTest extends InputProcessorTestCase
                         ],
                     ]
                 ),
-                '',
+                '[groups][3]',
             ],
             [
                 json_encode(
@@ -506,7 +506,7 @@ final class JsonInputTest extends InputProcessorTestCase
                         ],
                     ]
                 ),
-                '[groups][0][groups][1]',
+                '[groups][0][groups][1][groups][3]',
             ],
         ];
     }

--- a/lib/Core/Tests/Input/StringQueryInputTest.php
+++ b/lib/Core/Tests/Input/StringQueryInputTest.php
@@ -459,8 +459,8 @@ final class StringQueryInputTest extends InputProcessorTestCase
     public static function provideGroupsOverflowTests(): iterable
     {
         return [
-            ['(name: value, value2;); (name: value, value2;); (name: value, value2;); (name: value, value2;)', ''],
-            ['( ((name: value, value2)); ((name: value, value2;); (name: value, value2;); (name: value, value2;); (name: value, value2;)) )', '[0][1]'],
+            ['(name: value, value2;); (name: value, value2;); (name: value, value2;); (name: value, value2;)', '[3]'],
+            ['( ((name: value, value2)); ((name: value, value2;); (name: value, value2;); (name: value, value2;); (name: value, value2;)) )', '[0][1][3]'],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

- Fix wrong message-id
- Wrong domain for groups count overflow
- Missing error-path for groups count overflow (the message changed to be pointed to the exact position, so it needs this proper path)