### PR TITLE
[SFBundle] Easier translation of order-field

### DIFF
--- a/lib/Symfony/SearchBundle/Tests/TranslatorBasedAliasResolverTest.php
+++ b/lib/Symfony/SearchBundle/Tests/TranslatorBasedAliasResolverTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\SearchBundle\Tests;
+
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Rollerworks\Bundle\SearchBundle\TranslatorBasedAliasResolver;
+use Rollerworks\Bundle\SearchBundle\Type\TranslatableFieldTypeExtension;
+use Rollerworks\Bundle\SearchBundle\Type\TranslatableOrderFieldTypeExtension;
+use Rollerworks\Component\Search\Extension\Core\Type\TextType;
+use Rollerworks\Component\Search\Field\OrderFieldType;
+use Rollerworks\Component\Search\Test\SearchIntegrationTestCase;
+use Symfony\Component\Translation\TranslatableMessage;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * @internal
+ */
+final class TranslatorBasedAliasResolverTest extends SearchIntegrationTestCase
+{
+    use ProphecyTrait;
+
+    /** @test */
+    public function it_uses_field_name_when_label_is_empty(): void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->expects($this->never())->method('trans');
+
+        $resolver = new TranslatorBasedAliasResolver($translator);
+        $searchFactory = $this->getFactory();
+
+        $this->assertEquals('id', $resolver($searchFactory->createField('id', TextType::class)));
+        $this->assertEquals('name', $resolver($searchFactory->createField('name', TextType::class)));
+        $this->assertEquals('@id', $resolver($searchFactory->createField('@id', OrderFieldType::class)));
+    }
+
+    /** @test */
+    public function it_keeps_label_as_is_when_not_translatable(): void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->expects($this->never())->method('trans');
+
+        $resolver = new TranslatorBasedAliasResolver($translator);
+        $searchFactory = $this->getFactory();
+
+        $this->assertEquals('id2', $resolver($searchFactory->createField('id', TextType::class, ['label' => 'id2'])));
+        $this->assertEquals('name2', $resolver($searchFactory->createField('name', TextType::class, ['label' => 'name2'])));
+        $this->assertEquals('@id2', $resolver($searchFactory->createField('@id', OrderFieldType::class, ['label' => '@id2'])));
+        $this->assertEquals('@id2', $resolver($searchFactory->createField('@id', OrderFieldType::class, ['label' => 'id2'])));
+    }
+
+    /** @test */
+    public function it_translates_label_when_translatable(): void
+    {
+        $translator = $this->prophesize(TranslatorInterface::class);
+        $translator->trans(Argument::cetera())->will(static fn(array $args): string => $args[0][0] === '@' ? $args[0] . 'T' : 'T' . $args[0]);
+
+        $resolver = new TranslatorBasedAliasResolver($translator->reveal());
+        $searchFactory = $this->getFactory();
+
+        $this->assertEquals('Tid2', $resolver($searchFactory->createField('id', TextType::class, ['label' => new TranslatableMessage('id2')])));
+        $this->assertEquals('Tname2', $resolver($searchFactory->createField('name', TextType::class, ['label' => new TranslatableMessage('name2')])));
+        $this->assertEquals('@id2T', $resolver($searchFactory->createField('@id', OrderFieldType::class, ['label' => new TranslatableMessage('@id2')])));
+        $this->assertEquals('@Tid2', $resolver($searchFactory->createField('@id', OrderFieldType::class, ['label' => new TranslatableMessage('id2')])));
+    }
+
+    protected function getTypeExtensions(): array
+    {
+        return [
+            new TranslatableFieldTypeExtension(),
+            new TranslatableOrderFieldTypeExtension(),
+        ];
+    }
+}

--- a/lib/Symfony/SearchBundle/TranslatorBasedAliasResolver.php
+++ b/lib/Symfony/SearchBundle/TranslatorBasedAliasResolver.php
@@ -14,19 +14,17 @@ declare(strict_types=1);
 namespace Rollerworks\Bundle\SearchBundle;
 
 use Rollerworks\Component\Search\Field\FieldConfig;
+use Rollerworks\Component\Search\Field\OrderField;
 use Symfony\Contracts\Translation\TranslatableInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class TranslatorBasedAliasResolver
 {
-    private TranslatorInterface $translator;
-
-    public function __construct(TranslatorInterface $translator)
+    public function __construct(private TranslatorInterface $translator)
     {
-        $this->translator = $translator;
     }
 
-    public function __invoke(FieldConfig $field)
+    public function __invoke(FieldConfig $field): string
     {
         $label = $field->getOption('label');
 
@@ -35,7 +33,11 @@ final class TranslatorBasedAliasResolver
         }
 
         if ($label instanceof TranslatableInterface) {
-            return $label->trans($this->translator);
+            $label = $label->trans($this->translator);
+        }
+
+        if ($field instanceof OrderField && $label[0] !== '@') {
+            $label = '@' . $label;
         }
 
         return $label;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  |yes
| BC breaks?    | yes/no
| Deprecations? | no
| Tickets       | 
| License       | MIT

When the field is an order field but the translated label doesn't begin with an-`@` prepend the `@`-sign.
