### PR TITLE
[Doctrine] Add the Entity to OrmQueryField

### DIFF
--- a/lib/Doctrine/Orm/FieldConfigBuilder.php
+++ b/lib/Doctrine/Orm/FieldConfigBuilder.php
@@ -71,7 +71,8 @@ final class FieldConfigBuilder
             $this->fieldSet->get($fieldName),
             $this->getMappingType($mappingName, $entity, $property, $type),
             $property,
-            $alias ?? $this->defaultAlias
+            $alias ?? $this->defaultAlias,
+            $entity
         );
     }
 

--- a/lib/Doctrine/Orm/OrmQueryField.php
+++ b/lib/Doctrine/Orm/OrmQueryField.php
@@ -22,6 +22,21 @@ use Rollerworks\Component\Search\Field\FieldConfig;
  */
 final class OrmQueryField extends QueryField
 {
+    public string $entity;
+
+    public function __construct(string $mappingName, FieldConfig $fieldConfig, string $dbType, string $column, string $alias, string $entity)
+    {
+        parent::__construct(
+            $mappingName,
+            $fieldConfig,
+            $dbType,
+            $column,
+            $alias
+        );
+
+        $this->entity = $entity;
+    }
+
     protected function initConversions(FieldConfig $fieldConfig): void
     {
         $converter = $fieldConfig->getOption('doctrine_orm_conversion');

--- a/lib/Doctrine/Orm/Tests/FieldConfigBuilderTest.php
+++ b/lib/Doctrine/Orm/Tests/FieldConfigBuilderTest.php
@@ -127,13 +127,13 @@ final class FieldConfigBuilderTest extends TestCase
         $fields = $fieldConfigBuilder->getFields();
 
         // Invoice
-        self::assertEquals(new QueryField('id', $fieldSet->get('id'), 'smallint', 'id', 'I'), $fields['id'][null]);
-        self::assertEquals(new QueryField('credit_parent#0', $fieldSet->get('credit_parent'), 'integer', 'parent', 'I'), $fields['credit_parent'][0]);
+        self::assertEquals(new QueryField('id', $fieldSet->get('id'), 'smallint', 'id', 'I', self::INVOICE_CLASS), $fields['id'][null]);
+        self::assertEquals(new QueryField('credit_parent#0', $fieldSet->get('credit_parent'), 'integer', 'parent', 'I', self::INVOICE_CLASS), $fields['credit_parent'][0]);
 
         // Customer
-        self::assertEquals(new QueryField('customer', $fieldSet->get('customer'), 'integer', 'id', 'C'), $fields['customer'][null]);
-        self::assertEquals(new QueryField('customer_name#first_name', $fieldSet->get('customer_name'), 'string', 'first_name', 'C'), $fields['customer_name']['first_name']);
-        self::assertEquals(new QueryField('customer_name#last_name', $fieldSet->get('customer_name'), 'string', 'last_name', 'C'), $fields['customer_name']['last_name']);
+        self::assertEquals(new QueryField('customer', $fieldSet->get('customer'), 'integer', 'id', 'C', self::CUSTOMER_CLASS), $fields['customer'][null]);
+        self::assertEquals(new QueryField('customer_name#first_name', $fieldSet->get('customer_name'), 'string', 'first_name', 'C', self::CUSTOMER_CLASS), $fields['customer_name']['first_name']);
+        self::assertEquals(new QueryField('customer_name#last_name', $fieldSet->get('customer_name'), 'string', 'last_name', 'C', self::CUSTOMER_CLASS), $fields['customer_name']['last_name']);
     }
 
     /** @test */
@@ -159,8 +159,8 @@ final class FieldConfigBuilderTest extends TestCase
         $fields = $fieldConfigBuilder->getFields();
 
         // Invoice
-        self::assertEquals(new QueryField('id', $fieldSet->get('id'), 'smallint', 'id', 'I'), $fields['id'][null]);
-        self::assertEquals(new QueryField('credit_parent#0', $fieldSet->get('credit_parent'), 'integer', 'parent', 'I'), $fields['credit_parent'][0]);
+        self::assertEquals(new QueryField('id', $fieldSet->get('id'), 'smallint', 'id', 'I', self::INVOICE_CLASS), $fields['id'][null]);
+        self::assertEquals(new QueryField('credit_parent#0', $fieldSet->get('credit_parent'), 'integer', 'parent', 'I', self::INVOICE_CLASS), $fields['credit_parent'][0]);
     }
 
     /** @test */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | 
| Tickets       | 
| License       | MIT

All information was already available except for the entity, while some conversions might read additional mapping info from an entity.

_In @Lifthill I have a specific conversion which requires the entity class._
