### PR TITLE
[Doctrine] Fix deprecations in internal code

### DIFF
--- a/lib/Doctrine/Dbal/Extension/Conversion/AgeDateConversion.php
+++ b/lib/Doctrine/Dbal/Extension/Conversion/AgeDateConversion.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Extension\Doctrine\Dbal\Conversion;
 
-use Doctrine\DBAL\Types\Type as DBALType;
 use Rollerworks\Component\Search\Doctrine\Dbal\ColumnConversion;
 use Rollerworks\Component\Search\Doctrine\Dbal\ConversionHints;
 use Rollerworks\Component\Search\Doctrine\Dbal\ValueConversion;
@@ -48,9 +47,9 @@ final class AgeDateConversion implements ColumnConversion, ValueConversion
     public function convertValue($value, array $options, ConversionHints $hints): string
     {
         if ($value instanceof \DateTimeImmutable) {
-            return $hints->createParamReferenceFor($value, DBALType::getType('date'));
+            return $hints->createParamReferenceFor($value, 'date');
         }
 
-        return $hints->createParamReferenceFor($value, DBALType::getType('integer'));
+        return $hints->createParamReferenceFor($value, 'integer');
     }
 }

--- a/lib/Doctrine/Dbal/Tests/SqlConditionGeneratorTest.php
+++ b/lib/Doctrine/Dbal/Tests/SqlConditionGeneratorTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Rollerworks\Component\Search\Tests\Doctrine\Dbal;
 
 use Doctrine\DBAL\Query\QueryBuilder;
-use Doctrine\DBAL\Types\Type;
 use Rollerworks\Component\Search\Doctrine\Dbal\ColumnConversion;
 use Rollerworks\Component\Search\Doctrine\Dbal\ConversionHints;
 use Rollerworks\Component\Search\Doctrine\Dbal\Test\QueryBuilderAssertion;
@@ -729,10 +728,10 @@ final class SqlConditionGeneratorTest extends DbalTestCase
                 self::assertEquals('dd-MM-yy', $passedOptions['pattern']);
 
                 if ($value instanceof \DateTimeImmutable) {
-                    return 'CAST(' . $hints->createParamReferenceFor($value->format('Y-m-d'), Type::getType('string')) . ' AS AGE)';
+                    return 'CAST(' . $hints->createParamReferenceFor($value->format('Y-m-d'), 'string') . ' AS AGE)';
                 }
 
-                return $hints->createParamReferenceFor($value, Type::getType('integer'));
+                return $hints->createParamReferenceFor($value, 'integer');
             })
         ;
 

--- a/lib/Doctrine/Orm/Extension/Conversion/AgeDateConversion.php
+++ b/lib/Doctrine/Orm/Extension/Conversion/AgeDateConversion.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Extension\Doctrine\Orm\Conversion;
 
-use Doctrine\DBAL\Types\Type as DBALType;
 use Rollerworks\Component\Search\Doctrine\Dbal\ConversionHints;
 use Rollerworks\Component\Search\Doctrine\Orm\ColumnConversion;
 use Rollerworks\Component\Search\Doctrine\Orm\ValueConversion;
@@ -32,9 +31,9 @@ final class AgeDateConversion implements ColumnConversion, ValueConversion
     public function convertValue($value, array $options, ConversionHints $hints): string
     {
         if ($value instanceof \DateTimeImmutable) {
-            return $hints->createParamReferenceFor($value, DBALType::getType('date'));
+            return $hints->createParamReferenceFor($value, 'date');
         }
 
-        return $hints->createParamReferenceFor($value, DBALType::getType('integer'));
+        return $hints->createParamReferenceFor($value, 'integer');
     }
 }

--- a/lib/Doctrine/Orm/Extension/Conversion/DateIntervalConversion.php
+++ b/lib/Doctrine/Orm/Extension/Conversion/DateIntervalConversion.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Rollerworks\Component\Search\Extension\Doctrine\Orm\Conversion;
 
 use Carbon\CarbonInterval;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Rollerworks\Component\Search\Doctrine\Dbal\ConversionHints;
 use Rollerworks\Component\Search\Doctrine\Orm\ValueConversion;
@@ -27,7 +26,7 @@ final class DateIntervalConversion implements ValueConversion
     public function convertValue($value, array $options, ConversionHints $hints): string
     {
         if ($value instanceof \DateTimeImmutable) {
-            return $hints->createParamReferenceFor($value, Type::getType(Types::DATETIME_IMMUTABLE));
+            return $hints->createParamReferenceFor($value, Types::DATETIME_IMMUTABLE);
         }
 
         $value = clone $value;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

Passing a Type object for parameter references is deprecated, but was still used in our own code base.

_This have been part of BETA7 but was missed by me._
