### PR TITLE
Fix broken tests

### DIFF
--- a/lib/Core/Exception/TransformationFailedException.php
+++ b/lib/Core/Exception/TransformationFailedException.php
@@ -17,12 +17,14 @@ final class TransformationFailedException extends \RuntimeException implements S
 {
     private $invalidMessage;
     private $invalidMessageParameters;
+    private mixed $value;
 
-    public function __construct(string $message = '', int $code = 0, ?\Throwable $previous = null, ?string $invalidMessage = null, array $invalidMessageParameters = [])
+    public function __construct(string $message = '', int $code = 0, ?\Throwable $previous = null, ?string $invalidMessage = null, array $invalidMessageParameters = [], mixed $value = null)
     {
         parent::__construct($message, $code, $previous);
 
         $this->setInvalidMessage($invalidMessage, $invalidMessageParameters);
+        $this->value = $value;
     }
 
     /**
@@ -45,5 +47,10 @@ final class TransformationFailedException extends \RuntimeException implements S
     public function getInvalidMessageParameters(): array
     {
         return $this->invalidMessageParameters;
+    }
+
+    public function getInvalidValue(): mixed
+    {
+        return $this->value;
     }
 }

--- a/lib/Core/Input/ErrorPathTranslator.php
+++ b/lib/Core/Input/ErrorPathTranslator.php
@@ -44,6 +44,8 @@ class ErrorPathTranslator
          * @var array<int, array<int, mixed>> $parts each root-index holds a path-chunk '[part]'
          *                                    [index] => ['matched', 'chunk']
          */
+        $parts = [];
+
         if ($path === '' || preg_match_all('/\[([^]]+)]/', $path, $parts, \PREG_SET_ORDER) === 0) {
             return '';
         }

--- a/lib/Core/Test/FieldTransformationAssertion.php
+++ b/lib/Core/Test/FieldTransformationAssertion.php
@@ -62,13 +62,13 @@ final class FieldTransformationAssertion
         try {
             $viewValue = $this->viewToModel($this->inputView);
         } catch (TransformationFailedException $e) {
-            Assert::fail('View->model: ' . $e->getMessage() . "\n" . $e->getTraceAsString());
+            Assert::fail('View->model: With input ' . var_export($this->inputView, true) . '. Message ' . $e->getMessage() . "\n" . $e->getTraceAsString());
         }
 
         try {
             $normValue = $this->normToModel($this->inputNorm);
         } catch (TransformationFailedException $e) {
-            Assert::fail('Norm->model: ' . $e->getMessage() . "\n" . $e->getTraceAsString());
+            Assert::fail('Norm->model: With input ' . var_export($this->inputNorm, true) . '. Message ' . $e->getMessage() . "\n" . $e->getTraceAsString());
         }
 
         Assert::assertEquals($model, $viewValue, 'View->model value does not equal');
@@ -126,13 +126,13 @@ final class FieldTransformationAssertion
         try {
             $viewValue = $this->modelToView($this->model);
         } catch (TransformationFailedException $e) {
-            Assert::fail('Model->view: ' . $e->getMessage() . "\n" . $e->getTraceAsString());
+            Assert::fail('Model->view: With value ' . var_export($this->model, true) . '. Message ' . $e->getMessage() . "\n" . $e->getTraceAsString());
         }
 
         try {
             $normValue = $this->modelToNorm($this->model);
         } catch (TransformationFailedException $e) {
-            Assert::fail('Model->norm: ' . $e->getMessage() . "\n" . $e->getTraceAsString());
+            Assert::fail('Model->norm: With value ' . var_export($this->model, true) . '. Message ' . $e->getMessage() . "\n" . $e->getTraceAsString());
         }
 
         Assert::assertEquals($expectedView, $viewValue, 'View value does not equal');
@@ -198,6 +198,10 @@ final class FieldTransformationAssertion
             Assert::assertEquals($expected->getCode(), $actual->getCode(), 'Code does not equal.');
             Assert::assertEquals($expected->getInvalidMessage(), $actual->getInvalidMessage(), 'Invalid message does not equal.');
             Assert::assertEquals($expected->getInvalidMessageParameters(), $actual->getInvalidMessageParameters(), 'Invalid-messages parameters does not equal.');
+
+            if ($expected->getInvalidValue() !== null) {
+                Assert::assertEquals($expected->getInvalidValue(), $actual->getInvalidValue(), 'Invalid value does not equal.');
+            }
         } catch (ExpectationFailedException $e) {
             Assert::assertEquals($expected, $actual, $e->getMessage());
         }

--- a/lib/Core/Tests/Extension/Core/DataTransformer/LocalizedBirthdayTransformerTest.php
+++ b/lib/Core/Tests/Extension/Core/DataTransformer/LocalizedBirthdayTransformerTest.php
@@ -57,7 +57,7 @@ final class LocalizedBirthdayTransformerTest extends TestCase
         // Since we test against other locales, we need the full implementation
         IntlTestHelper::requireFullIntl($this, '70.1');
 
-        \Locale::setDefault('ar');
+        \Locale::setDefault('ar_BH');
 
         $dateTransformer = $this->prophesize(DataTransformer::class);
         $dateTransformer->reverseTransform(Argument::any())->shouldNotBeCalled();

--- a/lib/Core/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/lib/Core/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -197,11 +197,25 @@ final class DateTimeTypeTest extends SearchIntegrationTestCase
 
         $outputTime = new \DateTimeImmutable('2010-06-02 03:04:00 UTC');
 
-        FieldTransformationAssertion::assertThat($field)
-            ->withInput('2 Juni 2010 3:04', '2010-06-02T03:04:00Z')
-            ->successfullyTransformsTo($outputTime)
-            ->andReverseTransformsTo(IcuVersion::compare(Intl::getIcuVersion(), '73.2', '>=', 1) ? '2 jun 2010 03:04' : '2 jun. 2010 03:04', '2010-06-02T03:04:00Z')
-        ;
+        if (IcuVersion::compare(Intl::getIcuVersion(), '73.2', '>=', 1)) {
+            FieldTransformationAssertion::assertThat($field)
+                ->withInput('2 Juni 2010, 03:04', '2010-06-02T03:04:00Z')
+                ->successfullyTransformsTo($outputTime)
+                ->andReverseTransformsTo('2 jun 2010, 03:04', '2010-06-02T03:04:00Z')
+            ;
+
+            FieldTransformationAssertion::assertThat($field)
+                ->withInput('2 Juni 2010 03:04', '2010-06-02T03:04:00Z')
+                ->successfullyTransformsTo($outputTime)
+                ->andReverseTransformsTo('2 jun 2010, 03:04', '2010-06-02T03:04:00Z')
+            ;
+        } else {
+            FieldTransformationAssertion::assertThat($field)
+                ->withInput('2 Juni 2010 03:04', '2010-06-02T03:04:00Z')
+                ->successfullyTransformsTo($outputTime)
+                ->andReverseTransformsTo('2 jun. 2010 03:04', '2010-06-02T03:04:00Z')
+            ;
+        }
 
         FieldTransformationAssertion::assertThat($field)
             ->withInput('1 week + 2 jaar', '2Y1W')

--- a/lib/Core/Tests/Extension/Core/Type/IntegerTypeTest.php
+++ b/lib/Core/Tests/Extension/Core/Type/IntegerTypeTest.php
@@ -17,6 +17,8 @@ use Rollerworks\Component\Search\Extension\Core\Type\IntegerType;
 use Rollerworks\Component\Search\FieldSetView;
 use Rollerworks\Component\Search\Test\FieldTransformationAssertion;
 use Rollerworks\Component\Search\Test\SearchIntegrationTestCase;
+use Symfony\Component\Intl\Intl;
+use Symfony\Component\Intl\Util\IcuVersion;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 /**
@@ -59,7 +61,7 @@ final class IntegerTypeTest extends SearchIntegrationTestCase
     /** @test */
     public function non_western_formatting(): void
     {
-        \Locale::setDefault('ar');
+        \Locale::setDefault('ar_BH');
 
         $field = $this->getFactory()->createField('number', IntegerType::class);
 

--- a/lib/Core/Tests/Extension/Core/Type/NumberTypeTest.php
+++ b/lib/Core/Tests/Extension/Core/Type/NumberTypeTest.php
@@ -86,7 +86,7 @@ final class NumberTypeTest extends SearchIntegrationTestCase
     /** @test */
     public function non_western_formatting(): void
     {
-        \Locale::setDefault('ar');
+        \Locale::setDefault('ar_BH');
 
         $field = $this->getFactory()->createField('number', NumberType::class);
 

--- a/lib/Core/Tests/GenericFieldSetTest.php
+++ b/lib/Core/Tests/GenericFieldSetTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Tests;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Rollerworks\Component\Search\Field\FieldConfig;
 use Rollerworks\Component\Search\Field\SearchFieldView;
@@ -92,9 +93,9 @@ final class GenericFieldSetTest extends TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject&FieldConfig
      */
-    private function createFieldMock(string $name, bool $withView = false)
+    private function createFieldMock(string $name, bool $withView = false): object
     {
         $field = $this->createMock(FieldConfig::class);
         $field->expects(self::any())->method('getName')->willReturn($name);

--- a/lib/Doctrine/Dbal/ColumnConversion.php
+++ b/lib/Doctrine/Dbal/ColumnConversion.php
@@ -29,9 +29,9 @@ interface ColumnConversion
      * The returned result must a be a platform specific SQL statement
      * that can be used as a column in query.
      *
-     * @param string          $column  The column name and table alias, eg. i.id
-     * @param array           $options Options of the Field configuration
-     * @param ConversionHints $hints   Special information for the conversion process
+     * @param string               $column  The column name and table alias, eg. i.id
+     * @param array<string, mixed> $options Options of the Field configuration
+     * @param ConversionHints      $hints   Special information for the conversion process
      */
     public function convertColumn(string $column, array $options, ConversionHints $hints): string;
 }

--- a/lib/Doctrine/Dbal/ValueConversion.php
+++ b/lib/Doctrine/Dbal/ValueConversion.php
@@ -30,9 +30,9 @@ interface ValueConversion
      * Used values must be registered as parameters using `$hints->createParamReferenceFor($value)`
      * with an option DBAL Type as second argument (converted afterwards).
      *
-     * @param mixed           $value   The "model" value format
-     * @param array           $options Options of the Field configuration
-     * @param ConversionHints $hints   Special information for the conversion process
+     * @param mixed                $value   The "model" value format
+     * @param array<string, mixed> $options Options of the Field configuration
+     * @param ConversionHints      $hints   Special information for the conversion process
      */
     public function convertValue($value, array $options, ConversionHints $hints): string;
 }

--- a/lib/Doctrine/Orm/ColumnConversion.php
+++ b/lib/Doctrine/Orm/ColumnConversion.php
@@ -28,9 +28,9 @@ interface ColumnConversion
     /**
      * Return the $column wrapped inside an DQL statement like: MY_FUNCTION(column).
      *
-     * @param string          $column  The column name and table alias, eg. i.id
-     * @param array           $options Options of the Field configuration
-     * @param ConversionHints $hints   Special information for the conversion process
+     * @param string               $column  The column name and table alias, eg. i.id
+     * @param array<string, mixed> $options Options of the Field configuration
+     * @param ConversionHints      $hints   Special information for the conversion process
      */
     public function convertColumn(string $column, array $options, ConversionHints $hints): string;
 }

--- a/lib/Doctrine/Orm/ValueConversion.php
+++ b/lib/Doctrine/Orm/ValueConversion.php
@@ -34,9 +34,9 @@ interface ValueConversion
      * Used values must be registered as parameters using `$hints->createParamReferenceFor($value)`
      * with an option DBAL Type as second argument (converted afterwards).
      *
-     * @param mixed           $value   The "model" value format
-     * @param array           $options Options of the Field configuration
-     * @param ConversionHints $hints   Special information for the conversion process
+     * @param mixed                $value   The "model" value format
+     * @param array<string, mixed> $options Options of the Field configuration
+     * @param ConversionHints      $hints   Special information for the conversion process
      */
     public function convertValue($value, array $options, ConversionHints $hints): string;
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,11 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Parameter \\#3 \\$resourceClass of method Rollerworks\\\\Component\\\\Search\\\\ApiPlatform\\\\Doctrine\\\\Orm\\\\Extension\\\\SearchExtension\\:\\:applyToCollection\\(\\) expects class\\-string, string given\\.$#"
+			count: 4
+			path: lib/ApiPlatform/Tests/Doctrine/Orm/Extension/SearchExtensionTest.php
+
+		-
 			message: "#^Call to an undefined static method Carbon\\\\Translator\\:\\:get\\(\\)\\.$#"
 			count: 1
 			path: lib/Core/Extension/Core/DataTransformer/DateIntervalTransformer.php
@@ -66,11 +71,6 @@ parameters:
 			path: lib/Core/Tests/Extension/Core/DataTransformer/DateTimeToRfc3339TransformerTest.php
 
 		-
-			message: "#^Call to method DateTimeImmutable\\:\\:setTimezone\\(\\) on a separate line has no effect\\.$#"
-			count: 2
-			path: lib/Core/Tests/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
-
-		-
 			message: "#^Parameter \\#1 \\$dateTime of method Rollerworks\\\\Component\\\\Search\\\\Extension\\\\Core\\\\DataTransformer\\\\DateTimeToStringTransformer\\:\\:transform\\(\\) expects DateTimeImmutable\\|null, string given\\.$#"
 			count: 1
 			path: lib/Core/Tests/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
@@ -79,11 +79,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$value of method Rollerworks\\\\Component\\\\Search\\\\Extension\\\\Core\\\\DataTransformer\\\\DateTimeToStringTransformer\\:\\:reverseTransform\\(\\) expects string, int given\\.$#"
 			count: 1
 			path: lib/Core/Tests/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
-
-		-
-			message: "#^Call to method DateTimeImmutable\\:\\:setTimezone\\(\\) on a separate line has no effect\\.$#"
-			count: 1
-			path: lib/Core/Tests/Extension/Core/DataTransformer/DateTimeToTimestampTransformerTest.php
 
 		-
 			message: "#^Parameter \\#1 \\$dateTime of method Rollerworks\\\\Component\\\\Search\\\\Extension\\\\Core\\\\DataTransformer\\\\DateTimeToTimestampTransformer\\:\\:transform\\(\\) expects DateTimeImmutable\\|null, string given\\.$#"
@@ -146,11 +141,6 @@ parameters:
 			path: lib/Core/Tests/Extension/Core/Type/DateTimeTypeTest.php
 
 		-
-			message: "#^Call to method DateTimeImmutable\\:\\:setTimezone\\(\\) on a separate line has no effect\\.$#"
-			count: 1
-			path: lib/Core/Tests/Extension/Core/Type/DateTimeTypeTest.php
-
-		-
 			message: "#^Call to an undefined method Rollerworks\\\\Component\\\\Search\\\\Field\\\\FieldConfig\\:\\:finalizeConfig\\(\\)\\.$#"
 			count: 2
 			path: lib/Core/Tests/Extension/Core/Type/DateTypeTest.php
@@ -201,21 +191,6 @@ parameters:
 			path: lib/Core/Tests/GenericFieldSetBuilderTest.php
 
 		-
-			message: "#^Method Rollerworks\\\\Component\\\\Search\\\\Tests\\\\GenericFieldSetTest\\:\\:createFieldMock\\(\\) has invalid return type PHPUnit_Framework_MockObject_MockObject\\.$#"
-			count: 1
-			path: lib/Core/Tests/GenericFieldSetTest.php
-
-		-
-			message: "#^Method Rollerworks\\\\Component\\\\Search\\\\Tests\\\\GenericFieldSetTest\\:\\:createFieldMock\\(\\) should return PHPUnit_Framework_MockObject_MockObject but returns PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&Rollerworks\\\\Component\\\\Search\\\\Field\\\\FieldConfig\\.$#"
-			count: 1
-			path: lib/Core/Tests/GenericFieldSetTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$fields of class Rollerworks\\\\Component\\\\Search\\\\GenericFieldSet constructor expects array\\<Rollerworks\\\\Component\\\\Search\\\\Field\\\\FieldConfig\\>, array\\<string, PHPUnit_Framework_MockObject_MockObject\\> given\\.$#"
-			count: 3
-			path: lib/Core/Tests/GenericFieldSetTest.php
-
-		-
 			message: "#^Parameter \\#1 \\$compares of method Rollerworks\\\\Component\\\\Search\\\\Doctrine\\\\Dbal\\\\Query\\\\QueryGenerator\\:\\:processCompares\\(\\) expects array\\<Rollerworks\\\\Component\\\\Search\\\\Value\\\\Compare\\>, array\\<Rollerworks\\\\Component\\\\Search\\\\Value\\\\ValueHolder\\> given\\.$#"
 			count: 2
 			path: lib/Doctrine/Dbal/Query/QueryGenerator.php
@@ -254,6 +229,11 @@ parameters:
 			message: "#^Offset 0 does not exist on array\\<string, Rollerworks\\\\Component\\\\Search\\\\Doctrine\\\\Orm\\\\OrmQueryField\\>\\.$#"
 			count: 2
 			path: lib/Doctrine/Orm/Tests/FieldConfigBuilderTest.php
+
+		-
+			message: "#^Variable \\$nestedBool might not be defined\\.$#"
+			count: 2
+			path: lib/Elasticsearch/QueryConditionGenerator.php
 
 		-
 			message: "#^Variable \\$query on left side of \\?\\? always exists and is not nullable\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,11 +11,6 @@ parameters:
 			path: lib/Core/Extension/Core/DataTransformer/DateIntervalTransformer.php
 
 		-
-			message: "#^Negated boolean expression is always false\\.$#"
-			count: 1
-			path: lib/Core/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
-
-		-
 			message: "#^Property Rollerworks\\\\Component\\\\Search\\\\Field\\\\OrderField\\:\\:\\$valueComparator is never written, only read\\.$#"
 			count: 1
 			path: lib/Core/Field/OrderField.php


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

The ICU data changed that dates now expect a comma, (which I don't remember even using in the NL_NL locale).
But as this isn't common we allow date times without comma's.

And the 'Ar(abic)' locale was changed to `ar_BH` to ensure Arabic numerals, 'ar' isn't an official locale (but a language).